### PR TITLE
Add backwards compatible collect function

### DIFF
--- a/xbout/__init__.py
+++ b/xbout/__init__.py
@@ -1,4 +1,4 @@
-from .load import open_boutdataset
+from .load import open_boutdataset, collect
 
 from . import geometries
 from .geometries import register_geometry, REGISTERED_GEOMETRIES

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -175,6 +175,14 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
     info : bool, optional
         Print information about collect? (default: True)
 
+    Notes
+    ----------
+    strict : This option found in boutdata.collect() is not present in this function
+             it is assumed that the varname given is correct, if variable does not exist
+             the function will fail
+    tind_auto : This option is not required when using _auto_open_mfboutdataset as an
+             automatic failure if datasets are different lengths is included
+
     Returns
     ----------
     ds : numpy.ndarray
@@ -185,6 +193,9 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
 
     ds = _auto_open_mfboutdataset(datapath, keep_xboundaries=xguards,
                                   keep_yboundaries=yguards, info=info)
+
+    if varname not in ds:
+        raise KeyError("No variable, {} was found in {}.".format(varname, datapath))
 
     dims = ['t', 'x', 'y', 'z']
     inds = [tind, xind, yind, zind]

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -231,10 +231,10 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
             selection[dim] = indexer
 
     try:
-         version = ds['BOUT_VERSION']
+        version = ds['BOUT_VERSION']
     except KeyError:
-         # If BOUT Version is not saved in the dataset
-         version = 0
+        # If BOUT Version is not saved in the dataset
+        version = 0
 
     # Subtraction of z-dimensional data occurs in boutdata.collect
     # if BOUT++ version is old - same feature added here

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -244,7 +244,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
     # if BOUT++ version is old - same feature added here
     if (version < 3.5) and ('z' in dims):
         zsize = int(ds['nz']) - 1
-        selection['z'] = slice(zsize)
+        ds = ds.isel(z=slice(zsize))
 
     if selection:
         ds = ds.isel(selection)

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -172,7 +172,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
         Name of the variable
     xind, yind, zind, tind : int, slice or list of int, optional
         Range of X, Y, Z or time indices to collect. Either a single
-        index to collect, a list containing [start, end] (inclusive
+        index to collect, a list containing [start, end, step (optional)] (inclusive
         end), or a slice object (usual python indexing). Default is to
         fetch all indices
     path : str, optional
@@ -220,8 +220,12 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
         if isinstance(ind, int):
             indexer = [ind]
         elif isinstance(ind, list):
-            start, end = ind
-            indexer = slice(start, end)
+            try:
+                start, end, step = ind
+                indexer = slice(start, end, step)
+            except ValueError:
+                start, end = ind
+                indexer = slice(start, end)
         elif ind is not None:
             indexer = ind
         else:

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -193,7 +193,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
 
     for i in range(len(dims)):
 
-        if indexers[i] != None:
+        if indexers[i] not None:
 
             if isinstance(indexers[i], int):
                 selection[dims[i]] = [indexers[i]]

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -186,14 +186,14 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
     ds = _auto_open_mfboutdataset(datapath, keep_xboundaries=xguards,
                                   keep_yboundaries=yguards, info=info)
 
-    dims = ('t', 'x', 'y', 'z')
-    indexers = (tind, xind, yind, zind)
+    dims = ['t', 'x', 'y', 'z']
+    indexers = [tind, xind, yind, zind]
 
     selection = {}
 
     for i in range(len(dims)):
 
-        if indexers[i] not None:
+        if indexers[i] is not None:
 
             if isinstance(indexers[i], int):
                 selection[dims[i]] = [indexers[i]]

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -172,7 +172,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
         Name of the variable
     xind, yind, zind, tind : int, slice or list of int, optional
         Range of X, Y, Z or time indices to collect. Either a single
-        index to collect, a list containing [start, end, step (optional)] (inclusive
+        index to collect, a list containing [start, end, step] or [start, end] (inclusive
         end), or a slice object (usual python indexing). Default is to
         fetch all indices
     path : str, optional
@@ -225,7 +225,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
                 indexer = slice(start, end, step)
             except ValueError:
                 start, end = ind
-                indexer = slice(start, end)
+                indexer = slice(start, end+1)
         elif ind is not None:
             indexer = ind
         else:

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -187,18 +187,21 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
                                   keep_yboundaries=yguards, info=info)
 
     dims = ['t', 'x', 'y', 'z']
-    indexers = [tind, xind, yind, zind]
+    inds = [tind, xind, yind, zind]
 
     selection = {}
 
-    for i in range(len(dims)):
+    for dim, ind in zip(dims, inds):
 
-        if indexers[i] is not None:
+        if isinstance(ind, int):
+            indexer = [ind]
+        elif isinstance(ind, list):
+            start, end = ind
+            indexer = slice(start, end)
+        elif ind is not None:
+            indexer = ind
 
-            if isinstance(indexers[i], int):
-                selection[dims[i]] = [indexers[i]]
-            else:
-                selection[dims[i]] = indexers[i]
+        selection[dim] = indexer
 
     if selection:
         ds = ds.isel(selection)

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -144,6 +144,68 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
     return ds
 
 
+def collect(varname, xind=None, yind=None, zind=None, tind=None,
+            path=".", yguards=False, xguards=True, info=True, prefix="BOUT.dmp"):
+
+    from os.path import join
+
+    """
+
+    Extract the data pertaining to a specified variable in a BOUT++ data set
+
+
+    Parameters
+    ----------
+    varname : str
+        Name of the variable
+    xind, yind, zind, tind : int, slice or list of int, optional
+        Range of X, Y, Z or time indices to collect. Either a single
+        index to collect, a list containing [start, end] (inclusive
+        end), or a slice object (usual python indexing). Default is to
+        fetch all indices
+    path : str, optional
+        Path to data files (default: ".")
+    prefix : str, optional
+        File prefix (default: "BOUT.dmp")
+    yguards : bool, optional
+        Collect Y boundary guard cells? (default: False)
+    xguards : bool, optional
+        Collect X boundary guard cells? (default: True)
+        (Set to True to be consistent with the definition of nx)
+    info : bool, optional
+        Print information about collect? (default: True)
+
+    Returns
+    ----------
+    ds : numpy.ndarray
+
+    """
+
+    datapath = join(path, prefix + "*.nc")
+
+    ds = _auto_open_mfboutdataset(datapath, keep_xboundaries=xguards,
+                                  keep_yboundaries=yguards, info=info)
+
+    dims = ('t', 'x', 'y', 'z')
+    indexers = (tind, xind, yind, zind)
+
+    selection = {}
+
+    for i in range(len(dims)):
+
+        if indexers[i] != None:
+
+            if isinstance(indexers[i], int):
+                selection[dims[i]] = [indexers[i]]
+            else:
+                selection[dims[i]] = indexers[i]
+
+    if selection:
+        ds = ds.isel(selection)
+
+    return ds[varname].values
+
+
 def _is_dump_files(datapath):
     """
     If there is only one file, and it's not got a time dimension, assume it's a

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -172,7 +172,7 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
         Name of the variable
     xind, yind, zind, tind : int, slice or list of int, optional
         Range of X, Y, Z or time indices to collect. Either a single
-        index to collect, a list containing [start, end, step] or [start, end] (inclusive
+        index to collect, a list containing [start, end] (inclusive
         end), or a slice object (usual python indexing). Default is to
         fetch all indices
     path : str, optional
@@ -220,12 +220,8 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
         if isinstance(ind, int):
             indexer = [ind]
         elif isinstance(ind, list):
-            try:
-                start, end, step = ind
-                indexer = slice(start, end, step)
-            except ValueError:
-                start, end = ind
-                indexer = slice(start, end+1)
+            start, end = ind
+            indexer = slice(start, end+1)
         elif ind is not None:
             indexer = ind
         else:

--- a/xbout/tests/test_against_collect.py
+++ b/xbout/tests/test_against_collect.py
@@ -179,18 +179,17 @@ class TestAccuracyAgainstOldCollect:
 
         var = 'n'
         indexers = ["tind", "xind", "yind", "zind"]
-        ind_list = [[0, 4, 2], [0, 4]]
+        ind_arg = [0, 4]
 
         for kwarg in indexers:
-            for ind_arg in ind_list:
-                # Extracting a the first index of each dimension for comparison
-                expected = old_collect(var, path=test_dir, **{kwarg: ind_arg})
+            # Extracting a the first index of each dimension for comparison
+            expected = old_collect(var, path=test_dir, **{kwarg: ind_arg})
 
-                # Test against backwards compatible collect function
-                actual = new_collect(var, path=test_dir, **{kwarg: ind_arg})
+            # Test against backwards compatible collect function
+            actual = new_collect(var, path=test_dir, **{kwarg: ind_arg})
 
-                assert expected.shape == actual.shape
-                npt.assert_equal(actual, expected)
+            assert expected.shape == actual.shape
+            npt.assert_equal(actual, expected)
 
     def test_new_collect_indexing_slice(self, tmpdir_factory):
         # Create temp directory for files

--- a/xbout/tests/test_against_collect.py
+++ b/xbout/tests/test_against_collect.py
@@ -142,6 +142,82 @@ class TestAccuracyAgainstOldCollect:
             actual = new_collect(v, path=test_dir)
             npt.assert_equal(actual, expected)
 
+
+    def test_new_collect_indexing_int(self, tmpdir_factory):
+        # Create temp directory for files
+        test_dir = tmpdir_factory.mktemp("test_data")
+
+        # Generate some test data
+        ds_list, file_list = create_bout_ds_list("BOUT.dmp", nxpe=3, nype=3,
+                                                  syn_data_type="linear")
+        for temp_ds, file_name in zip(ds_list, file_list):
+            temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
+
+        var = 'n'
+        indexers = ["tind", "xind", "yind", "zind"]
+        ind_arg = 0
+
+        for kwarg in indexers:
+            # Extracting a the first index of each dimension for comparison
+            expected = old_collect(var, path=test_dir, **{kwarg:ind_arg})
+
+            # Test against backwards compatible collect function
+            actual = new_collect(var, path=test_dir, **{kwarg:ind_arg})
+
+            assert expected.shape == actual.shape
+            npt.assert_equal(actual, expected)
+
+
+    def test_new_collect_indexing_list(self, tmpdir_factory):
+        # Create temp directory for files
+        test_dir = tmpdir_factory.mktemp("test_data")
+
+        # Generate some test data
+        ds_list, file_list = create_bout_ds_list("BOUT.dmp", nxpe=3, nype=3,
+                                                   syn_data_type="linear")
+        for temp_ds, file_name in zip(ds_list, file_list):
+            temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
+
+        var = 'n'
+        indexers = ["tind", "xind", "yind", "zind"]
+        ind_list = [[0, 4, 2], [0, 4]]
+
+        for kwarg in indexers:
+            for ind_arg in ind_list:
+                # Extracting a the first index of each dimension for comparison
+                expected = old_collect(var, path=test_dir, **{kwarg:ind_arg})
+
+                # Test against backwards compatible collect function
+                actual = new_collect(var, path=test_dir, **{kwarg:ind_arg})
+
+                assert expected.shape == actual.shape
+                npt.assert_equal(actual, expected)
+
+    def test_new_collect_indexing_slice(self, tmpdir_factory):
+        # Create temp directory for files
+        test_dir = tmpdir_factory.mktemp("test_data")
+
+        # Generate some test data
+        ds_list, file_list = create_bout_ds_list("BOUT.dmp", nxpe=3, nype=3,
+                                                    syn_data_type="linear")
+        for temp_ds, file_name in zip(ds_list, file_list):
+            temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
+
+        var = 'n'
+        indexers = ["tind", "xind", "yind", "zind"]
+        ind_list = [slice(0,4,2), slice(0,4)]
+
+        for kwarg in indexers:
+            for ind_arg in ind_list:
+                # Extracting a the first index of each dimension for comparison
+                expected = old_collect(var, path=test_dir, **{kwarg:ind_arg})
+
+                # Test against backwards compatible collect function
+                actual = new_collect(var, path=test_dir, **{kwarg:ind_arg})
+
+                assert expected.shape == actual.shape
+                npt.assert_equal(actual, expected)
+
 @pytest.mark.skip
 class test_speed_against_old_collect:
     ...

--- a/xbout/tests/test_against_collect.py
+++ b/xbout/tests/test_against_collect.py
@@ -1,8 +1,7 @@
 import pytest
 import numpy.testing as npt
 
-from xbout import open_boutdataset
-from xbout.load import collect as new_collect
+from xbout import open_boutdataset, collect as new_collect
 
 from .test_load import create_bout_ds, create_bout_ds_list, METADATA_VARS
 

--- a/xbout/tests/test_against_collect.py
+++ b/xbout/tests/test_against_collect.py
@@ -149,7 +149,8 @@ class TestAccuracyAgainstOldCollect:
 
         # Generate some test data
         ds_list, file_list = create_bout_ds_list("BOUT.dmp", nxpe=3, nype=3,
-                                                  syn_data_type="linear")
+                                                 syn_data_type="linear")
+
         for temp_ds, file_name in zip(ds_list, file_list):
             temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
 
@@ -159,10 +160,10 @@ class TestAccuracyAgainstOldCollect:
 
         for kwarg in indexers:
             # Extracting a the first index of each dimension for comparison
-            expected = old_collect(var, path=test_dir, **{kwarg:ind_arg})
+            expected = old_collect(var, path=test_dir, **{kwarg: ind_arg})
 
             # Test against backwards compatible collect function
-            actual = new_collect(var, path=test_dir, **{kwarg:ind_arg})
+            actual = new_collect(var, path=test_dir, **{kwarg: ind_arg})
 
             assert expected.shape == actual.shape
             npt.assert_equal(actual, expected)
@@ -174,7 +175,7 @@ class TestAccuracyAgainstOldCollect:
 
         # Generate some test data
         ds_list, file_list = create_bout_ds_list("BOUT.dmp", nxpe=3, nype=3,
-                                                   syn_data_type="linear")
+                                                 syn_data_type="linear")
         for temp_ds, file_name in zip(ds_list, file_list):
             temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
 
@@ -185,10 +186,10 @@ class TestAccuracyAgainstOldCollect:
         for kwarg in indexers:
             for ind_arg in ind_list:
                 # Extracting a the first index of each dimension for comparison
-                expected = old_collect(var, path=test_dir, **{kwarg:ind_arg})
+                expected = old_collect(var, path=test_dir, **{kwarg: ind_arg})
 
                 # Test against backwards compatible collect function
-                actual = new_collect(var, path=test_dir, **{kwarg:ind_arg})
+                actual = new_collect(var, path=test_dir, **{kwarg: ind_arg})
 
                 assert expected.shape == actual.shape
                 npt.assert_equal(actual, expected)
@@ -199,7 +200,8 @@ class TestAccuracyAgainstOldCollect:
 
         # Generate some test data
         ds_list, file_list = create_bout_ds_list("BOUT.dmp", nxpe=3, nype=3,
-                                                    syn_data_type="linear")
+                                                 syn_data_type="linear")
+
         for temp_ds, file_name in zip(ds_list, file_list):
             temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
 
@@ -210,10 +212,10 @@ class TestAccuracyAgainstOldCollect:
         for kwarg in indexers:
             for ind_arg in ind_list:
                 # Extracting a the first index of each dimension for comparison
-                expected = old_collect(var, path=test_dir, **{kwarg:ind_arg})
+                expected = old_collect(var, path=test_dir, **{kwarg: ind_arg})
 
                 # Test against backwards compatible collect function
-                actual = new_collect(var, path=test_dir, **{kwarg:ind_arg})
+                actual = new_collect(var, path=test_dir, **{kwarg: ind_arg})
 
                 assert expected.shape == actual.shape
                 npt.assert_equal(actual, expected)

--- a/xbout/tests/test_against_collect.py
+++ b/xbout/tests/test_against_collect.py
@@ -2,41 +2,60 @@ import pytest
 
 import numpy.testing as npt
 
-from xbout.load import _auto_open_mfboutdataset
+from xbout import open_boutdataset
+from .test_load import create_bout_ds_list
+
+from xbout.load import collect as new_collect
+from boutdata import collect as old_collect
+
+
+@pytest.fixture
+def create_test_file(tmpdir_factory):
+    def _foo(nxpe, nype):
+        # Create temp dir for test files
+        save_dir = tmpdir_factory.mktemp("test_data")
+
+        # Generate test data
+        ds_list, file_list = create_bout_ds_list("data", nxpe=nxpe, nype=nype,
+                                             syn_data_type="linear")
+
+        for ds, file_name in zip(ds_list, file_list):
+            ds.to_netcdf(str(save_dir.join(str(file_name))))
+
+        return save_dir
+    return _foo
 
 
 class TestAccuracyAgainstOldCollect:
-    @pytest.mark.skip
-    def test_single_file(self):
-        from boutdata import collect
+    # @pytest.mark.skip
+    def test_single_file(self, create_test_file):
+
+        save_dir = create_test_file(nxpe=1,nype=1)
+
         var = 'n'
-        expected = collect(var, path='./tests/data/dump_files/single',
-                           prefix='equilibrium', xguards=False)
+        expected = old_collect(var, path=save_dir, prefix='data', xguards=False)
 
-        ds, metadata = _auto_open_mfboutdataset('./tests/data/dump_files/single/equilibrium.nc')
-        print(ds)
-        actual = ds[var].values
-
-        assert expected.shape == actual.shape
-        npt.assert_equal(actual, expected)
-
-    @pytest.mark.skip
-    def test_multiple_files_along_x(self):
-        from boutdata import collect
-        var = 'n'
-        expected = collect(var, path='./tests/data/dump_files/',
-                           prefix='BOUT.dmp', xguards=False)
-
-        ds, metadata = _auto_open_mfboutdataset('./tests/data/dump_files/BOUT.dmp.*.nc')
-        actual = ds[var].values
+        actual = new_collect(var, path=save_dir, prefix='data', xguards=False)
 
         assert expected.shape == actual.shape
         npt.assert_equal(actual, expected)
 
 
-    @pytest.mark.skip
-    def test_multiple_files_along_x(self):
-        ...
+   # @pytest.mark.skip
+    def test_multiple_files_along_x(self, create_test_file):
+
+        save_dir = create_test_file(nxpe=3, nype=3)
+
+        var = 'n'
+        expected = old_collect(var, path=save_dir, prefix='data', xguards=False)
+
+        actual = new_collect(var, path=save_dir, prefix='data', xguards=False)
+
+        print(expected.shape, actual.shape)
+
+        assert expected.shape == actual.shape
+        npt.assert_equal(actual, expected)
+
 
     @pytest.mark.skip
     def test_metadata(self):

--- a/xbout/tests/test_against_collect.py
+++ b/xbout/tests/test_against_collect.py
@@ -142,7 +142,6 @@ class TestAccuracyAgainstOldCollect:
             actual = new_collect(v, path=test_dir)
             npt.assert_equal(actual, expected)
 
-
     def test_new_collect_indexing_int(self, tmpdir_factory):
         # Create temp directory for files
         test_dir = tmpdir_factory.mktemp("test_data")
@@ -167,7 +166,6 @@ class TestAccuracyAgainstOldCollect:
 
             assert expected.shape == actual.shape
             npt.assert_equal(actual, expected)
-
 
     def test_new_collect_indexing_list(self, tmpdir_factory):
         # Create temp directory for files
@@ -207,7 +205,7 @@ class TestAccuracyAgainstOldCollect:
 
         var = 'n'
         indexers = ["tind", "xind", "yind", "zind"]
-        ind_list = [slice(0,4,2), slice(0,4)]
+        ind_list = [slice(0, 4, 2), slice(0, 4)]
 
         for kwarg in indexers:
             for ind_arg in ind_list:


### PR DESCRIPTION
This pull request adds a new function, collect(), to xBOUT which aims to replicate the behaviour of [https://github.com/boutproject/boutdata/blob/master/boutdata/collect.py](url).

Feature suggested in #9 

