### PR TITLE
Some small fixes for loading grid files

### DIFF
--- a/xbout/grid.py
+++ b/xbout/grid.py
@@ -60,7 +60,8 @@ def open_grid(gridfilepath='./grid.nc', geometry=None, ds=None, quiet=False):
     else:
         # TODO should instead drop variables which appear twice from grid
         # i.e. assume dataset variables are correct
-        ds = xr.merge(ds, grid)
+        ds = xr.merge((ds, grid))
+
     ds = _set_attrs_on_all_vars(ds, 'grid', grid_metadata)
 
     if geometry is None:

--- a/xbout/grid.py
+++ b/xbout/grid.py
@@ -62,7 +62,12 @@ def open_grid(gridfilepath='./grid.nc', geometry=None, ds=None, quiet=False,
         if xboundaries > 0:
             grid = grid.isel(x=slice(xboundaries, -xboundaries, None))
     if not keep_yboundaries:
-        yboundaries = int(grid['y_boundary_guards'])
+        try:
+            yboundaries = int(grid['y_boundary_guards'])
+        except KeyError:
+            # y_boundary_guards variable not in grid file - older grid files never had
+            # y-boundary cells
+            yboundaries = 0
         if yboundaries > 0:
             # Remove y-boundary cells from first divertor target
             grid = grid.isel(y=slice(yboundaries, -yboundaries, None))

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -91,7 +91,9 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', chunks={},
     ds = _set_attrs_on_all_vars(ds, 'options', options)
 
     if gridfilepath:
-        ds = open_grid(gridfilepath=gridfilepath, geometry=geometry, ds=ds)
+        ds = open_grid(gridfilepath=gridfilepath, geometry=geometry, ds=ds,
+                       keep_xboundaries=keep_xboundaries,
+                       keep_yboundaries=keep_yboundaries)
 
     # TODO read and store git commit hashes from output files
 


### PR DESCRIPTION
Fixes two bugs with merging dataset and grid - passing a tuple as the first argument to xr.merge; and handling duplicated variables between grid and dataset, by preferring the version from the dataset (because these are the ones used in a simulation, which might have been modified from the ones loaded from the grid file, e.g. by having normalisations applied).

Adds support for boundary cells in grid files.