### PR TITLE
More permissive defaults for 2d animation

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -42,7 +42,7 @@ class BoutDataArrayAccessor:
                                                   indent=4, compact=True))
         return text
 
-    def animate2D(self, animate_over='t', x='x', y='y', animate=True,
+    def animate2D(self, animate_over='t', x=None, y=None, animate=True,
                   fps=10, save_as=None, sep_pos=None, ax=None, **kwargs):
         """
         Plots a color plot which is animated with time over the specified
@@ -56,9 +56,11 @@ class BoutDataArrayAccessor:
         animate_over : str, optional
             Dimension over which to animate
         x : str, optional
-            Dimension to use on the x axis, default is 'x'
+            Dimension to use on the x axis, default is None - then use the first spatial
+            dimension of the data
         y : str, optional
-            Dimension to use on the y axis, default is 'y'
+            Dimension to use on the y axis, default is None - then use the second spatial
+            dimension of the data
         sep_pos : int, optional
             Radial position at which to plot the separatrix
         fps : int, optional

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -49,6 +49,9 @@ def animate_imshow(data, animate_over='t', x=None, y=None, animate=True,
     # Check plot is the right orientation
     spatial_dims = list(data.dims)
 
+    if len(data.dims) != 3:
+        raise ValueError('Data passed to animate_imshow must be 3-dimensional')
+
     try:
         spatial_dims.remove(animate_over)
     except ValueError:

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -6,7 +6,7 @@ import animatplot as amp
 from .utils import plot_separatrix
 
 
-def animate_imshow(data, animate_over='t', x='x', y='y', animate=True,
+def animate_imshow(data, animate_over='t', x=None, y=None, animate=True,
                    vmin='min', vmax='max', fps=10, save_as=None,
                    sep_pos=None, ax=None, **kwargs):
     """
@@ -22,9 +22,11 @@ def animate_imshow(data, animate_over='t', x='x', y='y', animate=True,
     animate_over : str, optional
         Dimension over which to animate
     x : str, optional
-        Dimension to use on the x axis, default is 'x'
+        Dimension to use on the x axis, default is None - then use the first spatial
+        dimension of the data
     y : str, optional
-        Dimension to use on the y axis, default is 'y'
+        Dimension to use on the y axis, default is None - then use the second spatial
+        dimension of the data
     vmin : float, optional
         Minimum value to use for colorbar. Default is to use minimum value of
         data across whole timeseries.
@@ -45,12 +47,27 @@ def animate_imshow(data, animate_over='t', x='x', y='y', animate=True,
     variable = data.name
 
     # Check plot is the right orientation
-    t_read, y_read, x_read = data.dims
-    if (x_read is x) & (y_read is y):
-        pass
-    elif (x_read is y) & (y_read is x):
+    spatial_dims = list(data.dims)
+
+    try:
+        spatial_dims.remove(animate_over)
+    except ValueError:
+        raise ValueError("Dimension animate_over={} is not present in the data"
+                         .format(animate_over))
+
+    try:
+        if x is None and y is None:
+            x, y = spatial_dims
+        elif x is None:
+            spatial_dims.remove(y)
+            x = spatial_dims[0]
+        elif y is None:
+            spatial_dims.remove(x)
+            y = spatial_dims[0]
+
+        # Use (y, x) here so we transpose by default for imshow
         data = data.transpose(animate_over, y, x)
-    else:
+    except ValueError:
         raise ValueError("Dimensions {} or {} are not present in the data"
                          .format(x, y))
 

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -6,6 +6,7 @@ import animatplot as amp
 from .utils import plot_separatrix
 from matplotlib.animation import PillowWriter
 
+
 def animate_imshow(data, animate_over='t', x=None, y=None, animate=True,
                    vmin=None, vmax=None, fps=10, save_as=None,
                    sep_pos=None, ax=None, **kwargs):

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -58,21 +58,23 @@ def animate_imshow(data, animate_over='t', x=None, y=None, animate=True,
         raise ValueError("Dimension animate_over={} is not present in the data"
                          .format(animate_over))
 
-    try:
-        if x is None and y is None:
-            x, y = spatial_dims
-        elif x is None:
+    if x is None and y is None:
+        x, y = spatial_dims
+    elif x is None:
+        try:
             spatial_dims.remove(y)
-            x = spatial_dims[0]
-        elif y is None:
+        except ValueError:
+            raise ValueError("Dimension {} is not present in the data" .format(y))
+        x = spatial_dims[0]
+    elif y is None:
+        try:
             spatial_dims.remove(x)
-            y = spatial_dims[0]
+        except ValueError:
+            raise ValueError("Dimension {} is not present in the data" .format(x))
+        y = spatial_dims[0]
 
-        # Use (y, x) here so we transpose by default for imshow
-        data = data.transpose(animate_over, y, x)
-    except ValueError:
-        raise ValueError("Dimensions {} or {} are not present in the data"
-                         .format(x, y))
+    # Use (y, x) here so we transpose by default for imshow
+    data = data.transpose(animate_over, y, x)
 
     # Load values eagerly otherwise for some reason the plotting takes
     # 100's of times longer - for some reason animatplot does not deal

--- a/xbout/tests/test_animate.py
+++ b/xbout/tests/test_animate.py
@@ -32,11 +32,25 @@ class TestAnimate:
     def test_animate2D(self, create_test_file):
 
         save_dir, ds = create_test_file
+
         animation = ds['n'].isel(x=1).bout.animate2D(save_as="%s/testyz" % save_dir)
+
+        assert isinstance(animation, Imshow)
+
+        assert animation.ax.get_xlabel() == 'y'
+        assert animation.ax.get_ylabel() == 'z'
+
         animation = ds['n'].isel(y=2).bout.animate2D(save_as="%s/testxz" % save_dir)
+
+        assert isinstance(animation, Imshow)
+        assert animation.ax.get_xlabel() == 'x'
+        assert animation.ax.get_ylabel() == 'z'
+
         animation = ds['n'].isel(z=3).bout.animate2D(save_as="%s/testxy" % save_dir)
 
         assert isinstance(animation, Imshow)
+        assert animation.ax.get_xlabel() == 'x'
+        assert animation.ax.get_ylabel() == 'y'
 
     def test_animate1D(self, create_test_file):
 

--- a/xbout/tests/test_animate.py
+++ b/xbout/tests/test_animate.py
@@ -32,7 +32,9 @@ class TestAnimate:
     def test_animate2D(self, create_test_file):
 
         save_dir, ds = create_test_file
-        animation = ds['n'].isel(y=1).bout.animate2D(y='z', save_as="%s/test" % save_dir)
+        animation = ds['n'].isel(x=1).bout.animate2D(save_as="%s/testyz" % save_dir)
+        animation = ds['n'].isel(y=2).bout.animate2D(save_as="%s/testxz" % save_dir)
+        animation = ds['n'].isel(z=3).bout.animate2D(save_as="%s/testxy" % save_dir)
 
         assert isinstance(animation, Imshow)
 


### PR DESCRIPTION
Set default values of 'x' and 'y' arguments to None for animate2D and animate_imshow. When default arguments are passed, use the spatial dimensions of the data (i.e. the ones that are not 'animate_over').

Now for example, if you have a data-array `da` with `('t', 'x', 'z')` dimensions, you can make an animation with `da.bout.animate2D()`, where before an explicit argument was needed `da.bout.animate2D(y='z')`.