### PR TITLE
Arguments for open_mfdataset() now match signature in xarray master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,7 @@ install using `python setup.py`
 You can run the tests by navigating to the `/xBOUT/` directory and
 entering `pytest`.
 
-
-It relies on two upstream additions to xarray
-([first](https://github.com/pydata/xarray/pull/2482) &
-[second](https://github.com/pydata/xarray/pull/2553) pull requests).
-The first is merged, but the second isn't, so for now you need to clone
-the branch of xarray containing the PR
-[here](https://github.com/TomNicholas/xarray/tree/feature/nd_combine).
+Requires xarray v0.12.2 or later.
 
 You will also need to install [dask](https://dask.org/),
 as described in the xarray documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/TomNicholas/xarray@feature/nd_combine#egg=xarray
+xarray >= 0.12.2
 dask[array] >= 1.0.0
 natsort >= 5.5.0
 matplotlib >= 2.2

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -20,8 +20,9 @@ def _auto_open_mfboutdataset(datapath, chunks={}, info=True, keep_guards=True):
     _preprocess = partial(_trim, ghosts={'x': mxg, 'y': myg})
 
     ds = xarray.open_mfdataset(paths_grid, concat_dim=concat_dims,
-                               data_vars='minimal', preprocess=_preprocess,
-                               engine=filetype, chunks=chunks)
+                               combine='nested', data_vars='minimal',
+                               preprocess=_preprocess, engine=filetype,
+                               chunks=chunks)
 
     ds, metadata = _strip_metadata(ds)
 

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -19,10 +19,9 @@ def _auto_open_mfboutdataset(datapath, chunks={}, info=True, keep_guards=True):
 
     _preprocess = partial(_trim, ghosts={'x': mxg, 'y': myg})
 
-    ds = xarray.open_mfdataset(paths_grid, concat_dims=concat_dims,
+    ds = xarray.open_mfdataset(paths_grid, concat_dim=concat_dims,
                                data_vars='minimal', preprocess=_preprocess,
-                               engine=filetype, chunks=chunks,
-                               infer_order_from_coords=False)
+                               engine=filetype, chunks=chunks)
 
     ds, metadata = _strip_metadata(ds)
 


### PR DESCRIPTION
In order to merge my [pull request](https://github.com/pydata/xarray/pull/2553) into xarray, for now the argument signature of `xarray.open_mfdataset()` has been reverted to be backwards compatible.

This will change again in the future when the N-dimensional combine becomes public API, but for now we should use xarray's master branch instead of my fork, and match the signature.

@ZedThree I think this would be be appropriate PR in which to change the dependency?