### PR TITLE
Use tmpdir_factory in test_open_grid_extra_dims

### DIFF
--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -42,12 +42,13 @@ class TestOpenGrid:
         assert_equal(result, open_dataset(example_grid))
         result.close()
 
-    def test_open_grid_extra_dims(self, create_example_grid_file):
+    def test_open_grid_extra_dims(self, create_example_grid_file, tmpdir_factory):
         example_grid = open_dataset(create_example_grid_file)
 
         new_var = DataArray(name='new', data=[[1, 2], [8, 9]], dims=['x', 'w'])
-        # TODO this should be handled by pytest's tmpdir factory too
-        dodgy_grid_path = 'dodgy_grid.nc'
+
+        dodgy_grid_directory = tmpdir_factory.mktemp("dodgy_grid")
+        dodgy_grid_path = dodgy_grid_directory.join('dodgy_grid.nc')
         merge([example_grid, new_var]).to_netcdf(dodgy_grid_path,
                                                  engine='netcdf4')
 

--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -26,10 +26,7 @@ def create_example_grid_file(tmpdir_factory):
     save_dir = tmpdir_factory.mktemp("griddata")
 
     # Save
-    # Convert to str because tmpdir_factory returns a 'LocalPath' object, while xarray's
-    # to_netcdf method expects a str, and 'Path' is compatible with 'LocalPath' in
-    # Python-3.6 but not in Python-3.5
-    filepath = str(save_dir + '/grid.nc')
+    filepath = save_dir.join('grid.nc')
     grid.to_netcdf(filepath, engine='netcdf4')
 
     return Path(filepath)


### PR DESCRIPTION
Makes sure that the test's netcdf file is cleaned up when the test finishes.

Also remove a workaround in `test_grid.create_example_grid_file()` for `Path`/`LocalPath` incompatibility which is fixed now that we require Python>=3.6.