### PR TITLE
Return result from geometries._set_default_toroidal_coordinates()

### DIFF
--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -93,6 +93,8 @@ def _set_default_toroidal_coordinates(coordinates):
     coordinates['y'] = coordinates.get('y', 'theta')
     coordinates['z'] = coordinates.get('z', 'phi')
 
+    return coordinates
+
 
 @register_geometry('toroidal')
 def add_toroidal_geometry_coords(ds, coordinates=None):


### PR DESCRIPTION
Previously the return statement was missing, leading to a bug.