### PR TITLE
Update layout of plots in animate_list

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -170,7 +170,7 @@ class BoutDatasetAccessor:
     def animate_list(self, variables, animate_over='t', save_as=None, show=False, fps=10,
                      nrows=None, ncols=None, poloidal_plot=False, subplots_adjust=None,
                      vmin=None, vmax=None, logscale=None, titles=None, aspect='equal',
-                     controls=True, tight_layout=False, **kwargs):
+                     controls=True, tight_layout=True, **kwargs):
         """
         Parameters
         ----------
@@ -216,7 +216,7 @@ class BoutDatasetAccessor:
         controls : bool, optional
             If set to False, do not show the time-slider or pause button
         tight_layout : bool, optional
-            If set to True, call tight_layout() on the figure
+            If set to False, don't call tight_layout() on the figure.
         **kwargs : dict, optional
             Additional keyword arguments are passed on to each animation function
         """
@@ -316,11 +316,12 @@ class BoutDatasetAccessor:
 
         timeline = amp.Timeline(np.arange(v.sizes[animate_over]), fps=fps)
         anim = amp.Animation(blocks, timeline)
-        if controls:
-            anim.controls(timeline_slider_args={'text': animate_over})
 
         if tight_layout:
             fig.tight_layout()
+
+        if controls:
+            anim.controls(timeline_slider_args={'text': animate_over})
 
         if save_as is not None:
             anim.save(save_as + '.gif', writer=PillowWriter(fps=fps))

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -170,7 +170,7 @@ class BoutDatasetAccessor:
     def animate_list(self, variables, animate_over='t', save_as=None, show=False, fps=10,
                      nrows=None, ncols=None, poloidal_plot=False, subplots_adjust=None,
                      vmin=None, vmax=None, logscale=None, titles=None, aspect='equal',
-                     tight_layout=False, **kwargs):
+                     controls=True, tight_layout=False, **kwargs):
         """
         Parameters
         ----------
@@ -213,6 +213,8 @@ class BoutDatasetAccessor:
             a certain variable
         aspect : str or None, or sequence of str or None, optional
             Argument to set_aspect() for each plot
+        controls : bool, optional
+            If set to False, do not show the time-slider or pause button
         tight_layout : bool, optional
             If set to True, call tight_layout() on the figure
         **kwargs : dict, optional
@@ -314,7 +316,8 @@ class BoutDatasetAccessor:
 
         timeline = amp.Timeline(np.arange(v.sizes[animate_over]), fps=fps)
         anim = amp.Animation(blocks, timeline)
-        anim.controls(timeline_slider_args={'text': animate_over})
+        if controls:
+            anim.controls(timeline_slider_args={'text': animate_over})
 
         if tight_layout:
             fig.tight_layout()

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -245,7 +245,7 @@ class BoutDatasetAccessor:
             fig.subplots_adjust(**subplots_adjust)
 
         def _expand_list_arg(arg, arg_name):
-            if isinstance(arg, collections.Sequence):
+            if isinstance(arg, collections.Sequence) and not isinstance(arg, str):
                 if len(arg) != len(variables):
                     raise ValueError('if %s is a sequence, it must have the same '
                                      'number of elements as "variables"' % arg_name)

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -215,8 +215,10 @@ class BoutDatasetAccessor:
             Argument to set_aspect() for each plot
         controls : bool, optional
             If set to False, do not show the time-slider or pause button
-        tight_layout : bool, optional
+        tight_layout : bool or dict, optional
             If set to False, don't call tight_layout() on the figure.
+            If a dict is passed, the dict entries are passed as arguments to
+            tight_layout()
         **kwargs : dict, optional
             Additional keyword arguments are passed on to each animation function
         """
@@ -318,7 +320,9 @@ class BoutDatasetAccessor:
         anim = amp.Animation(blocks, timeline)
 
         if tight_layout:
-            fig.tight_layout()
+            if not isinstance(tight_layout, dict):
+                tight_layout = {}
+            fig.tight_layout(**tight_layout)
 
         if controls:
             anim.controls(timeline_slider_args={'text': animate_over})

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -1,6 +1,7 @@
 import collections
 from pprint import pformat as prettyformat
 from functools import partial
+import warnings
 
 from xarray import register_dataset_accessor, save_mfdataset, merge
 import animatplot as amp
@@ -320,6 +321,10 @@ class BoutDatasetAccessor:
         anim = amp.Animation(blocks, timeline)
 
         if tight_layout:
+            if subplots_adjust is not None:
+                warnings.warn('tight_layout argument to animate_list() is True, but '
+                              'subplots_adjust argument is not None. subplots_adjust '
+                              'is being ignored.')
             if not isinstance(tight_layout, dict):
                 tight_layout = {}
             fig.tight_layout(**tight_layout)

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -169,7 +169,8 @@ class BoutDatasetAccessor:
 
     def animate_list(self, variables, animate_over='t', save_as=None, show=False, fps=10,
                      nrows=None, ncols=None, poloidal_plot=False, subplots_adjust=None,
-                     vmin=None, vmax=None, logscale=None, titles=None, **kwargs):
+                     vmin=None, vmax=None, logscale=None, titles=None, aspect='equal',
+                     **kwargs):
         """
         Parameters
         ----------
@@ -210,6 +211,8 @@ class BoutDatasetAccessor:
         titles : sequence of str or None, optional
             Custom titles for each plot. Pass None in the sequence to use the default for
             a certain variable
+        aspect : str or None, or sequence of str or None, optional
+            Argument to set_aspect() for each plot
         **kwargs : dict, optional
             Additional keyword arguments are passed on to each animation function
         """
@@ -252,18 +255,19 @@ class BoutDatasetAccessor:
         vmax = _expand_list_arg(vmax, 'vmax')
         logscale = _expand_list_arg(logscale, 'logscale')
         titles = _expand_list_arg(titles, 'titles')
+        aspect = _expand_list_arg(aspect, 'aspect')
 
         blocks = []
         for subplot_args in zip(variables, axes, poloidal_plot, vmin, vmax,
-                                logscale, titles):
+                                logscale, titles, aspect):
 
             (v, ax, this_poloidal_plot, this_vmin, this_vmax, this_logscale,
-             this_title) = subplot_args
+             this_title, this_aspect) = subplot_args
 
             divider = make_axes_locatable(ax)
             cax = divider.append_axes("right", size="5%", pad=0.1)
 
-            ax.set_aspect("equal")
+            ax.set_aspect(this_aspect)
 
             if isinstance(v, str):
                 v = self.data[v]
@@ -288,7 +292,8 @@ class BoutDatasetAccessor:
                     var_blocks = animate_poloidal(data, ax=ax, cax=cax,
                                                   animate_over=animate_over,
                                                   animate=False, vmin=this_vmin,
-                                                  vmax=this_vmax, norm=norm, **kwargs)
+                                                  vmax=this_vmax, norm=norm,
+                                                  aspect=this_aspect, **kwargs)
                     for block in var_blocks:
                         blocks.append(block)
                 else:

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -170,7 +170,7 @@ class BoutDatasetAccessor:
     def animate_list(self, variables, animate_over='t', save_as=None, show=False, fps=10,
                      nrows=None, ncols=None, poloidal_plot=False, subplots_adjust=None,
                      vmin=None, vmax=None, logscale=None, titles=None, aspect='equal',
-                     **kwargs):
+                     tight_layout=False, **kwargs):
         """
         Parameters
         ----------
@@ -213,6 +213,8 @@ class BoutDatasetAccessor:
             a certain variable
         aspect : str or None, or sequence of str or None, optional
             Argument to set_aspect() for each plot
+        tight_layout : bool, optional
+            If set to True, call tight_layout() on the figure
         **kwargs : dict, optional
             Additional keyword arguments are passed on to each animation function
         """
@@ -314,7 +316,8 @@ class BoutDatasetAccessor:
         anim = amp.Animation(blocks, timeline)
         anim.controls(timeline_slider_args={'text': animate_over})
 
-        fig.tight_layout()
+        if tight_layout:
+            fig.tight_layout()
 
         if save_as is not None:
             anim.save(save_as + '.gif', writer=PillowWriter(fps=fps))

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -11,7 +11,7 @@ from matplotlib.animation import PillowWriter
 def animate_poloidal(da, *, ax=None, cax=None, animate_over='t', separatrix=True,
                      targets=True, add_limiter_hatching=True, cmap=None, vmin=None,
                      vmax=None, animate=True, save_as=None, fps=10, controls=True,
-                     **kwargs):
+                     aspect='equal', **kwargs):
     """
     Make a 2D plot in R-Z coordinates using animatplotlib's Pcolormesh, taking into
     account branch cuts (X-points).
@@ -48,6 +48,8 @@ def animate_poloidal(da, *, ax=None, cax=None, animate_over='t', separatrix=True
         Frame rate for the animation
     controls : bool, optional
         If False, do not add the timeline and pause button to the animation
+    aspect : str or None, optional
+        Argument to set_aspect()
     **kwargs : optional
         Additional arguments are passed on to the animation method
         animatplot.blocks.Pcolormesh
@@ -96,7 +98,7 @@ def animate_poloidal(da, *, ax=None, cax=None, animate_over='t', separatrix=True
     cmap = sm.get_cmap()
     fig.colorbar(sm, ax=ax, cax=cax)
 
-    ax.set_aspect('equal')
+    ax.set_aspect(aspect)
 
     regions = _decompose_regions(da)
 


### PR DESCRIPTION
Make aspect ratio setting user-settable.

Make `tight_layout()` optional, and default to `False`, because `tight_layout()` sometimes makes plots overlap.

Check for `str` explicitly in `_expand_list_arg`, because we do not want to treat a `str` argument like a `list`.