### PR TITLE
Test geometries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "3.6"
   - "3.7"
 install:
-  - pip install --upgrade vtk # fixes install of mayavi for Python-3.6, which is a dependency of boutdata
   - pip install --upgrade setuptools pip pytest pytest-cov coverage codecov boutdata "xarray!=0.14.0"
   - pip install -r requirements.txt
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
 install:
   - pip install --upgrade vtk # fixes install of mayavi for Python-3.6, which is a dependency of boutdata
-  - pip install --upgrade setuptools pip pytest pytest-cov coverage codecov boutdata
+  - pip install --upgrade setuptools pip pytest pytest-cov coverage codecov boutdata "xarray!=0.14.0"
   - pip install -r requirements.txt
   - pip install -e .
 script:

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -19,7 +19,6 @@ class BoutDatasetAccessor:
         self.data = ds
         self.metadata = ds.attrs.get('metadata')  # None if just grid file
         self.options = ds.attrs.get('options')  # None if no inp file
-        self.grid = ds.attrs.get('grid')  # None if no grid file
 
     def __str__(self):
         """
@@ -34,8 +33,6 @@ class BoutDatasetAccessor:
                "Metadata:\n{}\n".format(styled(self.metadata))
         if self.options:
             text += "Options:\n{}".format(styled(self.options))
-        if self.grid:
-            text += "Grid:\n{}".format(styled(self.grid))
         return text
 
     #def __repr__(self):

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -108,6 +108,16 @@ def add_toroidal_geometry_coords(ds, coordinates=None):
                          "Use the 'coordinates' argument of open_boutdataset to provide "
                          "alternative names".format(bad_names))
 
+    # Get extra geometry information from grid file if it's not in the dump files
+    needed_variables = ['psixy', 'Rxy', 'Zxy']
+    for v in needed_variables:
+        if v not in ds:
+            if ds._grid is None:
+                raise ValueError("Grid file is required to provide %s. Pass the grid "
+                                 "file name as the 'gridfilepath' argument to "
+                                 "open_boutdataset().")
+            ds[v] = ds._grid[v]
+
     # Change names of dimensions to Orthogonal Toroidal ones
     ds = ds.rename(y=coordinates['y'])
 

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -112,11 +112,11 @@ def add_toroidal_geometry_coords(ds, coordinates=None):
     needed_variables = ['psixy', 'Rxy', 'Zxy']
     for v in needed_variables:
         if v not in ds:
-            if ds._grid is None:
+            if ds.bout._grid is None:
                 raise ValueError("Grid file is required to provide %s. Pass the grid "
                                  "file name as the 'gridfilepath' argument to "
                                  "open_boutdataset().")
-            ds[v] = ds._grid[v]
+            ds[v] = ds.bout._grid[v]
 
     # Change names of dimensions to Orthogonal Toroidal ones
     ds = ds.rename(y=coordinates['y'])
@@ -157,11 +157,11 @@ def add_s_alpha_geometry_coords(ds, coordinates=None):
 
     # Add 'hthe' from grid file, needed below for radial coordinate
     if 'hthe' not in ds:
-        if ds._grid is None:
+        if ds.bout._grid is None:
             raise ValueError("Grid file is required to provide %s. Pass the grid "
                              "file name as the 'gridfilepath' argument to "
                              "open_boutdataset().")
-        ds['hthe'] = ds._grid['hthe']
+        ds['hthe'] = ds.bout._grid['hthe']
 
     ds = add_toroidal_geometry_coords(ds, coordinates=coordinates)
 

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -155,6 +155,14 @@ def add_s_alpha_geometry_coords(ds, coordinates=None):
 
     coordinates = _set_default_toroidal_coordinates(coordinates)
 
+    # Add 'hthe' from grid file, needed below for radial coordinate
+    if not 'hthe' in ds:
+        if ds._grid is None:
+            raise ValueError("Grid file is required to provide %s. Pass the grid "
+                             "file name as the 'gridfilepath' argument to "
+                             "open_boutdataset().")
+        ds['hthe'] = ds._grid['hthe']
+
     ds = add_toroidal_geometry_coords(ds, coordinates=coordinates)
 
     # Add 1D radial coordinate
@@ -165,8 +173,5 @@ def add_s_alpha_geometry_coords(ds, coordinates=None):
     ds['r'].attrs['units'] = 'm'
     ds = ds.set_coords('r')
     ds = ds.rename(x='r')
-
-    # Simplify psi to be radially-varying only
-    ds['r'] = ds['r'].isel({coordinates['y']: 0}).squeeze(drop=True)
 
     return ds

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -157,11 +157,14 @@ def add_s_alpha_geometry_coords(ds, coordinates=None):
 
     # Add 'hthe' from grid file, needed below for radial coordinate
     if 'hthe' not in ds:
+        hthe_from_grid = True
         if ds.bout._grid is None:
             raise ValueError("Grid file is required to provide %s. Pass the grid "
                              "file name as the 'gridfilepath' argument to "
                              "open_boutdataset().")
         ds['hthe'] = ds.bout._grid['hthe']
+    else:
+        hthe_from_grid = False
 
     ds = add_toroidal_geometry_coords(ds, coordinates=coordinates)
 
@@ -173,5 +176,9 @@ def add_s_alpha_geometry_coords(ds, coordinates=None):
     ds['r'].attrs['units'] = 'm'
     ds = ds.set_coords('r')
     ds = ds.rename(x='r')
+
+    if hthe_from_grid:
+        # remove hthe because it does not have correct metadata
+        del ds['hthe']
 
     return ds

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -156,7 +156,7 @@ def add_s_alpha_geometry_coords(ds, coordinates=None):
     coordinates = _set_default_toroidal_coordinates(coordinates)
 
     # Add 'hthe' from grid file, needed below for radial coordinate
-    if not 'hthe' in ds:
+    if 'hthe' not in ds:
         if ds._grid is None:
             raise ValueError("Grid file is required to provide %s. Pass the grid "
                              "file name as the 'gridfilepath' argument to "

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -39,7 +39,7 @@ except ValueError:
 
 
 def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
-                     geometry=None, chunks={},
+                     geometry=None, gridfilepath=None, chunks={},
                      keep_xboundaries=True, keep_yboundaries=False,
                      run_name=None, info=True):
     """
@@ -68,6 +68,9 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
         To define a new type of geometry you need to use the
         `register_geometry` decorator. You are encouraged to do this for your
         own BOUT++ physics module, to apply relevant normalisations.
+    gridfilepath : str, optional
+        The path to a grid file, containing any variables needed to apply the geometry
+        specified by the 'geometry' option, which are not contained in the dump files.
     keep_xboundaries : bool, optional
         If true, keep x-direction boundary cells (the cells past the physical
         edges of the grid, where boundary conditions are set); increases the
@@ -126,6 +129,17 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
     if geometry:
         if info:
             print("Applying {} geometry conventions".format(geometry))
+
+        if gridfilepath is not None:
+            print('here in load', ds.attrs)
+            ds.attrs["_grid"] = open_boutdataset(gridfilepath, chunks=chunks,
+                                                 keep_xboundaries=keep_xboundaries,
+                                                 keep_yboundaries=keep_yboundaries,
+                                                 info=info)
+            print('after in load', ds.attrs)
+        else:
+            ds.attrs["_grid"] = None
+
         # Update coordinates to match particular geometry of grid
         ds = geometries.apply_geometry(ds, geometry)
     else:

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -131,12 +131,11 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
             print("Applying {} geometry conventions".format(geometry))
 
         if gridfilepath is not None:
-            ds.attrs["_grid"] = open_boutdataset(gridfilepath, chunks=chunks,
-                                                 keep_xboundaries=keep_xboundaries,
-                                                 keep_yboundaries=keep_yboundaries,
-                                                 info=info)
+            ds.bout._grid = _open_grid(gridfilepath, chunks=chunks,
+                                       keep_xboundaries=keep_xboundaries,
+                                       keep_yboundaries=keep_yboundaries)
         else:
-            ds.attrs["_grid"] = None
+            ds.bout._grid = None
 
         # Update coordinates to match particular geometry of grid
         ds = geometries.apply_geometry(ds, geometry)

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -131,12 +131,10 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
             print("Applying {} geometry conventions".format(geometry))
 
         if gridfilepath is not None:
-            print('here in load', ds.attrs)
             ds.attrs["_grid"] = open_boutdataset(gridfilepath, chunks=chunks,
                                                  keep_xboundaries=keep_xboundaries,
                                                  keep_yboundaries=keep_yboundaries,
                                                  info=info)
-            print('after in load', ds.attrs)
         else:
             ds.attrs["_grid"] = None
 

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -364,7 +364,7 @@ class TestStripMetadata():
 
 
 # TODO also test loading multiple files which have guard cells
-class TestCombineNoTrim:
+class TestOpen:
     def test_single_file(self, tmpdir_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, nxpe=1, nype=1, nt=1)
         actual = open_boutdataset(datapath=path, keep_xboundaries=False)
@@ -418,6 +418,16 @@ class TestCombineNoTrim:
         xrt.assert_equal(actual.load(),
                          expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES,
                                        errors='ignore'))
+
+    def test_toroidal(self, tmpdir_factory, bout_xyt_example_files):
+        path = bout_xyt_example_files(tmpdir_factory, nxpe=3, nype=3, nt=1,
+                                      syn_data_type='stepped')
+        actual = open_boutdataset(datapath=path, geometry='toroidal')
+
+    def test_salpha(self, tmpdir_factory, bout_xyt_example_files):
+        path = bout_xyt_example_files(tmpdir_factory, nxpe=3, nype=3, nt=1,
+                                      syn_data_type='stepped')
+        actual = open_boutdataset(datapath=path, geometry='s-alpha')
 
     @pytest.mark.skip
     def test_combine_along_tx(self):

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -447,11 +447,19 @@ class TestOpen:
         actual = open_boutdataset(datapath=path, geometry='toroidal',
                                   gridfilepath=Path(path).parent.joinpath('grid.nc'))
 
+        # check dataset can be saved
+        save_dir = tmpdir_factory.mktemp('data')
+        actual.bout.save(str(save_dir.join('boutdata.nc')))
+
     def test_salpha(self, tmpdir_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, nxpe=3, nype=3, nt=1,
                                       syn_data_type='stepped', grid='grid')
         actual = open_boutdataset(datapath=path, geometry='s-alpha',
                                   gridfilepath=Path(path).parent.joinpath('grid.nc'))
+
+        # check dataset can be saved
+        save_dir = tmpdir_factory.mktemp('data')
+        actual.bout.save(str(save_dir.join('boutdata.nc')))
 
     @pytest.mark.skip
     def test_combine_along_tx(self):

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -76,7 +76,6 @@ class TestPathHandling:
         with pytest.raises(IOError):
             path = Path(str(files_dir.join('run*/example.*.nc')))
             actual_filepaths = _expand_filepaths(path)
-            print(actual_filepaths)
 
 
 @pytest.fixture()
@@ -189,7 +188,6 @@ def _bout_xyt_example_files(tmpdir_factory, prefix='BOUT.dmp', lengths=(6, 2, 4,
         xsize = lengths[1]*nxpe
         ysize = lengths[2]*nype
         grid_ds = create_bout_grid_ds(xsize=xsize, ysize=ysize, guards=guards)
-        print('check grid_ds',xsize,ysize,grid_ds)
         grid_ds.to_netcdf(str(save_dir.join(grid + ".nc")))
 
     # Return a glob-like path to all files created, which has all file numbers replaced with a single asterix
@@ -348,6 +346,7 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
     ds['t_array'] = DataArray(np.arange(t_length, dtype=float)*10., dims='t')
 
     return ds
+
 
 def create_bout_grid_ds(xsize=2, ysize=4, guards={}):
 


### PR DESCRIPTION
Builds on #55, so merging into `fix-test-against-collect`.

Adds unit tests for loading datasets with 'toroidal' or 's-alpha' geometries. These show the need to be able to pass a grid file to get `psixy`, `Rxy`, `Zxy`, `hthe` variables, which are not needed by BOUT++ so are never loaded or saved to the dump files. Therefore reinstates the option to pass a `gridfilepath`, but now the grid file can be opened with just `open_boutdataset` :tada:

Also includes a work-around to tell Travis to exclude xarray-0.14.0, which fixes the Travis tests.

Resolves #17.