### PR TITLE
More robust handling of 'chunks' when opening grid files

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -570,7 +570,7 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2):
     grid = xr.open_dataset(gridfilepath, engine=_check_filetype(gridfilepath))
     if 'z' in chunks and 'z' not in grid.dims:
         del chunks['z']
-    grid.chunk(chunks)
+    grid = grid.chunk(chunks)
 
     # TODO find out what 'yup_xsplit' etc are in the doublenull storm file John gave me
     # For now drop any variables with extra dimensions

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -561,16 +561,16 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2):
     # Passing 'chunks' with dimensions that are not present in the dataset causes an
     # error. A gridfile will be missing 't' and may be missing 'z' dimensions that dump
     # files have, so we must remove them from 'chunks'.
-    unrecognised_chunk_dims = list(set(chunks.keys()) - set(acceptable_dims))
-    chunks = copy(chunks)
+    grid_chunks = copy(chunks)
+    unrecognised_chunk_dims = list(set(grid_chunks.keys()) - set(acceptable_dims))
     for dim in unrecognised_chunk_dims:
-        del chunks[dim]
+        del grid_chunks[dim]
 
     gridfilepath = Path(datapath)
     grid = xr.open_dataset(gridfilepath, engine=_check_filetype(gridfilepath))
-    if 'z' in chunks and 'z' not in grid.dims:
-        del chunks['z']
-    grid = grid.chunk(chunks)
+    if 'z' in grid_chunks and 'z' not in grid.dims:
+        del grid_chunks['z']
+    grid = grid.chunk(grid_chunks)
 
     # TODO find out what 'yup_xsplit' etc are in the doublenull storm file John gave me
     # For now drop any variables with extra dimensions

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -567,18 +567,10 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2):
         del chunks[dim]
 
     gridfilepath = Path(datapath)
-    try:
-        grid = xr.open_dataset(gridfilepath, engine=_check_filetype(gridfilepath),
-                               chunks=chunks)
-    except ValueError as e:
-        if str(e) == "some chunks keys are not dimensions on this object: ['z']":
-            # If chunks contained 'z' but the gridfile did not, still want to open, so
-            # remove 'z' from the local chunks, and continue
-            del chunks['z']
-            grid = xr.open_dataset(gridfilepath, engine=_check_filetype(gridfilepath),
-                                   chunks=chunks)
-        else:
-            raise
+    grid = xr.open_dataset(gridfilepath, engine=_check_filetype(gridfilepath))
+    if 'z' in chunks and 'z' not in grid.dims:
+        del chunks['z']
+    grid.chunk(chunks)
 
     # TODO find out what 'yup_xsplit' etc are in the doublenull storm file John gave me
     # For now drop any variables with extra dimensions

--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -70,3 +70,16 @@ class TestOpenGrid:
         # clean up
         del REGISTERED_GEOMETRIES["Schwarzschild"]
         result.close()
+
+    def test_open_grid_chunks(self, create_example_grid_file):
+        example_grid = create_example_grid_file
+        result = open_boutdataset(datapath=example_grid, chunks={'x': 4, 'y': 5})
+        assert_equal(result, open_dataset(example_grid))
+        result.close()
+
+    def test_open_grid_chunks_not_in_grid(self, create_example_grid_file):
+        example_grid = create_example_grid_file
+        result = open_boutdataset(datapath=example_grid,
+                                  chunks={'anonexistantdimension': 5})
+        assert_equal(result, open_dataset(example_grid))
+        result.close()


### PR DESCRIPTION
Grid files don't have a 't' dimension, and usually don't have a `'z'` dimension, so if either are passed in the `chunks` argument, previously there would have been an error. This PR checks the dimensions in
`chunks` passed to a grid file are only `'x'`, `'y'`, or `'z'`, and drops `'z'` if it is passed and is not present in the grid file.

To handle the case when `'z'` is passed in `chunks` but is not present in the grid file, I'm catching the exception and then checking the message, which is not ideal - suggestions for a cleaner method welcome - but `'z'` should not often be passed in `chunks` (chunking in `z` would not be optimal since it's the last dimension in the array, and already contiguous both on disk and in memory) so this should not be critical.