### PR TITLE
Make plot_targets independent of dimension names

### DIFF
--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -271,8 +271,8 @@ def plot_targets(da, ax, hatching=True):
 
     j11, j12, j21, j22, ix1, ix2, nin, nx, ny, y_boundary_guards = _get_seps(da)
 
-    R = da.coords['R'].transpose('x', 'theta')
-    Z = da.coords['Z'].transpose('x', 'theta')
+    R = da.coords['R'].values
+    Z = da.coords['Z'].values
 
     if j22 + 1 < ny:
         # lower PFR exists


### PR DESCRIPTION
Same as change made recently to plot_separatrices:
Previously there were R.transpose('x', 'theta') and Z.transpose('x', 'theta'), but the transpose actually did not do anything, because it should have been e.g. R.transpose(['x', 'theta']) to transpose the dimensions, but worked correctly because no transpose was needed.