### PR TITLE
Document all optional arguments in docstrings of animation methods/functions

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -58,12 +58,14 @@ class BoutDataArrayAccessor:
         y : str, optional
             Dimension to use on the y axis, default is None - then use the second spatial
             dimension of the data
-        sep_pos : int, optional
-            Radial position at which to plot the separatrix
+        animate : bool, optional
+            If set to false, do not create the animation, just return the block or blocks
         fps : int, optional
             Frames per second of resulting gif
-        save_as : str, optional
-            Filename to give to the resulting gif
+        save_as : True or str, optional
+            If str is passed, save the animation as save_as+'.gif'.
+            If True is passed, save the animation with a default name,
+            '<variable name>_over_<animate_over>.gif'
         ax : matplotlib.pyplot.axes object, optional
             Axis on which to plot the gif
         poloidal_plot : bool, optional
@@ -77,7 +79,7 @@ class BoutDataArrayAccessor:
             passed.
         kwargs : dict, optional
             Additional keyword arguments are passed on to the plotting function
-            (e.g. imshow for 2D plots).
+            (animatplot.blocks.Pcolormesh).
         """
 
         data = self.data
@@ -115,6 +117,32 @@ class BoutDataArrayAccessor:
 
     def animate1D(self, animate_over='t', x='x', y='y', animate=True,
                   fps=10, save_as=None, sep_pos=None, ax=None, **kwargs):
+        """
+        Plots a line plot which is animated over time over the specified coordinate.
+
+        Currently only supports 1D+1 data, which it plots with animatplot's wrapping of
+        matplotlib's plot.
+
+        Parameters
+        ----------
+        animate_over : str, optional
+            Dimension over which to animate
+        fps : int, optional
+            Frames per second of resulting gif
+        save_as : True or str, optional
+            If str is passed, save the animation as save_as+'.gif'.
+            If True is passed, save the animation with a default name,
+            '<variable name>_over_<animate_over>.gif'
+        sep_pos : int, optional
+            Radial position at which to plot the separatrix
+        ax : Axes, optional
+            A matplotlib axes instance to plot to. If None, create a new
+            figure and axes, and plot to that
+        kwargs : dict, optional
+            Additional keyword arguments are passed on to the plotting function
+            (animatplot.blocks.Line).
+        """
+
         data = self.data
         variable = data.name
         n_dims = len(data.dims)

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -115,8 +115,8 @@ class BoutDataArrayAccessor:
                 "Data passed has an unsupported number of dimensions "
                 "({})".format(str(n_dims)))
 
-    def animate1D(self, animate_over='t', x='x', y='y', animate=True,
-                  fps=10, save_as=None, sep_pos=None, ax=None, **kwargs):
+    def animate1D(self, animate_over='t', animate=True, fps=10, save_as=None,
+                  sep_pos=None, ax=None, **kwargs):
         """
         Plots a line plot which is animated over time over the specified coordinate.
 

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -23,23 +23,39 @@ def animate_poloidal(da, *, ax=None, cax=None, animate_over='t', separatrix=True
     ax : Axes, optional
         A matplotlib axes instance to plot to. If None, create a new
         figure and axes, and plot to that
+    cax : Axes, optional
+        Matplotlib axes instance where the colorbar will be plotted. If None, the default
+        position created by matplotlab.figure.Figure.colorbar() will be used.
     separatrix : bool, optional
         Add dashed lines showing separatrices
     targets : bool, optional
         Draw solid lines at the target surfaces
     add_limiter_hatching : bool, optional
         Draw hatched areas at the targets
+    cmap : matplotlib.colors.Colormap instance, optional
+        Colors to use for the plot
+    vmin : float, optional
+        Minimum value for the color scale
+    vmax : float, optional
+        Maximum value for the color scale
+    animate : bool, optional
+        If set to false, do not create the animation, just return the blocks
     save_as : True or str, optional
         If str is passed, save the animation as save_as+'.gif'.
         If True is passed, save the animation with a default name,
         '<variable name>_over_<animate_over>.gif'
+    fps : float, optional
+        Frame rate for the animation
+    controls : bool, optional
+        If False, do not add the timeline and pause button to the animation
     **kwargs : optional
-        Additional arguments are passed on to method
+        Additional arguments are passed on to the animation method
+        animatplot.blocks.Pcolormesh
 
-    ###Returns
-    ###-------
-    ###artists
-    ###    List of the contourf instances
+    Returns
+    -------
+    blocks
+        List of animatplot.blocks.Pcolormesh instances
     """
 
     # TODO generalise this
@@ -144,21 +160,33 @@ def animate_pcolormesh(data, animate_over='t', x=None, y=None, animate=True,
     y : str, optional
         Dimension to use on the y axis, default is None - then use the second spatial
         dimension of the data
+    animate : bool, optional
+        If set to false, do not create the animation, just return the block
     vmin : float, optional
         Minimum value to use for colorbar. Default is to use minimum value of
         data across whole timeseries.
     vmax : float, optional
         Maximum value to use for colorbar. Default is to use maximum value of
         data across whole timeseries.
+    vsymmetric : bool, optional
+        If set to true, make the color-scale symmetric
+    fps : int, optional
+        Frames per second of resulting gif
     save_as : True or str, optional
         If str is passed, save the animation as save_as+'.gif'.
         If True is passed, save the animation with a default name,
         '<variable name>_over_<animate_over>.gif'
-    fps : int, optional
-        Frames per second of resulting gif
+    ax : Axes, optional
+        A matplotlib axes instance to plot to. If None, create a new
+        figure and axes, and plot to that
+    cax : Axes, optional
+        Matplotlib axes instance where the colorbar will be plotted. If None, the default
+        position created by matplotlab.figure.Figure.colorbar() will be used.
+    controls : bool, optional
+        If False, do not add the timeline and pause button to the animation
     kwargs : dict, optional
-        Additional keyword arguments are passed on to the plotting function
-        (e.g. imshow for 2D plots).
+        Additional keyword arguments are passed on to the animation function
+        animatplot.blocks.Pcolormesh
     """
 
     variable = data.name
@@ -254,23 +282,30 @@ def animate_line(data, animate_over='t', animate=True,
     data : xarray.DataArray
     animate_over : str, optional
         Dimension over which to animate
+    animate : bool, optional
+        If set to false, do not create the animation, just return the block
     vmin : float, optional
         Minimum value to use for colorbar. Default is to use minimum value of
         data across whole timeseries.
     vmax : float, optional
         Maximum value to use for colorbar. Default is to use maximum value of
         data across whole timeseries.
-    sep_pos : int, optional
-        Radial position at which to plot the separatrix
+    fps : int, optional
+        Frames per second of resulting gif
     save_as : True or str, optional
         If str is passed, save the animation as save_as+'.gif'.
         If True is passed, save the animation with a default name,
         '<variable name>_over_<animate_over>.gif'
-    fps : int, optional
-        Frames per second of resulting gif
+    sep_pos : int, optional
+        Radial position at which to plot the separatrix
+    ax : Axes, optional
+        A matplotlib axes instance to plot to. If None, create a new
+        figure and axes, and plot to that
+    controls : bool, optional
+        If False, do not add the timeline and pause button to the animation
     kwargs : dict, optional
         Additional keyword arguments are passed on to the plotting function
-        (e.g. imshow for 2D plots).
+        animatplot.blocks.Line
     """
 
     variable = data.name

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -29,6 +29,10 @@ def animate_poloidal(da, *, ax=None, cax=None, animate_over='t', separatrix=True
         Draw solid lines at the target surfaces
     add_limiter_hatching : bool, optional
         Draw hatched areas at the targets
+    save_as : True or str, optional
+        If str is passed, save the animation as save_as+'.gif'.
+        If True is passed, save the animation with a default name,
+        '<variable name>_over_<animate_over>.gif'
     **kwargs : optional
         Additional arguments are passed on to method
 
@@ -111,9 +115,10 @@ def animate_poloidal(da, *, ax=None, cax=None, animate_over='t', separatrix=True
         if controls:
             anim.controls(timeline_slider_args={'text': animate_over})
 
-        if not save_as:
-            save_as = "{}_over_{}".format(da.name, animate_over)
-        anim.save(save_as + '.gif', writer=PillowWriter(fps=fps))
+        if save_as is not None:
+            if save_as is True:
+                save_as = "{}_over_{}".format(da.name, animate_over)
+            anim.save(save_as + '.gif', writer=PillowWriter(fps=fps))
 
     return blocks
 
@@ -145,8 +150,10 @@ def animate_pcolormesh(data, animate_over='t', x=None, y=None, animate=True,
     vmax : float, optional
         Maximum value to use for colorbar. Default is to use maximum value of
         data across whole timeseries.
-    save_as: str, optional
-        Filename to give to the resulting gif
+    save_as : True or str, optional
+        If str is passed, save the animation as save_as+'.gif'.
+        If True is passed, save the animation with a default name,
+        '<variable name>_over_<animate_over>.gif'
     fps : int, optional
         Frames per second of resulting gif
     kwargs : dict, optional
@@ -226,9 +233,10 @@ def animate_pcolormesh(data, animate_over='t', x=None, y=None, animate=True,
         if controls:
             anim.controls(timeline_slider_args={'text': animate_over})
 
-        if not save_as:
-            save_as = "{}_over_{}".format(variable, animate_over)
-        anim.save(save_as + '.gif', writer=PillowWriter(fps=fps))
+        if save_as is not None:
+            if save_as is True:
+                save_as = "{}_over_{}".format(variable, animate_over)
+            anim.save(save_as + '.gif', writer=PillowWriter(fps=fps))
 
     return pcolormesh_block
 
@@ -254,8 +262,10 @@ def animate_line(data, animate_over='t', animate=True,
         data across whole timeseries.
     sep_pos : int, optional
         Radial position at which to plot the separatrix
-    save_as: str, optional
-        Filename to give to the resulting gif
+    save_as : True or str, optional
+        If str is passed, save the animation as save_as+'.gif'.
+        If True is passed, save the animation with a default name,
+        '<variable name>_over_<animate_over>.gif'
     fps : int, optional
         Frames per second of resulting gif
     kwargs : dict, optional
@@ -308,8 +318,9 @@ def animate_line(data, animate_over='t', animate=True,
         if controls:
             anim.controls(timeline_slider_args={'text': animate_over})
 
-        if not save_as:
-            save_as = "{}_over_{}".format(variable, animate_over)
-        anim.save(save_as + '.gif', writer=PillowWriter(fps=fps))
+        if save_as is not None:
+            if save_as is True:
+                save_as = "{}_over_{}".format(variable, animate_over)
+            anim.save(save_as + '.gif', writer=PillowWriter(fps=fps))
 
     return line_block


### PR DESCRIPTION
Also remove unused `x` and `y` arguments to `animate1D()`.