### PR TITLE
Fix plotting to allow for core-only grids

### DIFF
--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import xarray as xr
 
-from .utils import _decompose_regions, plot_separatrices, plot_targets
+from .utils import _decompose_regions, _is_core_only, plot_separatrices, plot_targets
 
 
 def regions(da, ax=None, **kwargs):
@@ -170,6 +170,10 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
         fig.colorbar(artists[0], ax=ax, extend=extend)
 
     ax.set_title(da.name)
+
+    if _is_core_only(da):
+        separatrix = False
+        targets = False
 
     if separatrix:
         plot_separatrices(da, ax)

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -147,6 +147,12 @@ def _decompose_regions(da):
 
     return regions
 
+def _is_core_only(da):
+
+    _, _, _, _, ix1, ix2, _, nx, _, _ = _get_seps(da)
+
+    return (ix1 >= nx and ix2 >= nx)
+
 
 def plot_separatrices(da, ax):
     """Plot separatrices"""

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -147,6 +147,7 @@ def _decompose_regions(da):
 
     return regions
 
+
 def _is_core_only(da):
 
     _, _, _, _, ix1, ix2, _, nx, _, _ = _get_seps(da)


### PR DESCRIPTION
Adds function that checks whether `ixseps1` and `ixseps2` are >= `nx`, suggesting a core only grid with no separatrix or target info to be plotted.