### PR TITLE
Calc - subpackage for analysis functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 with open("README.md", 'r') as f:
     long_description = f.read()
@@ -10,6 +10,16 @@ with open("xbout/_version.py") as f:
 name = 'xBOUT'
 version = version_dict['__version__']
 release = version
+
+extras_require = {
+  'calc': ['numpy >= 1.13.0', 'scipy >= 1.3.0', 'dask >= 2.2.0',
+           'statsmodels >= 0.10.1', 'xrft', 'xhistogram'],
+  'docs': ['sphinx >= 1.4'],
+}
+
+packages = ['xbout', 'xbout.calc']
+
+tests = [p + '.tests' for p in packages]
 
 setup(
     name=name,
@@ -28,10 +38,8 @@ setup(
         'animatplot>=0.3',
         'netcdf4>=1.4.0',
     ],
-    extras_require={
-        'tests': ['pytest >= 3.3.0'],
-        'docs': ['sphinx >= 1.4'],
-    },
+    extras_require=extras_require,
+    tests_require=['pytest >= 3.3.0'],
     long_description=long_description,
     long_description_content_type="text/markdown",
     classifiers=[
@@ -47,7 +55,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: Visualization"
     ],
-    packages=find_packages(),
+    packages=packages + tests,
     include_package_data=True,
     command_options={
         'build_sphinx': {

--- a/xbout/calc/__init__.py
+++ b/xbout/calc/__init__.py
@@ -1,0 +1,1 @@
+from .turbulence import rms

--- a/xbout/calc/tests/test_turbulence.py
+++ b/xbout/calc/tests/test_turbulence.py
@@ -1,0 +1,53 @@
+import numpy as np
+from xarray import DataArray
+import pytest
+import numpy.testing as npt
+
+from xbout.calc.turbulence import rms
+
+
+class TestRootMeanSquare:
+    def test_no_dim(self):
+        dat = np.array([5, 7, 3.2, -1, -4.4])
+        orig = DataArray(dat, dims=['x'])
+
+        # Need to supply dimension
+        with pytest.raises(ValueError):
+            rms(orig, dim=None)
+
+    def test_1d(self):
+        dat = np.array([5, 7, 3.2, -1, -4.4])
+        orig = DataArray(dat, dims=['x'])
+
+        sum_squares = np.sum(dat**2)
+        mean_squares = sum_squares/dat.size
+        rootmeansquare = np.sqrt(mean_squares)
+
+        expected = rootmeansquare
+        actual = rms(orig, dim='x').values
+        npt.assert_equal(actual, expected)
+
+    def test_reduce_2d(self):
+        dat = np.array([[5, 7, 3.2, -1, -4.4], [-1, -2.5, 0, 8, 3.0]])
+        orig = DataArray(dat, dims=['x', 't'])
+        axis = 1
+        sum_squares = np.sum(dat**2, axis=axis)
+        mean_squares = sum_squares / dat.shape[axis]
+        rootmeansquare = np.sqrt(mean_squares)
+
+        expected = rootmeansquare
+        actual = rms(orig, dim='t').values
+        npt.assert_equal(actual, expected)
+
+    def test_reduce_2d_dask(self):
+        dat = np.array([[5, 7, 3.2, -1, -4.4], [-1, -2.5, 0, 8, 3.0]])
+        orig = DataArray(dat, dims=['x', 't'])
+        chunked = orig.chunk({'x': 1})
+        axis = 1
+        sum_squares = np.sum(dat**2, axis=axis)
+        mean_squares = sum_squares / dat.shape[axis]
+        rootmeansquare = np.sqrt(mean_squares)
+
+        expected = rootmeansquare
+        actual = rms(chunked, dim='t').values
+        npt.assert_equal(actual, expected)

--- a/xbout/calc/tests/test_turbulence.py
+++ b/xbout/calc/tests/test_turbulence.py
@@ -27,16 +27,16 @@ class TestRootMeanSquare:
         actual = rms(orig, dim='x').values
         npt.assert_equal(actual, expected)
 
-    def test_reduce_2d(self):
+    @pytest.mark.parametrize('dim, axis', [('t', 1), ('x', 0)])
+    def test_reduce_2d(self, dim, axis):
         dat = np.array([[5, 7, 3.2, -1, -4.4], [-1, -2.5, 0, 8, 3.0]])
         orig = DataArray(dat, dims=['x', 't'])
-        axis = 1
         sum_squares = np.sum(dat**2, axis=axis)
         mean_squares = sum_squares / dat.shape[axis]
         rootmeansquare = np.sqrt(mean_squares)
 
         expected = rootmeansquare
-        actual = rms(orig, dim='t').values
+        actual = rms(orig, dim=dim).values
         npt.assert_equal(actual, expected)
 
     def test_reduce_2d_dask(self):

--- a/xbout/calc/turbulence.py
+++ b/xbout/calc/turbulence.py
@@ -1,0 +1,32 @@
+import numpy as np
+import xarray as xr
+
+
+# TODO write a decorator to add functions as accessors to dataarrays?
+
+
+def rms_gufunc(x):
+    """Generalized ufunc to calculate root mean squared value of an array."""
+    squares = np.square(x)
+    return np.sqrt(np.mean(squares, axis=-1))
+
+
+def rms(da, dim=None, dask='parallelized', keep_attrs=True):
+    """
+    Reduces a dataarray by calculating the root mean square along the dimension
+    dim.
+    """
+
+    # TODO If dim is None then take the root mean square along all dimensions?
+    if dim is None:
+        raise ValueError('Must supply a dimension along which to calculate rms')
+
+    rms = xr.apply_ufunc(rms_gufunc, da,
+                         input_core_dims=[[dim]],
+                         dask=dask, output_dtypes=[da.dtype],
+                         keep_attrs=keep_attrs)
+
+    # Return the name of the da as variable_rms
+    rms.name = str(da.name) + '_rms'
+
+    return rms

--- a/xbout/calc/turbulence.py
+++ b/xbout/calc/turbulence.py
@@ -5,7 +5,7 @@ import xarray as xr
 # TODO write a decorator to add functions as accessors to dataarrays?
 
 
-def rms_gufunc(x):
+def _rms_gufunc(x):
     """Generalized ufunc to calculate root mean squared value of an array."""
     squares = np.square(x)
     return np.sqrt(np.mean(squares, axis=-1))
@@ -21,7 +21,7 @@ def rms(da, dim=None, dask='parallelized', keep_attrs=True):
     if dim is None:
         raise ValueError('Must supply a dimension along which to calculate rms')
 
-    rms = xr.apply_ufunc(rms_gufunc, da,
+    rms = xr.apply_ufunc(_rms_gufunc, da,
                          input_core_dims=[[dim]],
                          dask=dask, output_dtypes=[da.dtype],
                          keep_attrs=keep_attrs)


### PR DESCRIPTION
Starts work towards closing #5, by adding a subpackage `xbout[calc]` which is optionally-installable.

`calc` should be the home for any standard analysis functions which bout++ users might want, but that aren't specific to a particular bout++ module. For example I've created a `turbulence` module within `calc`, which has the root-mean-square fluctuations calculating function `rms` as an example. Next I will add another module `fft` which uses [xrft](https://xrft.readthedocs.io/en/latest/) to do common Fourier analysis tasks with the data.