### PR TITLE
[WIP] Plot poloidal plane with contourf

### DIFF
--- a/examples/plot_grid.py
+++ b/examples/plot_grid.py
@@ -1,0 +1,23 @@
+import matplotlib.pyplot as plt
+
+from xbout import open_grid
+
+
+file = '/home/tegn500/Documents/Work/Code/xBOUT/examples/data/disconnected-double-null.grd.nc'
+salpha = '/home/tegn500/Documents/Work/Code/Scripts/analyse_STORM/pylib/tomnicholas/salpha/grid.nc'
+grid = open_grid(file, geometry='toroidal')
+
+fig, ax = plt.subplots()
+
+grid['psi'].bout.contourf(ax=ax)
+
+#x = grid['R'].values.flat
+#y = grid['Z'].values.flat
+#z = grid['psi'].values.flat
+#tri = ax.tricontourf(x, y, z)
+
+#ax.separatrices()
+#ax.limiters()
+#ax.branch_cuts()
+
+plt.show()

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -107,4 +107,6 @@ class BoutDataArrayAccessor:
     def contourf(self, ax=None, **kwargs):
         return plotfuncs.contourf(self.data, ax=ax, **kwargs)
 
+    def regions(self, ax=None, **kwargs):
+        return plotfuncs.regions(self.data, ax=ax, **kwargs)
     # TODO Could trial a 2D surface plotting method here

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -4,7 +4,7 @@ from functools import partial
 from xarray import register_dataarray_accessor
 
 from .plotting.animate import animate_imshow, animate_line
-from .plotting.plots import pcolormesh
+from .plotting import plotfuncs
 
 
 @register_dataarray_accessor('bout')
@@ -104,8 +104,7 @@ class BoutDataArrayAccessor:
             return line_block
 
     # TODO BOUT-specific plotting functionality would be implemented as methods here, e.g. ds.bout.plot_poloidal
-
-    def pcolormesh(self, x='R', y='Z', ax=None, **kwargs):
-        return pcolormesh(self.data, x=x, y=y, ax=ax, **kwargs)
+    def contourf(self, ax=None, **kwargs):
+        return plotfuncs.contourf(self.data, ax=ax, **kwargs)
 
     # TODO Could trial a 2D surface plotting method here

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -3,12 +3,10 @@ import matplotlib.pyplot as plt
 
 import animatplot as amp
 
-from .utils import plot_separatrix
-
 
 def animate_imshow(data, animate_over='t', x='x', y='y', animate=True,
                    vmin='min', vmax='max', fps=10, save_as=None,
-                   sep_pos=None, ax=None, **kwargs):
+                   ax=None, **kwargs):
     """
     Plots a color plot which is animated with time over the specified
     coordinate.
@@ -31,8 +29,6 @@ def animate_imshow(data, animate_over='t', x='x', y='y', animate=True,
     vmax : float, optional
         Maximum value to use for colorbar. Default is to use maximum value of
         data across whole timeseries.
-    sep_pos : int, optional
-        Radial position at which to plot the separatrix
     save_as: str, optional
         Filename to give to the resulting gif
     fps : int, optional
@@ -84,9 +80,7 @@ def animate_imshow(data, animate_over='t', x='x', y='y', animate=True,
     ax.set_xlabel(x)
     ax.set_ylabel(y)
 
-    # Plot separatrix
-    if sep_pos:
-        ax = plot_separatrix(data, sep_pos, ax)
+    # TODO Plot separatrix
 
     if animate:
         anim.controls(timeline_slider_args={'text': animate_over})

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -1,7 +1,45 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
+import xarray as xr
+
 from .utils import _decompose_regions
+
+def regions(da, ax=None, **kwargs):
+    """
+    Plots each logical plotting region as a different color for debugging.
+
+    Uses matplotlib.pcolormesh
+    """
+
+    x = kwargs.pop('x', 'R')
+    y = kwargs.pop('y', 'Z')
+
+    if len(da.dims) != 2:
+        raise ValueError("da must be 2D (x,y)")
+
+    if ax is None:
+        fig, ax = plt.subplots()
+
+    regions = _decompose_regions(da)
+
+    colored_regions = [xr.full_like(region, fill_value=num / len(regions))
+                       for num, region in enumerate(regions)]
+
+    first, *rest = colored_regions
+    artists = [first.plot.pcolormesh(x=x, y=y, vmin=0, vmax=1, cmap='tab20',
+                                     infer_intervals=False,
+                                     add_colorbar=False, ax=ax, **kwargs)]
+    if rest:
+        for region in rest:
+            artist = region.plot.pcolormesh(x=x, y=y, vmin=0, vmax=1,
+                                            cmap='tab20',
+                                            infer_intervals=False,
+                                            add_colorbar=False,
+                                            add_labels=False, ax=ax, **kwargs)
+            artists.append(artist)
+    return artists
+
 
 
 def contourf(da, levels=7, ax=None, **kwargs):

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -1,9 +1,10 @@
 import matplotlib.pyplot as plt
+import numpy as np
 
 from .utils import _decompose_regions
 
 
-def contourf(da, ax=None, **kwargs):
+def contourf(da, levels=7, ax=None, **kwargs):
     """
     Plots a 2D filled contour plot, taking into account branch cuts (X-points).
 
@@ -35,6 +36,9 @@ def contourf(da, ax=None, **kwargs):
     if ax is None:
         fig, ax = plt.subplots()
 
+    if isinstance(levels, np.int):
+        levels = np.linspace(da.min(), da.max(), levels, endpoint=True)
+
     regions = _decompose_regions(da)
     region_kwargs = {}
 
@@ -42,11 +46,11 @@ def contourf(da, ax=None, **kwargs):
 
     # Plot all regions on same axis
     first, *rest = regions
-    artists = [first.plot.contourf(x=x, y=y, ax=ax,
+    artists = [first.plot.contourf(x=x, y=y, ax=ax, levels=levels,
                                    **kwargs, **region_kwargs)]
     if rest:
         for region in rest:
-            artist = region.plot.contourf(x=x, y=y, ax=ax,
+            artist = region.plot.contourf(x=x, y=y, ax=ax, levels=levels,
                                           add_colorbar=False, add_labels=False,
                                           **kwargs, **region_kwargs)
             artists.append(artist)

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -1,0 +1,181 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
+
+def contourf(da, nlevel=10, ax=None, **kwargs):
+    """
+    Plots a 2D contour plot, taking into account branch cuts (X-points).
+
+    Parameters
+    ----------
+    da : xarray.DataArray
+        A 2D (x,y) DataArray of data to plot
+    nlevel : int, optional
+        Number of levels in the contour plot
+    ax : Axes, optional
+        A matplotlib axes instance to plot to. If None, create a new
+        figure and axes, and plot to that
+
+    Returns
+    -------
+    con
+        The contourf instance
+
+    Examples
+    --------
+    To put a plot into an axis with a color bar:
+    >>> fig, axis = plt.subplots()
+    >>> c = gridcontourf(grid, data, show=False, ax=axis)
+    >>> fig.colorbar(c, ax=axis)
+    >>> plt.show()
+    """
+
+    print(da)
+
+    # TODO generalise this
+    x='R'
+    y='Z'
+
+    if len(da.dims) != 2:
+        raise ValueError("da must be 2D (x,y)")
+
+    grid = da.attrs['grid']
+    j11 = grid['jyseps1_1']
+    j12 = grid['jyseps1_2']
+    j21 = grid['jyseps2_1']
+    j22 = grid['jyseps2_2']
+    ix1 = grid['ixseps1']
+    ix2 = grid['ixseps2']
+    nin = grid.get('ny_inner', j12)
+
+    nx = grid['nx']
+    ny = grid['ny']
+
+    R = da.coords['R']
+    Z = da.coords['R']
+
+    add_colorbar = False
+    if ax is None:
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        add_colorbar = True
+
+    mind = da.min()
+    maxd = da.max()
+
+    levels = np.linspace(mind, maxd, nlevel, endpoint=True)
+
+    ystart = 0  # Y index to start the next section
+    if j11 >= 0:
+        # plot lower inner leg
+        region1 = da[:, ystart:(j11 + 1)]
+        region1.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                              add_colorbar=False)
+
+        yind = [j11, j22 + 1]
+        region2 = da[:ix1, yind]
+        region2.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                              add_colorbar=False)
+
+        region3 = da[ix1:, j11: (j11 + 2)]
+        region3.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                              add_colorbar=False)
+
+        yind = [j22, j11 + 1]
+        region4 = da[:ix1, yind]
+        region4.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                              add_colorbar=False)
+
+        ystart = j11 + 1
+
+    # Inner SOL
+    region5 = da[:, ystart:(j21 + 1)]
+    region5.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                          add_colorbar=False)
+
+    ystart = j21 + 1
+
+    if j12 > j21:
+        # Contains upper PF region
+
+        # Inner leg
+        region6 = da[ix1:, j21:(j21 + 2)]
+        region6.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                              add_colorbar=False)
+        region7 = da[:, ystart:nin]
+        region7.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                              add_colorbar=False)
+
+        # Outer leg
+        region8 = da[:, nin:(j12 + 1)]
+        region8.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                              add_colorbar=False)
+
+        region9 = da[:, nin:(j12 + 1)]
+        region9.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                              add_colorbar=False)
+
+        region10 = da[ix1:, j12:(j12 + 2)]
+        region10.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                              add_colorbar=False)
+
+        yind = [j21, j12 + 1]
+
+        region11 = da[:ix1, yind]
+        region11.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                               add_colorbar=False)
+
+        yind = [j21 + 1, j12]
+
+        region12 = da[:ix1, yind]
+        region12.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                               add_colorbar=False)
+
+        ystart = j12 + 1
+    else:
+        ystart -= 1
+
+    # Outer SOL
+    region12 = da[:, ystart:(j22 + 1)]
+    region12.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                           add_colorbar=False)
+
+
+    ystart = j22 + 1
+
+    if j22 + 1 < ny:
+        # Outer leg
+
+        region13 = da[ix1:, j22:(j22 + 2)]
+        region13.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                               add_colorbar=False)
+
+        region14 = da[:, ystart:ny]
+        region14.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                               add_colorbar=False)
+
+        # X-point regions
+        xregion1 = da[ix1 - 1, j11]
+        xregion2 = da[ix1, j11]
+        xregion3 = da[ix1, j11 + 1]
+        xregion4 = da[ix1 - 1, j11 + 1]
+
+        xregion_lower = xr.concat([xregion1, xregion2, xregion3, xregion4],
+                                  dim='x')
+
+        xregion5 = da[ix1 - 1, j22 + 1]
+        xregion6 = da[ix1, j22 + 1]
+        xregion7 = da[ix1, j22]
+        xregion8 = da[ix1 - 1, j22]
+
+        xregion_upper = xr.concat([xregion5, xregion6, xregion7, xregion8],
+                                  dim='x')
+
+        xregion = xr.concat([xregion_lower.drop('theta'),
+                             xregion_upper.drop('theta')], dim='theta')
+
+        xregion.plot.contourf(x=x, y=y, levels=levels, ax=ax,
+                              add_colorbar=False)
+
+    return None

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -42,7 +42,8 @@ def regions(da, ax=None, **kwargs):
 
 
 
-def contourf(da, levels=7, ax=None, separatrix=True, targets=True, **kwargs):
+def contourf(da, levels=7, ax=None, separatrix=True, targets=True,
+             add_limiter_hatching=True, **kwargs):
     """
     Plots a 2D filled contour plot, taking into account branch cuts (X-points).
 
@@ -102,6 +103,6 @@ def contourf(da, levels=7, ax=None, separatrix=True, targets=True, **kwargs):
         plot_separatrices(da, ax)
 
     if targets:
-        plot_targets(da, ax)
+        plot_targets(da, ax, hatching=add_limiter_hatching)
 
     return artists

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import xarray as xr
 
-from .utils import _decompose_regions, plot_separatrices
+from .utils import _decompose_regions, plot_separatrices, plot_targets
 
 def regions(da, ax=None, **kwargs):
     """
@@ -42,7 +42,7 @@ def regions(da, ax=None, **kwargs):
 
 
 
-def contourf(da, levels=7, ax=None, separatrix=True, **kwargs):
+def contourf(da, levels=7, ax=None, separatrix=True, targets=True, **kwargs):
     """
     Plots a 2D filled contour plot, taking into account branch cuts (X-points).
 
@@ -100,5 +100,8 @@ def contourf(da, levels=7, ax=None, separatrix=True, **kwargs):
 
     if separatrix:
         plot_separatrices(da, ax)
+
+    if targets:
+        plot_targets(da, ax)
 
     return artists

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import xarray as xr
 
-from .utils import _decompose_regions
+from .utils import _decompose_regions, plot_separatrices
 
 def regions(da, ax=None, **kwargs):
     """
@@ -42,7 +42,7 @@ def regions(da, ax=None, **kwargs):
 
 
 
-def contourf(da, levels=7, ax=None, **kwargs):
+def contourf(da, levels=7, ax=None, separatrix=True, **kwargs):
     """
     Plots a 2D filled contour plot, taking into account branch cuts (X-points).
 
@@ -97,5 +97,8 @@ def contourf(da, levels=7, ax=None, **kwargs):
                                           add_colorbar=False, add_labels=False,
                                           **kwargs, **region_kwargs)
             artists.append(artist)
+
+    if separatrix:
+        plot_separatrices(da, ax)
 
     return artists

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -71,6 +71,11 @@ def contourf(da, levels=7, ax=None, **kwargs):
     if len(da.dims) != 2:
         raise ValueError("da must be 2D (x,y)")
 
+    # TODO work out how to auto-set the aspect ration of the plot correctly
+    height = da.coords[y].max() - da.coords[y].min()
+    width = da.coords[x].max() - da.coords[x].min()
+    aspect = height / width
+
     if ax is None:
         fig, ax = plt.subplots()
 

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -1,181 +1,54 @@
 import matplotlib.pyplot as plt
-import numpy as np
-import xarray as xr
+
+from .utils import _decompose_regions
 
 
-def contourf(da, nlevel=10, ax=None, **kwargs):
+def contourf(da, ax=None, **kwargs):
     """
-    Plots a 2D contour plot, taking into account branch cuts (X-points).
+    Plots a 2D filled contour plot, taking into account branch cuts (X-points).
+
+    Wraps `xarray.plot.contourf`, so automatically adds a colorbar and labels.
 
     Parameters
     ----------
     da : xarray.DataArray
         A 2D (x,y) DataArray of data to plot
-    nlevel : int, optional
-        Number of levels in the contour plot
     ax : Axes, optional
         A matplotlib axes instance to plot to. If None, create a new
         figure and axes, and plot to that
+    **kwargs : optional
+        Additional arguments are passed on to xarray.plot.contourf
 
     Returns
     -------
-    con
-        The contourf instance
-
-    Examples
-    --------
-    To put a plot into an axis with a color bar:
-    >>> fig, axis = plt.subplots()
-    >>> c = gridcontourf(grid, data, show=False, ax=axis)
-    >>> fig.colorbar(c, ax=axis)
-    >>> plt.show()
+    artists
+        List of the contourf instances
     """
 
-    print(da)
-
     # TODO generalise this
-    x='R'
-    y='Z'
+    x = kwargs.pop('x', 'R')
+    y = kwargs.pop('y', 'Z')
 
     if len(da.dims) != 2:
         raise ValueError("da must be 2D (x,y)")
 
-    grid = da.attrs['grid']
-    j11 = grid['jyseps1_1']
-    j12 = grid['jyseps1_2']
-    j21 = grid['jyseps2_1']
-    j22 = grid['jyseps2_2']
-    ix1 = grid['ixseps1']
-    ix2 = grid['ixseps2']
-    nin = grid.get('ny_inner', j12)
-
-    nx = grid['nx']
-    ny = grid['ny']
-
-    R = da.coords['R']
-    Z = da.coords['R']
-
-    add_colorbar = False
     if ax is None:
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        add_colorbar = True
+        fig, ax = plt.subplots()
 
-    mind = da.min()
-    maxd = da.max()
+    regions = _decompose_regions(da)
+    region_kwargs = {}
 
-    levels = np.linspace(mind, maxd, nlevel, endpoint=True)
+    # TODO create colorbar using all the data?
 
-    ystart = 0  # Y index to start the next section
-    if j11 >= 0:
-        # plot lower inner leg
-        region1 = da[:, ystart:(j11 + 1)]
-        region1.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                              add_colorbar=False)
+    # Plot all regions on same axis
+    first, *rest = regions
+    artists = [first.plot.contourf(x=x, y=y, ax=ax,
+                                   **kwargs, **region_kwargs)]
+    if rest:
+        for region in rest:
+            artist = region.plot.contourf(x=x, y=y, ax=ax,
+                                          add_colorbar=False, add_labels=False,
+                                          **kwargs, **region_kwargs)
+            artists.append(artist)
 
-        yind = [j11, j22 + 1]
-        region2 = da[:ix1, yind]
-        region2.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                              add_colorbar=False)
-
-        region3 = da[ix1:, j11: (j11 + 2)]
-        region3.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                              add_colorbar=False)
-
-        yind = [j22, j11 + 1]
-        region4 = da[:ix1, yind]
-        region4.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                              add_colorbar=False)
-
-        ystart = j11 + 1
-
-    # Inner SOL
-    region5 = da[:, ystart:(j21 + 1)]
-    region5.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                          add_colorbar=False)
-
-    ystart = j21 + 1
-
-    if j12 > j21:
-        # Contains upper PF region
-
-        # Inner leg
-        region6 = da[ix1:, j21:(j21 + 2)]
-        region6.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                              add_colorbar=False)
-        region7 = da[:, ystart:nin]
-        region7.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                              add_colorbar=False)
-
-        # Outer leg
-        region8 = da[:, nin:(j12 + 1)]
-        region8.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                              add_colorbar=False)
-
-        region9 = da[:, nin:(j12 + 1)]
-        region9.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                              add_colorbar=False)
-
-        region10 = da[ix1:, j12:(j12 + 2)]
-        region10.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                              add_colorbar=False)
-
-        yind = [j21, j12 + 1]
-
-        region11 = da[:ix1, yind]
-        region11.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                               add_colorbar=False)
-
-        yind = [j21 + 1, j12]
-
-        region12 = da[:ix1, yind]
-        region12.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                               add_colorbar=False)
-
-        ystart = j12 + 1
-    else:
-        ystart -= 1
-
-    # Outer SOL
-    region12 = da[:, ystart:(j22 + 1)]
-    region12.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                           add_colorbar=False)
-
-
-    ystart = j22 + 1
-
-    if j22 + 1 < ny:
-        # Outer leg
-
-        region13 = da[ix1:, j22:(j22 + 2)]
-        region13.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                               add_colorbar=False)
-
-        region14 = da[:, ystart:ny]
-        region14.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                               add_colorbar=False)
-
-        # X-point regions
-        xregion1 = da[ix1 - 1, j11]
-        xregion2 = da[ix1, j11]
-        xregion3 = da[ix1, j11 + 1]
-        xregion4 = da[ix1 - 1, j11 + 1]
-
-        xregion_lower = xr.concat([xregion1, xregion2, xregion3, xregion4],
-                                  dim='x')
-
-        xregion5 = da[ix1 - 1, j22 + 1]
-        xregion6 = da[ix1, j22 + 1]
-        xregion7 = da[ix1, j22]
-        xregion8 = da[ix1 - 1, j22]
-
-        xregion_upper = xr.concat([xregion5, xregion6, xregion7, xregion8],
-                                  dim='x')
-
-        xregion = xr.concat([xregion_lower.drop('theta'),
-                             xregion_upper.drop('theta')], dim='theta')
-
-        xregion.plot.contourf(x=x, y=y, levels=levels, ax=ax,
-                              add_colorbar=False)
-
-    return None
+    return artists

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -125,20 +125,19 @@ def _decompose_regions(da):
 
     # TODO is this correct check that there is actually a second X-point?
     if j21 < nin:
-        # TODO fix this to properly cover the upper X-point
         # X-point regions
-        corner1 = da[ix2 - 1, j12]
-        corner2 = da[ix2, j12]
-        corner3 = da[ix2, j12 + 1]
-        corner4 = da[ix2 - 1, j12 + 1]
+        corner1 = da[ix1-1, j12]
+        corner2 = da[ix1, j12]
+        corner3 = da[ix1, j12+1]
+        corner4 = da[ix1-1, j12+1]
 
         xregion_lower = xr.concat([corner1, corner2, corner3, corner4],
                                   dim='dim1')
 
-        corner5 = da[ix2 - 1, j21 + 1]
-        corner6 = da[ix2, j21 + 1]
-        corner7 = da[ix2, j21]
-        corner8 = da[ix2 - 1, j21]
+        corner5 = da[ix1 - 1, j21 + 1]
+        corner6 = da[ix1, j21+1]
+        corner7 = da[ix1, j21]
+        corner8 = da[ix1 - 1, j21]
 
         xregion_upper = xr.concat([corner5, corner6, corner7, corner8],
                                   dim='dim1')

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -123,8 +123,8 @@ def _decompose_regions(da):
 
         regions.extend([region13, region14, region15])
 
-    # TODO what's the condition for there to be a second x-point?
-    if True:
+    # TODO is this correct check that there is actually a second X-point?
+    if j21 < nin:
         # TODO fix this to properly cover the upper X-point
         # X-point regions
         corner1 = da[ix2 - 1, j12]
@@ -205,7 +205,7 @@ def plot_separatrices(da, ax):
         if ix2 < ix1:
             raise ValueError("Inner separatrix must be the at the bottom")
 
-        # TODO correct check that there is actually a second X-point?
+        # TODO is this correct check that there is actually a second X-point?
         if j21 < nin:
             # Upper X-point location
             Rx = 0.125 * (R[ix2 - 1, j12] + R[ix2, j12]
@@ -246,22 +246,13 @@ def plot_separatrices(da, ax):
                                   np.flip(upper_outer_R)))
         inner_Z = np.concatenate((lower_inner_Z, core_inner_Z, [Zx],
                                   np.flip(upper_outer_Z)))
-        ax.plot(inner_R, inner_Z, 'r--')
+        ax.plot(inner_R, inner_Z, 'k--')
 
-        outer_R = np.concatenate((np.flip(lower_outer_R), np.flip(core_outer_R), [Rx],
-                                  upper_inner_R))
-        outer_Z = np.concatenate((np.flip(lower_outer_Z), np.flip(core_outer_Z), [Zx],
-                                  upper_inner_Z))
-        ax.plot(outer_R, outer_Z, 'r--')
-
-        #ax.plot(lower_inner_R, lower_inner_Z, 'r--')
-        #ax.plot(lower_outer_R, lower_outer_Z, 'r-->')
-
-        #ax.plot(upper_inner_R, upper_inner_Z, 'r-->')
-        #ax.plot(upper_outer_R, upper_outer_Z, 'r--')
-
-        #ax.plot(core_inner_R, core_inner_Z, 'r--')
-        #ax.plot(core_outer_R, core_outer_Z, 'r--')
+        outer_R = np.concatenate((np.flip(lower_outer_R),
+                                  np.flip(core_outer_R), [Rx], upper_inner_R))
+        outer_Z = np.concatenate((np.flip(lower_outer_Z),
+                                  np.flip(core_outer_Z), [Zx], upper_inner_Z))
+        ax.plot(outer_R, outer_Z, 'k--')
 
 
 def plot_targets(da, ax, hatching=True):

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -40,18 +40,7 @@ def _decompose_regions(da):
 
     # TODO are we dealing with empty regions sensibly?
 
-    grid = da.attrs['grid']
-    j11 = grid['jyseps1_1']
-    j12 = grid['jyseps1_2']
-    j21 = grid['jyseps2_1']
-    j22 = grid['jyseps2_2']
-    ix1 = grid['ixseps1']
-    ix2 = grid['ixseps2']
-    nin = grid.get('ny_inner', j12)
-
-    nx = grid['nx']
-    ny = grid['ny']
-
+    j11, j12, j21, j22, ix1, ix2, nin, _, ny = _get_seps(da)
     regions = []
 
     ystart = 0  # Y index to start the next section
@@ -164,17 +153,7 @@ def _decompose_regions(da):
 def plot_separatrices(da, ax):
     """Plot separatrices"""
 
-    grid = da.attrs['grid']
-    j11 = grid['jyseps1_1']
-    j12 = grid['jyseps1_2']
-    j21 = grid['jyseps2_1']
-    j22 = grid['jyseps2_2']
-    ix1 = grid['ixseps1']
-    ix2 = grid['ixseps2']
-    nin = grid.get('ny_inner', j12)
-
-    nx = grid['nx']
-    ny = grid['ny']
+    j11, j12, j21, j22, ix1, ix2, nin, *_ = _get_seps(da)
 
     R = da.coords['R'].transpose('x', 'theta')
     Z = da.coords['Z'].transpose('x', 'theta')
@@ -214,10 +193,26 @@ def plot_separatrices(da, ax):
                    + Z[ix1, (j12 + 1):(j22 + 1)])
     core_Z = concatenate(([Zx], core_Z1, core_Z2, [Zx]))
 
+    ax.plot(lower_inner_R, lower_inner_Z, 'k--')
+    ax.plot(lower_outer_R, lower_outer_Z, 'k--')
+    ax.plot(core_R, core_Z, 'k--')
+
     if ix2 != ix1:
         # TODO plot second separatrix
         pass
 
-    ax.plot(lower_inner_R, lower_inner_Z, 'k--')
-    ax.plot(lower_outer_R, lower_outer_Z, 'k--')
-    ax.plot(core_R, core_Z, 'k--')
+
+def _get_seps(da):
+    grid = da.attrs['grid']
+    j11 = grid['jyseps1_1']
+    j12 = grid['jyseps1_2']
+    j21 = grid['jyseps2_1']
+    j22 = grid['jyseps2_2']
+    ix1 = grid['ixseps1']
+    ix2 = grid['ixseps2']
+    nin = grid.get('ny_inner', j12)
+
+    nx = grid['nx']
+    ny = grid['ny']
+
+    return j11, j12, j21, j22, ix1, ix2, nin, nx, ny

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -253,6 +253,45 @@ def plot_separatrices(da, ax):
         ax.plot(core_outer_R, core_outer_Z, 'r--')
 
 
+def plot_targets(da, ax):
+    """Plot divertor and limiter target plates"""
+
+    j11, j12, j21, j22, ix1, ix2, nin, nx, ny = _get_seps(da)
+
+    R = da.coords['R'].transpose('x', 'theta')
+    Z = da.coords['Z'].transpose('x', 'theta')
+
+    if j22 + 1 < ny:
+        # lower PFR exists
+        xin = 0
+    else:
+        xin = ix2
+
+    inner_lower_target_R = R[xin:, 0]
+    inner_lower_target_Z = Z[xin:, 0]
+    ax.plot(inner_lower_target_R, inner_lower_target_Z, 'k-', linewidth=2)
+
+    outer_lower_target_R = R[xin:, ny-1]
+    outer_lower_target_Z = Z[xin:, ny-1]
+    ax.plot(outer_lower_target_R, outer_lower_target_Z, 'k-', linewidth=2)
+
+    if j21 < nin:
+        # upper PFR exists
+        xin = 0
+    else:
+        xin = ix2
+
+    if j21 < nin:
+        inner_upper_target_R = R[xin:, nin-1]
+        inner_upper_target_Z = Z[xin:, nin-1]
+        ax.plot(inner_upper_target_R, inner_upper_target_Z, 'k-', linewidth=2)
+
+    if j12 > nin+1:
+        outer_upper_target_R = R[xin:, nin]
+        outer_upper_target_Z = Z[xin:, nin]
+        ax.plot(outer_upper_target_R, outer_upper_target_Z, 'k-', linewidth=2)
+
+
 def _get_seps(da):
     grid = da.attrs['grid']
     j11 = grid['jyseps1_1']

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -37,6 +37,7 @@ def plot_separatrix(da, sep_pos, ax, radial_coord='x'):
 
 def _decompose_regions(da):
 
+    # TODO are we dealing with empty regions sensibly?
 
     grid = da.attrs['grid']
     j11 = grid['jyseps1_1']
@@ -132,7 +133,9 @@ def _decompose_regions(da):
 
         regions.extend([region13, region14, region15])
 
-    if True:  # what's the condition for there to be a second x-point?
+    # TODO what's the condition for there to be a second x-point?
+    if True:
+        # TODO fix this to properly cover the upper X-point
         # X-point regions
         corner1 = da[ix2 - 1, j12]
         corner2 = da[ix2, j12]

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -1,5 +1,7 @@
 import warnings
 
+import xarray as xr
+
 
 def plot_separatrix(da, sep_pos, ax, radial_coord='x'):
     """
@@ -31,3 +33,104 @@ def plot_separatrix(da, sep_pos, ax, radial_coord='x'):
         ax.axvline(x=sep_x_pos, linewidth=2, color="black", linestyle='--')
 
         return ax
+
+
+def _decompose_regions(da):
+
+
+    grid = da.attrs['grid']
+    j11 = grid['jyseps1_1']
+    j12 = grid['jyseps1_2']
+    j21 = grid['jyseps2_1']
+    j22 = grid['jyseps2_2']
+    ix1 = grid['ixseps1']
+    ix2 = grid['ixseps2']
+    nin = grid.get('ny_inner', j12)
+
+    nx = grid['nx']
+    ny = grid['ny']
+
+    regions = []
+
+    ystart = 0  # Y index to start the next section
+    if j11 >= 0:
+        # plot lower inner leg
+        region1 = da[:, ystart:(j11 + 1)]
+
+        yind = [j11, j22 + 1]
+        region2 = da[:ix1, yind]
+
+        region3 = da[ix1:, j11: (j11 + 2)]
+
+        yind = [j22, j11 + 1]
+        region4 = da[:ix1, yind]
+
+        regions.extend([region1, region2, region3, region4])
+
+        ystart = j11 + 1
+
+    # Inner SOL
+    region5 = da[:, ystart:(j21 + 1)]
+    regions.append(region5)
+
+    ystart = j21 + 1
+
+    if j12 > j21:
+        # Contains upper PF region
+
+        # Inner leg
+        region6 = da[ix1:, j21:(j21 + 2)]
+        region7 = da[:, ystart:nin]
+
+        # Outer leg
+        region8 = da[:, nin:(j12 + 1)]
+        region9 = da[ix1:, j12:(j12 + 2)]
+
+        yind = [j21, j12 + 1]
+
+        region10 = da[:ix1, yind]
+
+        yind = [j21 + 1, j12]
+        region11 = da[:ix1, yind]
+
+        regions.extend([region6, region7, region8,
+                        region9, region10, region11])
+
+        ystart = j12 + 1
+    else:
+        ystart -= 1
+
+    # Outer SOL
+    region12 = da[:, ystart:(j22 + 1)]
+    regions.append(region12)
+
+    ystart = j22 + 1
+
+    if j22 + 1 < ny:
+        # Outer leg
+        region13 = da[ix1:, j22:(j22 + 2)]
+        region14 = da[:, ystart:ny]
+
+        # X-point regions
+        xregion1 = da[ix1 - 1, j11]
+        xregion2 = da[ix1, j11]
+        xregion3 = da[ix1, j11 + 1]
+        xregion4 = da[ix1 - 1, j11 + 1]
+
+        xregion_lower = xr.concat([xregion1, xregion2, xregion3, xregion4],
+                                  dim='x')
+
+        xregion5 = da[ix1 - 1, j22 + 1]
+        xregion6 = da[ix1, j22 + 1]
+        xregion7 = da[ix1, j22]
+        xregion8 = da[ix1 - 1, j22]
+
+        xregion_upper = xr.concat([xregion5, xregion6, xregion7, xregion8],
+                                  dim='x')
+
+        region15 = xr.concat([xregion_lower.drop('theta'),
+                              xregion_upper.drop('theta')], dim='theta')
+
+        regions.extend([region13, region14, region15])
+
+    return regions

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -200,7 +200,7 @@ def plot_separatrices(da, ax):
     ax.plot(lower_outer_R, lower_outer_Z, 'k--')
     ax.plot(core_R, core_Z, 'k--')
 
-    # TODO plot second separatrix
+    # Plot second separatrix
     if ix2 != ix1:
         if ix2 < ix1:
             raise ValueError("Inner separatrix must be the at the bottom")
@@ -242,15 +242,26 @@ def plot_separatrices(da, ax):
         core_outer_Z = 0.5 * (Z[ix2 - 1, (j12 + 1):(j22 + 1)]
                          + Z[ix2, (j12 + 1):(j22 + 1)])
 
-        # TODO join these up (inc x-point) properly
-        ax.plot(lower_inner_R, lower_inner_Z, 'r--')
-        ax.plot(lower_outer_R, lower_outer_Z, 'r--')
+        inner_R = np.concatenate((lower_inner_R, core_inner_R, [Rx],
+                                  np.flip(upper_outer_R)))
+        inner_Z = np.concatenate((lower_inner_Z, core_inner_Z, [Zx],
+                                  np.flip(upper_outer_Z)))
+        ax.plot(inner_R, inner_Z, 'r--')
 
-        ax.plot(upper_inner_R, upper_inner_Z, 'r--')
-        ax.plot(upper_outer_R, upper_outer_Z, 'r--')
+        outer_R = np.concatenate((np.flip(lower_outer_R), np.flip(core_outer_R), [Rx],
+                                  upper_inner_R))
+        outer_Z = np.concatenate((np.flip(lower_outer_Z), np.flip(core_outer_Z), [Zx],
+                                  upper_inner_Z))
+        ax.plot(outer_R, outer_Z, 'r--')
 
-        ax.plot(core_inner_R, core_inner_Z, 'r--')
-        ax.plot(core_outer_R, core_outer_Z, 'r--')
+        #ax.plot(lower_inner_R, lower_inner_Z, 'r--')
+        #ax.plot(lower_outer_R, lower_outer_Z, 'r-->')
+
+        #ax.plot(upper_inner_R, upper_inner_Z, 'r-->')
+        #ax.plot(upper_outer_R, upper_outer_Z, 'r--')
+
+        #ax.plot(core_inner_R, core_inner_Z, 'r--')
+        #ax.plot(core_outer_R, core_outer_Z, 'r--')
 
 
 def plot_targets(da, ax, hatching=True):

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -112,25 +112,46 @@ def _decompose_regions(da):
         region14 = da[:, ystart:ny]
 
         # X-point regions
-        xregion1 = da[ix1 - 1, j11]
-        xregion2 = da[ix1, j11]
-        xregion3 = da[ix1, j11 + 1]
-        xregion4 = da[ix1 - 1, j11 + 1]
+        corner1 = da[ix1 - 1, j11]
+        corner2 = da[ix1, j11]
+        corner3 = da[ix1, j11 + 1]
+        corner4 = da[ix1 - 1, j11 + 1]
 
-        xregion_lower = xr.concat([xregion1, xregion2, xregion3, xregion4],
-                                  dim='x')
+        xregion_lower = xr.concat([corner1, corner2, corner3, corner4],
+                                  dim='dim1')
 
-        xregion5 = da[ix1 - 1, j22 + 1]
-        xregion6 = da[ix1, j22 + 1]
-        xregion7 = da[ix1, j22]
-        xregion8 = da[ix1 - 1, j22]
+        corner5 = da[ix1 - 1, j22 + 1]
+        corner6 = da[ix1, j22 + 1]
+        corner7 = da[ix1, j22]
+        corner8 = da[ix1 - 1, j22]
 
-        xregion_upper = xr.concat([xregion5, xregion6, xregion7, xregion8],
-                                  dim='x')
+        xregion_upper = xr.concat([corner5, corner6, corner7, corner8],
+                                  dim='dim1')
 
-        region15 = xr.concat([xregion_lower.drop('theta'),
-                              xregion_upper.drop('theta')], dim='theta')
+        region15 = xr.concat([xregion_lower, xregion_upper], dim='dim2')
 
         regions.extend([region13, region14, region15])
+
+    if True:  # what's the condition for there to be a second x-point?
+        # X-point regions
+        corner1 = da[ix2 - 1, j12]
+        corner2 = da[ix2, j12]
+        corner3 = da[ix2, j12 + 1]
+        corner4 = da[ix2 - 1, j12 + 1]
+
+        xregion_lower = xr.concat([corner1, corner2, corner3, corner4],
+                                  dim='dim1')
+
+        corner5 = da[ix2 - 1, j21 + 1]
+        corner6 = da[ix2, j21 + 1]
+        corner7 = da[ix2, j21]
+        corner8 = da[ix2 - 1, j21]
+
+        xregion_upper = xr.concat([corner5, corner6, corner7, corner8],
+                                  dim='dim1')
+
+        region16 = xr.concat([xregion_lower, xregion_upper], dim='dim2')
+
+        regions.append(region16)
 
     return regions


### PR DESCRIPTION
Adds accessor methods to plot poloidal slices using the old `griddata` approach. Should be general enough to work for any tokamak geometry.

Adds `da.bout.contourf()`, which gives:
![griddata_doublenull](https://user-images.githubusercontent.com/35968931/60869871-b2480780-a227-11e9-9536-da4579c50101.png)

Optionally plots both separatrices, and optionally marks the positions of the limiters with hatched lines to indicate solid surfaces.

Also adds `da.bout.regions()`, which I created for debugging purposes, but it helps understand how the griddata-style plotting approach works:

![regions](https://user-images.githubusercontent.com/35968931/60870231-58940d00-a228-11e9-8a49-9618b8e12b19.png)

To get this to work for any geometry I had to extend the old griddata and fix a few bugs with it, but the result is that it can now handle both X-points, both separatrices, and knows how big the limiters should be, as you can see in this s-alpha plot:
![griddata_salpha](https://user-images.githubusercontent.com/35968931/60869876-b6742500-a227-11e9-919b-d05b1ba58214.png)

It would be good if someone could try it with (or just send me) a single-null grid file to test against, as I've only tried it with these two examples.

One problem I'm still having is getting the aspect ratio of the plot correct automatically. If I force it with `plt.set_aspect()` then I end up with loads of whitespace which I can't seem to get rid of.

(@ZedThree This PR should be based off of the grids PR, branch feature/grids on my forked version of xBOUT, but I couldn't quite work out how to do that.)