### PR TITLE
Replace is with == for string comparison

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -71,7 +71,7 @@ class BoutDatasetAccessor:
         else:
             to_save = self.data[variables]
 
-        if savepath is './boutdata.nc':
+        if savepath == './boutdata.nc':
             print("Will save data into the current working directory, named as"
                   " boutdata_[var].nc")
         if savepath is None:


### PR DESCRIPTION
This comparison works for small strings due to caching/interning of short strings. https://bugs.python.org/issue34850