### PR TITLE
Drop timing info

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -8,6 +8,9 @@ from functools import partial
 
 from natsort import natsorted
 
+_bout_timing_variables = ['wall_time', 'wtime', 'wtime_rhs', 'wtime_invert',
+                          'wtime_comms', 'wtime_io', 'wtime_per_rhs', 'wtime_per_rhs_e',
+                          'wtime_per_rhs_i']
 
 def _auto_open_mfboutdataset(datapath, chunks={}, info=True, keep_guards=True):
     filepaths, filetype = _expand_filepaths(datapath)
@@ -155,6 +158,8 @@ def _trim(ds, ghosts={}, keep_guards=True):
     """
     Trims all ghost and guard cells off a single dataset read from a single
     BOUT dump file, to prepare for concatenation.
+    Also drops some variables that store timing information, which are different for each
+    process and so cannot be concatenated.
 
     Parameters
     ----------
@@ -173,6 +178,10 @@ def _trim(ds, ghosts={}, keep_guards=True):
             selection[dim] = slice(ghosts[dim], -ghosts[dim])
 
     trimmed_ds = ds.isel(**selection)
+
+    vars_to_drop = [v for v in _bout_timing_variables if v in ds]
+    trimmed_ds = trimmed_ds.drop(vars_to_drop)
+
     return trimmed_ds
 
 

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -179,8 +179,7 @@ def _trim(ds, ghosts={}, keep_guards=True):
 
     trimmed_ds = ds.isel(**selection)
 
-    vars_to_drop = [v for v in _bout_timing_variables if v in ds]
-    trimmed_ds = trimmed_ds.drop(vars_to_drop)
+    trimmed_ds = trimmed_ds.drop(_bout_timing_variables, errors='ignore')
 
     return trimmed_ds
 

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -8,7 +8,7 @@ from functools import partial
 
 from natsort import natsorted
 
-_bout_timing_variables = ['wall_time', 'wtime', 'wtime_rhs', 'wtime_invert',
+_BOUT_TIMING_VARIABLES = ['wall_time', 'wtime', 'wtime_rhs', 'wtime_invert',
                           'wtime_comms', 'wtime_io', 'wtime_per_rhs', 'wtime_per_rhs_e',
                           'wtime_per_rhs_i']
 
@@ -179,7 +179,7 @@ def _trim(ds, ghosts={}, keep_guards=True):
 
     trimmed_ds = ds.isel(**selection)
 
-    trimmed_ds = trimmed_ds.drop(_bout_timing_variables, errors='ignore')
+    trimmed_ds = trimmed_ds.drop(_BOUT_TIMING_VARIABLES, errors='ignore')
 
     return trimmed_ds
 

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -356,20 +356,15 @@ class TestTrim:
 
     def test_trim_timing_info(self):
         ds = create_test_data(0)
-        from xbout.load import _bout_timing_variables
+        from xbout.load import _BOUT_TIMING_VARIABLES
 
-        # remove a couple of entries from _bout_timing_variables so we test that _trim
+        # remove a couple of entries from _BOUT_TIMING_VARIABLES so we test that _trim
         # does not fail if not all of them are present
-        _bout_timing_variables = _bout_timing_variables[:-2]
+        _BOUT_TIMING_VARIABLES = _BOUT_TIMING_VARIABLES[:-2]
 
-        for v in _bout_timing_variables:
+        for v in _BOUT_TIMING_VARIABLES:
             ds[v] = 42.
-        expected = create_test_data(0)
-        try:
-            xrt.assert_equal(ds, expected)
-        except AssertionError:
-            pass
-        else:
-            assert False, "ds has had variables added, should be different from expected"
         ds = _trim(ds)
+
+        expected = create_test_data(0)
         xrt.assert_equal(ds, expected)

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -353,3 +353,23 @@ class TestTrim:
         selection = {'time': slice(2, -2)}
         expected = ds.isel(**selection)
         xrt.assert_equal(expected, actual)
+
+    def test_trim_timing_info(self):
+        ds = create_test_data(0)
+        from xbout.load import _bout_timing_variables
+
+        # remove a couple of entries from _bout_timing_variables so we test that _trim
+        # does not fail if not all of them are present
+        _bout_timing_variables = _bout_timing_variables[:-2]
+
+        for v in _bout_timing_variables:
+            ds[v] = 42.
+        expected = create_test_data(0)
+        try:
+            xrt.assert_equal(ds, expected)
+        except AssertionError:
+            pass
+        else:
+            assert False, "ds has had variables added, should be different from expected"
+        ds = _trim(ds)
+        xrt.assert_equal(ds, expected)


### PR DESCRIPTION
BOUT++ v4.3 will write some variables with timing information into the dump files: `wall_time', wtime, wtime_rhs, wtime_invert, wtime_comms, wtime_io, wtime_per_rhs, wtime_per_rhs_e, wtime_per_rhs_i`. Timing information is not consistent between processes and therefore cannot be concatenated, so instead drop these variables before concatenating. A check is made so only variables that exist in the dataset are dropped, so this is backwards compatible.