### PR TITLE
Increase matplotlib version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 xarray >= 0.12.2
 dask[array] >= 1.0.0
 natsort >= 5.5.0
-matplotlib >= 3.0.3
+matplotlib >= 3.1.1
 animatplot >= 0.3
 netcdf4 >= 1.4.0
 Pillow >= 6.1.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'xarray>=v0.12.2',
         'dask[array]>=1.0.0',
         'natsort>=5.5.0',
-        'matplotlib>=3.0.3',
+        'matplotlib>=3.1.1',
         'animatplot>=0.3',
         'netcdf4>=1.4.0',
         'Pillow>=6.1.0'


### PR DESCRIPTION
Increase the required version of matplotlib to avoid bug with looping .gif files using PillowWriter, as mentioned in #60 

Fixes #60