### PR TITLE
drop_variables argument to open_boutdataset

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -40,7 +40,7 @@ except ValueError:
 def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
                      geometry=None, gridfilepath=None, chunks={},
                      keep_xboundaries=True, keep_yboundaries=False,
-                     run_name=None, info=True):
+                     run_name=None, info=True, drop_variables=None):
     """
     Load a dataset from a set of BOUT output files, including the input options
     file. Can also load from a grid file.
@@ -85,6 +85,9 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
         Useful if you are going to open multiple simulations and compare the
         results.
     info : bool, optional
+    drop_variables : sequence, optional
+        Drop variables in this list before merging. Allows user to ignore variables from
+        a particular physics model that are not consistent between processors.
 
     Returns
     -------
@@ -98,7 +101,8 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
         # Gather pointers to all numerical data from BOUT++ output files
         ds = _auto_open_mfboutdataset(datapath=datapath, chunks=chunks,
                                       keep_xboundaries=keep_xboundaries,
-                                      keep_yboundaries=keep_yboundaries)
+                                      keep_yboundaries=keep_yboundaries,
+                                      drop_variables=drop_variables)
     else:
         # Its a grid file
         ds = _open_grid(datapath, chunks=chunks,
@@ -266,7 +270,8 @@ def _is_dump_files(datapath):
 
 
 def _auto_open_mfboutdataset(datapath, chunks={}, info=True,
-                             keep_xboundaries=False, keep_yboundaries=False):
+                             keep_xboundaries=False, keep_yboundaries=False,
+                             drop_variables=None):
     filepaths, filetype = _expand_filepaths(datapath)
 
     # Open just one file to read processor splitting
@@ -277,7 +282,7 @@ def _auto_open_mfboutdataset(datapath, chunks={}, info=True,
     _preprocess = partial(_trim, guards={'x': mxg, 'y': myg},
                           keep_boundaries={'x': keep_xboundaries,
                                            'y': keep_yboundaries},
-                          nxpe=nxpe, nype=nype)
+                          nxpe=nxpe, nype=nype, drop_variables=drop_variables)
 
     ds = xr.open_mfdataset(paths_grid, concat_dim=concat_dims, combine='nested',
                            data_vars='minimal', preprocess=_preprocess, engine=filetype,
@@ -424,7 +429,7 @@ def _arrange_for_concatenation(filepaths, nxpe=1, nype=1):
     return paths_grid, concat_dims
 
 
-def _trim(ds, *, guards, keep_boundaries, nxpe, nype):
+def _trim(ds, *, guards, keep_boundaries, nxpe, nype, drop_variables):
     """
     Trims all guard (and optionally boundary) cells off a single dataset read from a
     single BOUT dump file, to prepare for concatenation.
@@ -461,6 +466,9 @@ def _trim(ds, *, guards, keep_boundaries, nxpe, nype):
                            guards)
         selection[dim] = slice(lower, upper)
     trimmed_ds = ds.isel(**selection)
+
+    if drop_variables is not None:
+        trimmed_ds = trimmed_ds.drop(drop_variables, errors='ignore')
 
     # Ignore FieldPerps for now
     for name in trimmed_ds:

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -482,6 +482,15 @@ class TestOpen:
         save_dir = tmpdir_factory.mktemp('data')
         actual.bout.save(str(save_dir.join('boutdata.nc')))
 
+    def test_drop_vars(self, tmpdir_factory, bout_xyt_example_files):
+        path = bout_xyt_example_files(tmpdir_factory, nxpe=4, nype=1, nt=1,
+                                      syn_data_type='stepped')
+        ds = open_boutdataset(datapath=path, keep_xboundaries=False,
+                              drop_variables=['T'])
+
+        assert 'T' not in ds.keys()
+        assert 'n' in ds.keys()
+
     @pytest.mark.skip
     def test_combine_along_tx(self):
         ...
@@ -596,7 +605,7 @@ class TestTrim:
         # Manually add filename - encoding normally added by xr.open_dataset
         ds.encoding['source'] = 'folder0/BOUT.dmp.0.nc'
         actual = _trim(ds, guards={}, keep_boundaries={}, nxpe=1,
-                       nype=1)
+                       nype=1, drop_variables=None)
         xrt.assert_equal(actual, ds)
 
     def test_trim_guards(self):
@@ -604,7 +613,7 @@ class TestTrim:
         # Manually add filename - encoding normally added by xr.open_dataset
         ds.encoding['source'] = 'folder0/BOUT.dmp.0.nc'
         actual = _trim(ds, guards={'time': 2}, keep_boundaries={},
-                       nxpe=1, nype=1)
+                       nxpe=1, nype=1, drop_variables=None)
         selection = {'time': slice(2, -2)}
         expected = ds.isel(**selection)
         xrt.assert_equal(expected, actual)
@@ -727,7 +736,8 @@ class TestTrim:
         ds['jyseps2_1'] = 8
         ds['jyseps1_2'] = 8
 
-        actual = _trim(ds, guards={'x': 2}, keep_boundaries={'x': True}, nxpe=1, nype=1)
+        actual = _trim(ds, guards={'x': 2}, keep_boundaries={'x': True}, nxpe=1, nype=1,
+                       drop_variables=None)
         expected = ds  # Should be unchanged
         xrt.assert_equal(expected, actual)
 
@@ -741,7 +751,8 @@ class TestTrim:
         ds['jyseps2_1'] = 8
         ds['jyseps1_2'] = 8
 
-        actual = _trim(ds, guards={'y': 2}, keep_boundaries={'y': True}, nxpe=1, nype=1)
+        actual = _trim(ds, guards={'y': 2}, keep_boundaries={'y': True}, nxpe=1, nype=1,
+                       drop_variables=None)
         expected = ds  # Should be unchanged
         xrt.assert_equal(expected, actual)
 
@@ -762,7 +773,8 @@ class TestTrim:
         ds['ny_inner'] = 8
         ds['MYSUB'] = 4
 
-        actual = _trim(ds, guards={'y': 2}, keep_boundaries={'y': True}, nxpe=1, nype=4)
+        actual = _trim(ds, guards={'y': 2}, keep_boundaries={'y': True}, nxpe=1, nype=4,
+                       drop_variables=None)
         expected = ds  # Should be unchanged
         if not lower:
             expected = expected.isel(y=slice(2, None, None))
@@ -780,7 +792,8 @@ class TestTrim:
 
         for v in _BOUT_PER_PROC_VARIABLES:
             ds[v] = 42.
-        ds = _trim(ds, guards={}, keep_boundaries={}, nxpe=1, nype=1)
+        ds = _trim(ds, guards={}, keep_boundaries={}, nxpe=1, nype=1,
+                   drop_variables=None)
 
         expected = create_test_data(0)
         xrt.assert_equal(ds, expected)


### PR DESCRIPTION
Allow user to ignore model-specific variables that may not be consistent between files. Ideally the user should not have to do this by hand, so a model-specific function, e.g. `open_stormdataset` would handle the list of possibly-inconsistent variables for that model.