### PR TITLE
Save keep_xboundaries and keep_yboundaries

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -126,6 +126,9 @@ def _auto_open_mfboutdataset(datapath, chunks={}, info=True,
 
     ds, metadata = _separate_metadata(ds)
 
+    metadata['keep_xboundaries'] = keep_xboundaries
+    metadata['keep_yboundaries'] = keep_yboundaries
+
     return ds, metadata
 
 

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -126,8 +126,10 @@ def _auto_open_mfboutdataset(datapath, chunks={}, info=True,
 
     ds, metadata = _separate_metadata(ds)
 
-    metadata['keep_xboundaries'] = keep_xboundaries
-    metadata['keep_yboundaries'] = keep_yboundaries
+    # Store as ints because netCDF doesn't support bools, so we can't save bool
+    # attributes
+    metadata['keep_xboundaries'] = int(keep_xboundaries)
+    metadata['keep_yboundaries'] = int(keep_yboundaries)
 
     return ds, metadata
 


### PR DESCRIPTION
Save the `keep_xboundaries` and `keep_yboundaries` options passed to `open_boutdataset` as attributes, in case we want to check later on what they were. Save them as `int` rather than `bool` so that they can be saved to netCDF files (which don't support `bool` variables).