### PR TITLE
Message and workaround when name of coordinate conflicts with variable

### DIFF
--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -95,10 +95,7 @@ def add_toroidal_geometry_coords(ds, coordinates=None):
     coordinates = _set_default_toroidal_coordinates(coordinates)
 
     # Check whether coordinates names conflict with variables in ds
-    bad_names = []
-    for name in coordinates.values():
-        if name in ds:
-            bad_names.append(name)
+    bad_names = [name for name in coordinates.values() if name in ds]
     if bad_names:
         raise ValueError('Coordinate names {} clash with variables in the dataset. '
                          "Use the 'coordinates' argument of open_boutdataset to provide "

--- a/xbout/grid.py
+++ b/xbout/grid.py
@@ -7,8 +7,8 @@ from . import geometries
 from .utils import _set_attrs_on_all_vars, _check_filetype, _separate_metadata
 
 
-def open_grid(gridfilepath='./grid.nc', geometry=None, ds=None, quiet=False,
-              keep_xboundaries=False, keep_yboundaries=False):
+def open_grid(gridfilepath='./grid.nc', geometry=None, coordinates=None, ds=None,
+              quiet=False, keep_xboundaries=False, keep_yboundaries=False):
     """
     Opens a BOUT++ grid file.
 
@@ -29,6 +29,9 @@ def open_grid(gridfilepath='./grid.nc', geometry=None, ds=None, quiet=False,
 
         To define a new type of geometry you need to use the
         `register_geometry` decorator.
+    coordinates : sequence of str, optional
+        Names to give the physical coordinates corresponding to 'x', 'y' and 'z' (in
+        order). If not specified, default names are chosen.
     ds : xarray.Dataset, optional
         BOUT dataset to merge grid information with.
         Leave unspecified if you just want to open the grid file alone.
@@ -105,6 +108,6 @@ def open_grid(gridfilepath='./grid.nc', geometry=None, ds=None, quiet=False,
 
     if geometry is not None:
         # Update coordinates to match particular geometry of grid
-        ds = geometries.apply_geometry(ds, geometry)
+        ds = geometries.apply_geometry(ds, geometry, coordinates=coordinates)
 
     return ds

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -36,10 +36,10 @@ except ValueError:
 # TODO somehow check that we have access to the latest version of auto_combine
 
 
-def open_boutdataset(datapath='./BOUT.dmp.*.nc', chunks={},
+def open_boutdataset(datapath='./BOUT.dmp.*.nc',
                      inputfilepath=None, gridfilepath=None, geometry=None,
-                     keep_xboundaries=True, keep_yboundaries=False,
-                     run_name=None, info=True):
+                     coordinates=None, chunks={}, keep_xboundaries=True,
+                     keep_yboundaries=False, run_name=None, info=True):
     """
     Load a dataset from a set of BOUT output files, including the input options file.
 
@@ -50,9 +50,11 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', chunks={},
     inputfilepath : str, optional
     gridfilepath : str, optional
     geometry : str, optional
-        Type of geometry to treat this data as having. The choice applies the
-        corresponding function from the set of registered geometries. Default
-        is None.
+        Create coordinates for a certain type of geometry.
+        Currently supported: toroidal, s-alpha
+    coordinates : sequence of str, optional
+        Names to give the physical coordinates corresponding to 'x', 'y' and 'z' (in
+        order). If not specified, default names are chosen.
     keep_xboundaries : bool, optional
         If true, keep x-direction boundary cells (the cells past the physical
         edges of the grid, where boundary conditions are set); increases the
@@ -91,7 +93,8 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', chunks={},
     ds = _set_attrs_on_all_vars(ds, 'options', options)
 
     if gridfilepath:
-        ds = open_grid(gridfilepath=gridfilepath, geometry=geometry, ds=ds,
+        ds = open_grid(gridfilepath=gridfilepath, geometry=geometry,
+                       coordinates=coordinates, ds=ds,
                        keep_xboundaries=keep_xboundaries,
                        keep_yboundaries=keep_yboundaries)
 
@@ -121,9 +124,8 @@ def _auto_open_mfboutdataset(datapath, chunks={}, info=True,
                           keep_boundaries={'x': keep_xboundaries, 'y': keep_yboundaries},
                           nxpe=nxpe, nype=nype)
 
-    ds = xr.open_mfdataset(paths_grid, concat_dim=concat_dims,
-                           combine='nested', data_vars='minimal',
-                           preprocess=_preprocess, engine=filetype,
+    ds = xr.open_mfdataset(paths_grid, concat_dim=concat_dims, combine='nested',
+                           data_vars='minimal', preprocess=_preprocess, engine=filetype,
                            chunks=chunks)
 
     ds, metadata = _separate_metadata(ds)

--- a/xbout/tests/test_geometries.py
+++ b/xbout/tests/test_geometries.py
@@ -14,7 +14,7 @@ class TestGeometryRegistration:
 
     def test_register_new_geometry(self):
         @register_geometry(name="Schwarzschild")
-        def add_schwarzschild_coords(ds):
+        def add_schwarzschild_coords(ds, coordinates=None):
             ds['event_horizon'] = 4.0
             return ds
 

--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -63,7 +63,7 @@ class TestOpenGrid:
 
     def test_open_grid_apply_geometry(self, create_example_grid_file):
         @register_geometry(name="Schwarzschild")
-        def add_schwarzschild_coords(ds):
+        def add_schwarzschild_coords(ds, coordinates=None):
             ds['event_horizon'] = 4.0
             return ds
 


### PR DESCRIPTION
When adding physical coordinates ('geometry') to a dataset, it is an error if the name of one of the coordinates is the same as the name of a variable in the dataset. Provide informative error messages if this happens. Give a workaround - now there is a `coordinates` argument to
`open_boutdataset` (and various lower-level functions) that can be used to pass a tuple/list of names to be used instead of the defaults.

Basing this PR on `grid-fixes` (#46) to avoid merge conflicts.