### PR TITLE
Update names of coordinates for 'toroidal' geometry

### DIFF
--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -89,9 +89,9 @@ def _set_default_toroidal_coordinates(coordinates):
         coordinates = {}
 
     # Replace any values that have not been passed in with defaults
-    coordinates['x'] = coordinates.get('x', 'psi')
+    coordinates['x'] = coordinates.get('x', 'psi_poloidal')
     coordinates['y'] = coordinates.get('y', 'theta')
-    coordinates['z'] = coordinates.get('z', 'phi')
+    coordinates['z'] = coordinates.get('z', 'zeta')
 
 
 @register_geometry('toroidal')


### PR DESCRIPTION
Use {`psi_poloidal`, `theta`, `zeta`} instead of {`psi`, `theta`, `phi`} to reduce likelihood of name clashes with plasma variables: `phi` and `psi` are often used for electrostatic and magnetic potentials.

When combined with the recently merged #53, resolves #54.