### PR TITLE
Allow more general wildcard patterns in _expand_wildcards

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -313,7 +313,7 @@ def _expand_wildcards(path):
     """Return list of filepaths matching wildcard"""
 
     # Find first parent directory which does not contain a wildcard
-    base_dir = next(parent for parent in path.parents if '*' not in str(parent))
+    base_dir = Path(path.root)
 
     # Find path relative to parent
     search_pattern = str(path.relative_to(base_dir))

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -70,6 +70,25 @@ class TestPathHandling:
 
         assert actual_filepaths == expected_filepaths
 
+    @pytest.mark.parametrize("ii, jj", [(1, 1), (1, 4), (3, 1), (5, 3), (1, 12),
+                                        (3, 111)])
+    def test_glob_expansion_brackets(self, tmpdir, ii, jj):
+        files_dir = tmpdir.mkdir("data")
+        filepaths = []
+        for i in range(ii):
+            example_run_dir = files_dir.mkdir('run' + str(i))
+            for j in range(jj):
+                example_file = example_run_dir.join('example.' + str(j) + '.nc')
+                example_file.write("content")
+                filepaths.append(Path(str(example_file)))
+        expected_filepaths = natsorted(filepaths,
+                                       key=lambda filepath: str(filepath))
+
+        path = Path(str(files_dir.join('run[1-9]/example.*.nc')))
+        actual_filepaths = _expand_wildcards(path)
+
+        assert actual_filepaths == expected_filepaths[jj:]
+
     def test_no_files(self, tmpdir):
         files_dir = tmpdir.mkdir("data")
 


### PR DESCRIPTION
Glob the whole relative path, so any wildcard, not just '*' is supported.

Allows doing something like
```
ds = open_boutdataset('run[2-5]/BOUT.dmp.*.nc')
```
to open a subset of the run directories.