### PR TITLE
Test and update minimum supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: python
 python:
   - "3.6"
   - "3.7"
+env:
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0"
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.12.2 dask==1.0.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.3 netcdf4==1.4.0 Pillow==6.1.0" # test with oldest supported version of packages
 install:
-  - pip install --upgrade setuptools pip pytest pytest-cov coverage codecov boutdata "xarray!=0.14.0"
+  - pip install --upgrade ${PIP_PACKAGES}
   - pip install -r requirements.txt
   - pip install -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
 env:
   - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0"
-  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.12.2 dask==1.0.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.3 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.12.2 dask==1.0.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.0 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages
 install:
   - pip install --upgrade ${PIP_PACKAGES}
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
 env:
   - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0"
-  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.12.2 dask==1.0.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.3 netcdf4==1.4.0 Pillow==6.1.0" # test with oldest supported version of packages
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.12.2 dask==1.0.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.3 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages
 install:
   - pip install --upgrade ${PIP_PACKAGES}
   - pip install -r requirements.txt

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Requirements
   - ``dask[array] >= 1.0.0``
   - ``natsort >= 5.5.0``
   - ``matplotlib >= 2.2``
-  - ``animatplot >= 0.3``
+  - ``animatplot >= 0.4.0``
   - ``netcdf4 >= 1.4.0``
 - All dependencies can be installed by running:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ xarray >= 0.12.2
 dask[array] >= 1.0.0
 natsort >= 5.5.0
 matplotlib >= 3.1.1
-animatplot >= 0.3
+animatplot >= 0.4.0
 netcdf4 >= 1.4.0
 Pillow >= 6.1.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'dask[array]>=1.0.0',
         'natsort>=5.5.0',
         'matplotlib>=3.1.1',
-        'animatplot>=0.3',
+        'animatplot>=0.4.0',
         'netcdf4>=1.4.0',
         'Pillow>=6.1.0'
     ],

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -127,8 +127,7 @@ def animate_line(data, animate_over='t', animate=True,
     """
     Plots a line plot which is animated with time.
 
-    Currently only supports 1D+1 data, which it plots with xarray's
-    wrapping of matplotlib's plot.
+    Currently only supports 1D+1 data, which it plots with animatplot's Line animation.
 
     Parameters
     ----------


### PR DESCRIPTION
I happened to notice that `xarray` have Travis tests with the minimum supported versions of all their dependencies. This seems like a very good idea, so this PR adds a new case to Travis with all dependencies set to their minimum supported versions. An exception is the netCDF4 python package, because we claim to support 1.4.0, but 1.4.0 and 1.4.1 fail to pip-install on Travis, so I've used 1.4.2.

Also update the minimum required version of animatplot from 0.3 to 0.4.0 because animate_line requires 0.4.0, as there was a change in the animatplot.blocks.Line API.