### PR TITLE
Replacement Options File Parser

### DIFF
--- a/xbout/__init__.py
+++ b/xbout/__init__.py
@@ -1,6 +1,6 @@
 from .load import open_boutdataset, collect
 
-from .options import BoutOptionsFile
+from .options import OptionsFile
 
 from . import geometries
 from .geometries import register_geometry, REGISTERED_GEOMETRIES

--- a/xbout/__init__.py
+++ b/xbout/__init__.py
@@ -1,6 +1,6 @@
 from .load import open_boutdataset, collect
 
-from .options import OptionsFile, evaluation
+from .options import OptionsFile
 
 from . import geometries
 from .geometries import register_geometry, REGISTERED_GEOMETRIES

--- a/xbout/__init__.py
+++ b/xbout/__init__.py
@@ -1,5 +1,7 @@
 from .load import open_boutdataset, collect
 
+from .options import BoutOptions
+
 from . import geometries
 from .geometries import register_geometry, REGISTERED_GEOMETRIES
 

--- a/xbout/__init__.py
+++ b/xbout/__init__.py
@@ -1,6 +1,6 @@
 from .load import open_boutdataset, collect
 
-from .options import BoutOptions
+from .options import BoutOptionsFile
 
 from . import geometries
 from .geometries import register_geometry, REGISTERED_GEOMETRIES

--- a/xbout/__init__.py
+++ b/xbout/__init__.py
@@ -1,6 +1,6 @@
 from .load import open_boutdataset, collect
 
-from .options import OptionsFile
+from .options import OptionsFile, evaluation
 
 from . import geometries
 from .geometries import register_geometry, REGISTERED_GEOMETRIES

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -14,6 +14,8 @@ from dask.diagnostics import ProgressBar
 
 from .plotting.animate import animate_poloidal, animate_pcolormesh, animate_line
 from .plotting.utils import _create_norm
+
+
 @register_dataset_accessor('bout')
 class BoutDatasetAccessor:
     """

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -1,36 +1,493 @@
-from configparser import ConfigParser
 from pathlib import Path
-from pprint import PrettyPrinter
+import os
+import re
+
+import numpy
 
 
-class BoutOptionsParser(ConfigParser):
-    def __init__(self):
-        super().__init__(self,
-                         delimiters=('=',),
-                         comment_prefixes=('#',),
-                         inline_comment_prefixes=('#',),
-                         empty_lines_in_values=False)
+# These are imported to be used by 'eval' in
+# BoutOptions.evaluate_scalar() and BoutOptionsFile.evaluate().
+# Change the names to match those used by C++/BOUT++
+from numpy import (pi, sin, cos, tan, arccos as acos, arcsin as asin,
+                   arctan as atan, arctan2 as atan2, sinh, cosh, tanh,
+                   arcsinh as asinh, arccosh as acosh, arctanh as atanh,
+                   exp, log, log10, power as pow, sqrt, ceil, floor,
+                   round, abs)
 
 
-class BoutOptions(BoutOptionsParser):
-    def __init__(self, filepath):
-        super().__init__()
+class BoutOptions:
+    """This class represents a tree structure. Each node (BoutOptions
+    object) can have several sub-nodes (sections), and several
+    key-value pairs.
 
-        # Initialise options by reading file
-        # Insert section header on 1st line to avoid MissingSectionHeaderError
-        with open(filepath, 'r') as original:
-            modified = "[top]\n" + original.read()
-            self.read_string(modified)
-        self.filepath = Path(filepath)
+    Parameters
+    ----------
+    name : str, optional
+        Name of the root section (default: "root")
+    parent : BoutOptions, optional
+        A parent BoutOptions object (default: None)
 
-    def to_flat_dict(self):
-        return {section: self.items(section) for section in self.sections()}
+    Examples
+    --------
+
+    >>> optRoot = BoutOptions()  # Create a root
+
+    Specify value of a key in a section "test"
+    If the section does not exist then it is created
+
+    >>> optRoot.getSection("test")["key"] = 4
+
+    Get the value of a key in a section "test"
+    If the section does not exist then a KeyError is raised
+
+    >>> print(optRoot["test"]["key"])
+    4
+
+    To pretty print the options
+
+    >>> print(optRoot)
+    root
+     |- test
+     |   |- key = 4
+
+    """
+
+    def __init__(self, name="root", parent=None):
+        self._sections = {}
+        self._keys = {}
+        self._name = name
+        self._parent = parent
+
+    def get_section(self, name):
+        """
+        Return a section object. If the section does not exist then it is
+        created.
+
+        Parameters
+        ----------
+        name : str
+            Name of the section to get/create
+
+        Returns
+        -------
+        BoutOptions
+            A new section with the original object as the parent
+        """
+        name = name.lower()
+
+        if name in self._sections:
+            return self._sections[name]
+        else:
+            newsection = BoutOptions(name, self)
+            self._sections[name] = newsection
+            return newsection
+
+    def getSection(self, name):
+        """
+        Return a section object. If the section does not exist then it is
+        created
+
+        (non-PEP8 compliant alias for get_section, for backwards compatibility)
+
+        Parameters
+        ----------
+        name : str
+            Name of the section to get/create
+
+        Returns
+        -------
+        BoutOptions
+            A new section with the original object as the parent
+
+        """
+        return self.get_section(name)
+
+    def __getitem__(self, key):
+        """
+        First check if it's a section, then a value
+        """
+        key = key.lower()
+        if key in self._sections:
+            return self._sections[key]
+
+        if key not in self._keys:
+            raise KeyError(f"Key {key} not in section {self.path()}")
+        return self._keys[key]
+
+    def __setitem__(self, key, value):
+        """
+        Set a key
+        """
+        if len(key) == 0:
+            return
+        self._keys[key.lower()] = value
+
+    def path(self):
+        """Returns the path of this section, joining together names of
+        parents
+
+        """
+
+        if self._parent:
+            return self._parent.path() + ":" + self._name
+        return self._name
+
+    def keys(self):
+        """Returns all keys, including sections and values
+
+        """
+        return list(self._sections) + list(self._keys)
+
+    def sections(self):
+        """Return a list of sub-sections
+
+        """
+        return self._sections.keys()
+
+    def values(self):
+        """Return a list of values
+
+        """
+        return self._keys.keys()
+
+    def as_dict(self):
+        """Return a nested dictionary of all the options.
+
+        """
+        dicttree = {name:self[name] for name in self.values()}
+        dicttree.update({name:self[name].as_dict() for name in self.sections()})
+        return dicttree
+
+    def __len__(self):
+        return len(self._sections) + len(self._keys)
+
+    def __iter__(self):
+        """Iterates over all keys. First values, then sections
+
+        """
+        for k in self._keys:
+            yield k
+        for s in self._sections:
+            yield s
+
+    def __str__(self, indent=""):
+        """Print a pretty version of the options tree
+
+        """
+        text = self._name + "\n"
+
+        for k in self._keys:
+            text += indent + " |- " + k + " = " + str(self._keys[k]) + "\n"
+
+        for s in self._sections:
+            text += indent + " |- " + self._sections[s].__str__(indent+" |  ")
+        return text
+
+    def evaluate_scalar(self, name):
+        """
+        Evaluate (recursively) scalar expressions
+        """
+        expression = self._substitute_expressions(name)
+
+        # replace ^ with ** so that Python evaluates exponentiation
+        expression = expression.replace("^", "**")
+
+        return eval(expression)
+
+    def _substitute_expressions(self, name):
+        expression = str(self[name]).lower()
+        expression = self._evaluate_section(expression, "")
+        parent = self._parent
+        while parent is not None:
+            sectionname = parent._name
+            if sectionname is "root":
+                sectionname = ""
+            expression = parent._evaluate_section(expression, sectionname)
+            parent = parent._parent
+
+        return expression
+
+    def _evaluate_section(self, expression, nested_sectionname):
+        # pass a nested section name so that we can traverse the options tree
+        # rooted at our own level and each level above us so that we can use
+        # relatively qualified variable names, e.g. if we are in section
+        # 'foo:bar:baz' then a variable 'x' from section 'bar' could be called
+        # 'bar:x' (found traversing the tree starting from 'bar') or
+        # 'foo:bar:x' (found when traversing tree starting from 'foo').
+        for var in self.values():
+            if nested_sectionname is not "":
+                nested_name = nested_sectionname + ":" + var
+            else:
+                nested_name = var
+            if re.search(r"(?<!:)\b"+re.escape(nested_name.lower())+r"\b", expression.lower()):
+                # match nested_name only if not preceded by colon (which indicates more nesting)
+                expression = re.sub(r"(?<!:)\b" + re.escape(nested_name.lower()) + r"\b",
+                                    "(" + self._substitute_expressions(var) + ")",
+                                    expression)
+
+        for subsection in self.sections():
+            if nested_sectionname is not "":
+                nested_name = nested_sectionname + ":" + subsection
+            else:
+                nested_name = subsection
+            expression = self.getSection(subsection)._evaluate_section(expression, nested_name)
+
+        return expression
+
+    def write(self, filename=None, overwrite=False):
+        """ Write to BOUT++ options file
+
+        This method will throw an error rather than overwriting an existing
+        file unless the overwrite argument is set to true.
+        Note, no comments from the original input file are transferred to the
+        new one.
+
+        Parameters
+        ----------
+        filename : str
+            Path of the file to write
+            (defaults to path of the file that was read in)
+        overwrite : bool
+            If False then throw an exception if 'filename' already exists.
+            Otherwise, just overwrite without asking.
+            (default False)
+        """
+        if filename is None:
+            filename = self.filename
+
+        if not overwrite and os.path.exists(filename):
+            raise ValueError("Not overwriting existing file, cannot write "
+                             f"output to {filename}")
+
+        def write_section(basename, opts, f):
+            if basename:
+                f.write("["+basename+"]\n")
+            for key, value in opts._keys.items():
+                f.write(key+" = "+str(value)+"\n")
+            for section in opts.sections():
+                section_name = basename+":"+section if basename else section
+                write_section(section_name, opts[section], f)
+
+        with open(filename, "w") as f:
+            write_section("", self, f)
+
+
+class BoutOptionsFile(BoutOptions):
+    """Parses a BOUT.inp configuration file, producing a tree of
+    BoutOptions.
+
+    Slight differences from ConfigParser, including allowing values
+    before the first section header, and supporting nested section headers.
+    Nesting uses the syntax [header:subheader].
+
+    Parameters
+    ----------
+    filename : str, optional
+        Path to file to read
+    name : str, optional
+        Name of root section (default: "root")
+    gridfilename : str, optional
+        If present, path to gridfile from which to read grid sizes (nx, ny, nz)
+    nx, ny : int, optional
+        - Specify sizes of grid, used when evaluating option strings
+        - Cannot be given if gridfilename is specified
+        - Must both be given if either is
+        - If neither gridfilename nor nx, ny are given then will try to
+          find nx, ny from (in order) the 'mesh' section of options,
+          outputfiles in the same directory is the input file, or the grid
+          file specified in the options file (used as a path relative to
+          the current directory)
+    nz : int, optional
+        Use this value for nz when evaluating option expressions, if given.
+        Overrides values found from input file, output files or grid files
+
+    Examples
+    --------
+
+    >>> opts = BoutOptionsFile("BOUT.inp")
+    >>> print(opts)   # Print all options in a tree
+    root
+    |- nout = 100
+    |- timestep = 2
+    ...
+
+    >>> opts["All"]["scale"] # Value "scale" in section "All"
+    1.0
+
+    """
+
+    def __init__(self, filename="BOUT.inp", name="root",
+                 gridfilename=None, nx=None, ny=None, nz=None):
+        super().__init__(self, name)
+
+        # Open the file
+        self.filepath = Path(filename)
+        with open(self.filepath, "r") as f:
+            self._read_file(f)
+
+        # TODO
+        #self.nx, self.ny, self.nz = self._read_grid(gridfilename, nx, ny, nz)
+
+    # TODO needs to be changed: DataFile -> Dataset
+    def _read_grid(self, gridfilename=None, nx=None, ny=None, nz=None):
+        try:
+            # define arrays of x, y, z to be used for substitutions
+            gridfile = None
+            nzfromfile = None
+            if gridfilename:
+                if nx is not None or ny is not None:
+                    raise ValueError("nx or ny given as inputs even though "
+                                     "gridfilename was given explicitly, "
+                                     "don't know which parameters to choose")
+                with DataFile(gridfilename) as gridfile:
+                    self.nx = float(gridfile["nx"])
+                    self.ny = float(gridfile["ny"])
+                    try:
+                        nzfromfile = gridfile["MZ"]
+                    except KeyError:
+                        pass
+            elif nx or ny:
+                if nx is None:
+                    raise ValueError("nx not specified. If either nx or ny are given, then both must be.")
+                if ny is None:
+                    raise ValueError("ny not specified. If either nx or ny are given, then both must be.")
+                self.nx = nx
+                self.ny = ny
+            else:
+                try:
+                    self.nx = self["mesh"].evaluate_scalar("nx")
+                    self.ny = self["mesh"].evaluate_scalar("ny")
+                except KeyError:
+                    try:
+                        # get nx, ny, nz from output files
+                        from boutdata.collect import findFiles
+                        file_list = findFiles(path=os.path.dirname(), prefix="BOUT.dmp")
+                        with DataFile(file_list[0]) as f:
+                            self.nx = f["nx"]
+                            self.ny = f["ny"]
+                            nzfromfile = f["MZ"]
+                    except (IOError, KeyError):
+                        try:
+                            gridfilename = self["mesh"]["file"]
+                        except KeyError:
+                            gridfilename = self["grid"]
+                        with DataFile(gridfilename) as gridfile:
+                            self.nx = float(gridfile["nx"])
+                            self.ny = float(gridfile["ny"])
+                            try:
+                                nzfromfile = float(gridfile["MZ"])
+                            except KeyError:
+                                pass
+            if nz is not None:
+                self.nz = nz
+            else:
+                try:
+                    self.nz = self["mesh"].evaluate_scalar("nz")
+                except KeyError:
+                    try:
+                        self.nz = self.evaluate_scalar("mz")
+                    except KeyError:
+                        if nzfromfile is not None:
+                            self.nz = nzfromfile
+            mxg = self._keys.get("MXG", 2)
+            myg = self._keys.get("MYG", 2)
+
+            # make self.x, self.y, self.z three dimensional now so
+            # that expressions broadcast together properly.
+            self.x = numpy.linspace((0.5 - mxg)/(self.nx - 2*mxg),
+                                    1. - (0.5 - mxg)/(self.nx - 2*mxg),
+                                    self.nx)[:, numpy.newaxis, numpy.newaxis]
+            self.y = 2.*numpy.pi*numpy.linspace((0.5 - myg)/self.ny,
+                                                1.-(0.5 - myg)/self.ny,
+                                                self.ny + 2*myg)[numpy.newaxis, :, numpy.newaxis]
+            self.z = 2.*numpy.pi*numpy.linspace(0.5/self.nz,
+                                                1.-0.5/self.nz,
+                                                self.nz)[numpy.newaxis, numpy.newaxis, :]
+        except Exception as msg:
+            raise BaseException("While building x, y, z coordinate arrays, an "
+                                f"exception occured: {str(msg)}\n"
+                                "Evaluating non-scalar options not available")
+
+    def _read_file(self, f):
+        # Go through each line in the file
+        section = self  # Start with root section
+        for linenr, line in enumerate(f.readlines()):
+            # First remove comments, either # or ;
+            startpos = line.find("#")
+            if startpos != -1:
+                line = line[:startpos]
+            startpos = line.find(";")
+            if startpos != -1:
+                line = line[:startpos]
+
+            # Check section headers
+            startpos = line.find("[")
+            endpos = line.find("]")
+            if startpos != -1:
+                # A section heading
+                if endpos == -1:
+                    raise SyntaxError("Missing ']' on line %d" % (linenr,))
+                line = line[(startpos + 1):endpos].strip()
+
+                section = self
+                while True:
+                    scorepos = line.find(":")
+                    if scorepos == -1:
+                        break
+                    sectionname = line[0:scorepos]
+                    line = line[(scorepos + 1):]
+                    section = section.getSection(sectionname)
+                section = section.getSection(line)
+            else:
+                # A key=value pair
+
+                eqpos = line.find("=")
+                if eqpos == -1:
+                    # No '=', so just set to true
+                    section[line.strip()] = True
+                else:
+                    value = line[(eqpos + 1):].strip()
+                    try:
+                        # Try to convert to an integer
+                        value = int(value)
+                    except ValueError:
+                        try:
+                            # Try to convert to float
+                            value = float(value)
+                        except ValueError:
+                            # Leave as a string
+                            pass
+
+                    section[line[:eqpos].strip()] = value
 
     def __repr__(self):
-        return f"BoutOptions('{self.filepath}')"
+        # TODO Add grid-related options to this
+        return f"BoutOptionsFile('{self.filepath}')"
 
-    def __str__(self):
-        # TODO overload PrettyPrinter.isrecursive() to print nested dicts
-        contents = PrettyPrinter().pformat(self.to_flat_dict())
-        return f"Bout options file at '{self.filepath}':\n" \
-               f"{contents}"
+    def evaluate(self, name):
+        """Evaluate (recursively) expressions
+
+        Sections and subsections must be given as part of 'name',
+        separated by colons
+
+        Parameters
+        ----------
+        name : str
+            Name of variable to evaluate, including sections and
+            subsections
+
+        """
+        section = self
+        split_name = name.split(":")
+        for subsection in split_name[:-1]:
+            section = section.getSection(subsection)
+        expression = section._substitute_expressions(split_name[-1])
+
+        # replace ^ with ** so that Python evaluates exponentiation
+        expression = expression.replace("^", "**")
+
+        # substitute for x, y and z coordinates
+        for coord in ["x", "y", "z"]:
+            expression = re.sub(r"\b"+coord.lower()+r"\b", "self."+coord, expression)
+
+        return eval(expression)

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -1,0 +1,35 @@
+from configparser import ConfigParser
+from pathlib import Path
+from pprint import PrettyPrinter
+
+
+class BoutOptionsParser(ConfigParser):
+    def __init__(self):
+        super().__init__(self,
+                         delimiters=('=',),
+                         comment_prefixes=('#',),
+                         inline_comment_prefixes=('#',),
+                         empty_lines_in_values=False)
+
+
+class BoutOptions(BoutOptionsParser):
+    def __init__(self, filepath):
+        super().__init__()
+
+        # Initialise options by reading file
+        absfilepaths = self.read(filepath)
+        if len(absfilepaths) == 0:
+            raise FileNotFoundError(f"No file found at {Path(filepath)}")
+        self.filepath = Path(absfilepaths[0])
+
+    def to_flat_dict(self):
+        return {section: self.items(section) for section in self.sections()}
+
+    def __repr__(self):
+        return f"BoutOptions('{self.filepath}')"
+
+    def __str__(self):
+        # TODO overload PrettyPrinter.isrecursive() to print nested dicts
+        contents = PrettyPrinter().pformat(self.to_flat_dict())
+        return f"Bout options file at '{self.filepath}':\n" \
+               f"{contents}"

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -74,14 +74,15 @@ class Section(UserDict):
         if keep_comments or isinstance(line, Section):
             return line
         else:
-            # any comment will be discarded
-            value, comment, = line.split(COMMENT_DELIM)
-            # TODO remove whitespace?
+            # any comment will be discarded, along with any trailing whitespace
+            value, *comment = line.split(COMMENT_DELIM)
+            value = value.rstrip()
 
             if evaluate:
+                # value = self._evaluate(value)
                 raise NotImplementedError
-            else:
-                return value
+
+            return value
 
     def __setitem__(self, key, value):
         self.set(key, value)
@@ -139,7 +140,6 @@ class Section(UserDict):
                 file.write(line)
 
     # TODO .sections(), repr?
-
 
 
 class OptionsTree(Section):

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -10,35 +10,23 @@ from numpy import (pi, sin, cos, tan, arccos as acos, arcsin as asin,
                    exp, log, log10, power as pow, sqrt, ceil, floor,
                    round, abs)
 
+# TODO file reader
+# TODO substitution of keys within strings
+# TODO Sanitise some of the weirder things BOUT's option parser does:
+#  - Detect escaped arithmetic symbols (+-*/^), dot (.), or brackets ((){}[]) in option names
+#  - Detect escaping through backquotes in option names (`2ndvalue`)
+#  - Evaluate numletter as num*letter (and numbracket as num*bracket)
+#  - Substitute unicode representation of pi
+#  - Ensure option names don't contain ':' or '='
+#  - Check if all expressions are rounded to nearest integer?!
 # TODO ability to read from/write to nested dictionary
+
 
 SECTION_DELIM = ':'
 COMMENT_DELIM = ['#', ';']
 INDENT_STR = '|-- '
 BOOLEAN_STATES = {'true': True, 'on': True,
                   'false': False, 'off': False}
-
-
-def evaluation(value):
-    """
-
-
-    Parameters
-    ----------
-    value : str
-
-    """
-
-
-    # TODO substitution of other keys
-
-    if '^' in value:
-        value = value.replace('^', '**')
-
-    if value.lower() in BOOLEAN_STATES:
-        return BOOLEAN_STATES[value.lower()]
-    else:
-        return eval(value)
 
 
 class Section(UserDict):
@@ -107,7 +95,7 @@ class Section(UserDict):
             value = line.rstrip()
 
             if evaluate:
-                return evaluation(value)
+                return self.evaluate(value)
             else:
                 return value
 
@@ -206,6 +194,30 @@ class Section(UserDict):
     def __repr__(self):
         return f"Section(name='{self.name}', parent='{self.parent}', " \
                f"data={self.data})"
+
+    # TODO could this be a class method, or static method?
+    def evaluate(self, value, substitute=True):
+        """
+        Evaluates the string using eval, as it would when read in BOUT++.
+
+        Parameters
+        ----------
+        value : str
+        substitute : bool (default: True)
+
+        """
+
+        # TODO substitution of other keys
+        #if substitute:
+        #    value = self._substitute_keys_within(value)
+
+        if value.lower() in BOOLEAN_STATES:
+            # Treat booleans separately to cover lowercase 'true' etc.
+            return BOOLEAN_STATES[value.lower()]
+        else:
+            if '^' in value:
+                value = value.replace('^', '**')
+            return eval(value)
 
 
 class OptionsTree(Section):
@@ -330,4 +342,4 @@ class OptionsFile(OptionsTree):
 
     def __repr__(self):
         # TODO Add grid-related options
-        return f"BoutOptionsFile('{self.file}')"
+        return f"OptionsFile(file='{self.file}')"

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -13,7 +13,7 @@ from numpy import (pi, sin, cos, tan, arccos as acos, arcsin as asin,
 # TODO ability to read from/write to nested dictionary
 
 SECTION_DELIM = ':'
-COMMENT_DELIM = '#'
+COMMENT_DELIM = ['#', ';']
 INDENT_STR = '|-- '
 BOOLEAN_STATES = {'true': True, 'on': True,
                   'false': False, 'off': False}
@@ -102,8 +102,9 @@ class Section(UserDict):
             return line
         else:
             # any comment will be discarded, along with any trailing whitespace
-            value, *comment = line.split(COMMENT_DELIM)
-            value = value.rstrip()
+            for delim in COMMENT_DELIM:
+                line, *comments = line.split(delim)
+            value = line.rstrip()
 
             if evaluate:
                 return evaluation(value)

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -15,6 +15,10 @@ from numpy import (pi, sin, cos, tan, arccos as acos, arcsin as asin,
                    round, abs)
 
 
+# TODO rewrite using pathlib
+# TODO make forced lowercase optional
+# TODO ability to read from/write to nested dictionary
+
 class BoutOptions:
     """This class represents a tree structure. Each node (BoutOptions
     object) can have several sub-nodes (sections), and several
@@ -52,12 +56,15 @@ class BoutOptions:
 
     """
 
+    # TODO instead of storing itself, make sections separate classes?
     def __init__(self, name="root", parent=None):
         self._sections = {}
         self._keys = {}
         self._name = name
         self._parent = parent
 
+    # TODO get_section should not also be a setter!
+    # separate set_section method?
     def get_section(self, name):
         """
         Return a section object. If the section does not exist then it is
@@ -102,6 +109,9 @@ class BoutOptions:
         """
         return self.get_section(name)
 
+    # TODO .get() method with optional evaluation
+
+    # TODO comment stripping here
     def __getitem__(self, key):
         """
         First check if it's a section, then a value
@@ -122,16 +132,18 @@ class BoutOptions:
             return
         self._keys[key.lower()] = value
 
+    # TODO give this a new name which can't be confused with filepath
     def path(self):
-        """Returns the path of this section, joining together names of
+        """
+        Returns the path of this section, joining together names of
         parents
-
         """
 
         if self._parent:
             return self._parent.path() + ":" + self._name
         return self._name
 
+    # TODO this should return a dict of pairs: (section, list of keys)
     def keys(self):
         """Returns all keys, including sections and values
 
@@ -150,6 +162,8 @@ class BoutOptions:
         """
         return self._keys.keys()
 
+    # TODO an .items() method like configparser
+
     def as_dict(self):
         """Return a nested dictionary of all the options.
 
@@ -158,9 +172,11 @@ class BoutOptions:
         dicttree.update({name:self[name].as_dict() for name in self.sections()})
         return dicttree
 
+    # TODO more intuitive definition of length
     def __len__(self):
         return len(self._sections) + len(self._keys)
 
+    # TODO this should yield pairs: (section key, section)
     def __iter__(self):
         """Iterates over all keys. First values, then sections
 
@@ -183,6 +199,7 @@ class BoutOptions:
             text += indent + " |- " + self._sections[s].__str__(indent+" |  ")
         return text
 
+    # TODO import configparser's interpolation classes?
     def evaluate_scalar(self, name):
         """
         Evaluate (recursively) scalar expressions
@@ -234,6 +251,7 @@ class BoutOptions:
 
         return expression
 
+    # TODO option to write out comments - would allow for roundtripping
     def write(self, filename=None, overwrite=False):
         """ Write to BOUT++ options file
 
@@ -316,6 +334,7 @@ class BoutOptionsFile(BoutOptions):
 
     """
 
+    # TODO options to read grid size from Dataset
     def __init__(self, filename="BOUT.inp", name="root",
                  gridfilename=None, nx=None, ny=None, nz=None):
         super().__init__(self, name)
@@ -347,10 +366,12 @@ class BoutOptionsFile(BoutOptions):
                     except KeyError:
                         pass
             elif nx or ny:
+                errmsg = "{} not specified. If either nx or ny are given, " \
+                         "then both must be."
                 if nx is None:
-                    raise ValueError("nx not specified. If either nx or ny are given, then both must be.")
+                    raise ValueError(errmsg.format(nx))
                 if ny is None:
-                    raise ValueError("ny not specified. If either nx or ny are given, then both must be.")
+                    raise ValueError(errmsg.format(ny))
                 self.nx = nx
                 self.ny = ny
             else:
@@ -408,6 +429,7 @@ class BoutOptionsFile(BoutOptions):
                                 f"exception occured: {str(msg)}\n"
                                 "Evaluating non-scalar options not available")
 
+    # TODO better exception handling (import from configparser?)
     def _read_file(self, f):
         # Go through each line in the file
         section = self  # Start with root section
@@ -461,7 +483,7 @@ class BoutOptionsFile(BoutOptions):
                     section[line[:eqpos].strip()] = value
 
     def __repr__(self):
-        # TODO Add grid-related options to this
+        # TODO Add grid-related options
         return f"BoutOptionsFile('{self.filepath}')"
 
     def evaluate(self, name):

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -1,8 +1,5 @@
+from collections import UserDict
 from pathlib import Path
-import os
-import re
-
-import numpy
 
 
 # These are imported to be used by 'eval' in
@@ -14,14 +11,115 @@ from numpy import (pi, sin, cos, tan, arccos as acos, arcsin as asin,
                    exp, log, log10, power as pow, sqrt, ceil, floor,
                    round, abs)
 
-
-# TODO rewrite using pathlib
-# TODO make forced lowercase optional
 # TODO ability to read from/write to nested dictionary
 
-class BoutOptionsParser:
+SECTION_DELIM = ':'
+COMMENT_DELIM = '#'
+
+
+class Section(UserDict):
     """
-    Tree of options, representing the contents of an input file.
+    Section of an options file.
+
+    This section can have multiple sub-sections, and each section stores the
+    options as multiple key-value pairs.
+
+    Parameters
+    ----------
+    name : str
+        Name of the section
+    data : dict, optional
+    parent : BoutOptionsParser or Section
+        A parent Section or BoutOptionsParser object
+    """
+
+    # Inheriting from UserDict gives iter, del, len methods already, and the
+    # data attribute for storing the contents
+
+    def __init__(self, name, data=None, parent=None):
+        if data is None:
+            data = {}
+        super().__init__(data)
+
+        # TODO should name be optional?
+        self.name = name
+        # TODO check if parent has a section with the same name?
+        self._parent = parent
+
+    def __getitem__(self, key):
+        return self.get(key, evaluate=True, keep_comments=False)
+
+    def get(self, key, evaluate=True, keep_comments=False):
+        """
+        Fetch the value stored under a certain key.
+
+        Parameters
+        ----------
+        key : str
+        evaluate : bool, optional (default: True)
+            If true, attempts to evaluate the value as an expression by
+            substituting in other values from the options file. Other values
+            are specified by key, or by section:key.
+            If false, will return value as an unmodified string.
+        keep_comments : bool, optional (default: False)
+            If false, will strip off any inline comments, delimited by '#', and
+            any whitespace before returning.
+            If true, will return the whole line.
+        """
+
+        if evaluate and keep_comments:
+            raise ValueError("Cannot keep comments and evaluate the contents.")
+
+        line = self.data[key]
+        if keep_comments or isinstance(line, Section):
+            return line
+        else:
+            # any comment will be discarded
+            value, comment, = line.split(COMMENT_DELIM)
+            # TODO remove whitespace?
+
+            if evaluate:
+                raise NotImplementedError
+            else:
+                return value
+
+    def __setitem__(self, key, value):
+        self.set(key, value)
+
+    def set(self, key, value):
+        """
+        Store a value under a certain key.
+
+        Will cast the value to a string (unless value is a new section).
+        If a dictionary is passed, will create a new Section.
+
+        Parameters
+        ----------
+        key : str
+        value : str
+        """
+
+        if isinstance(value, dict):
+            value = Section(name=key, data=value)
+        if not isinstance(value, Section):
+            value = str(value)
+        self.data[key] = value
+
+    def __str__(self):
+        # TODO this needs to know the overall depth
+
+        namestr = f"[{self.name}]\n"
+        indent = "|-- "
+        datastr = indent.join(indent + f"{key} = {val}\n"
+                          for key, val in self.data.items())
+        return namestr + datastr
+
+    # TODO .keys(), .items(), .values(), .sections(), repr?
+
+
+class BoutOptionsTree(Section):
+    """
+    Tree of options, with the same structure as a complete BOUT++ input file.
 
     This class represents a tree structure. Each section (Section object) can
     have multiple sub-sections, and each section stores the options as multiple
@@ -30,7 +128,7 @@ class BoutOptionsParser:
     Examples
     --------
 
-    >>> opts = BoutOptions()  # Create a root
+    >>> opts = BoutOptionsTree()  # Create a root
 
     Specify value of a key in a section "test"
 
@@ -50,589 +148,59 @@ class BoutOptionsParser:
      |   |- key = 4
 
     """
-    ...
 
+    def __init__(self, data=None):
+        super().__init__(name='root', data=data)
 
-class Section:
-    """
-    Section of an input file.
+    # TODO .sections(), .as_dict(), str,
 
-    This section can have multiple sub-sections, and each section stores the
-    options as multiple key-value pairs.
-
-    Parameters
-    ----------
-    name : str
-        Name of the section
-    parent : BoutOptionsParser or Section
-        A parent Section or BoutOptionsParser object
-    """
-
-    def __init__(self, name=None, contents=None, parent=None):
-        self.name = name
-        # TODO check if parent has a section with the same name?
-        self._parent = parent
-        if contents is None:
-            self._contents = {}
-        else:
-            self._contents = contents
-
-    def get(self, key, evaluate=True, keep_comments=False):
+    def write(self, file, evaluate=False, keep_comments=True):
         """
-        Fetch the value stored under a certain key.
+        Writes out contents to a file, following the format of a BOUT.inp file.
 
         Parameters
         ----------
-        key : str
+        file
         evaluate : bool, optional (default: True)
             If true, attempts to evaluate the value as an expression by
-            substituting in other values from the options file. Other values
-            are specified by key, or by section:key.
-            If false, will return value as an unmodified string.
-        keep_comments :
+            substituting in other values from the options file, before writing.
+            Other values are specified by key, or by section:key.
+            If false, will write value as an unmodified string.
+        keep_comments : bool, optional (default: False)
             If false, will strip off any inline comments, delimited by '#', and
-            any whitespace before returning.
-            If true, will return the whole line.
+            any whitespace before writing.
+            If true, will write out the whole line.
         """
 
-        if evaluate and keep_comments:
-            raise ValueError("Cannot keep comments and evaluate the contents.")
+        with open(Path(file), 'w') as f:
+            ...
 
-        line = self._contents[key]
-        if keep_comments or isinstance(line, Section):
-            return line
-        else:
-            value, comment, = line.split('#')  # any comment will be discarded
-            # TODO remove whitespace?
 
-            if evaluate:
-                raise NotImplementedError
-            else:
-                return value
+class BoutOptionsFile(BoutOptionsTree):
+    """
+    The full contents of a particular BOUT++ input file.
 
-    def __getitem__(self, key):
-        return self.get(key, evaluate=True, keep_comments=False)
-
-    def set(self, key, value):
-        """
-        Store a value under a certain key.
-
-        Will attempt to cast the value to a string (unless it's a new section).
-
-        Parameters
-        ----------
-        key : str
-        value : str
-        """
-
-        if not isinstance(value, Section):
-            value = str(value)
-        self._contents[key] = value
-
-    def __setitem__(self, key, value):
-        self.set(key, value)
-
-    def keys(self):
-        """
-        Returns a list of all the keys for this section.
-
-        Returns
-        -------
-        list
-        """
-        return self._contents.keys()
-
-class BoutOptions:
-    """This class represents a tree structure. Each node (BoutOptions
-    object) can have several sub-nodes (sections), and several
-    key-value pairs.
+    This class represents a tree structure of options, all loaded from `file`.
+    Each section (Section object) can have multiple sub-sections, and each
+    section stores the options as multiple key-value pairs.
 
     Parameters
     ----------
-    name : str, optional
-        Name of the root section (default: "root")
-    parent : BoutOptions, optional
-        A parent BoutOptions object (default: None)
-
-    Examples
-    --------
-
-    >>> optRoot = BoutOptions()  # Create a root
-
-    Specify value of a key in a section "test"
-    If the section does not exist then it is created
-
-    >>> optRoot.getSection("test")["key"] = 4
-
-    Get the value of a key in a section "test"
-    If the section does not exist then a KeyError is raised
-
-    >>> print(optRoot["test"]["key"])
-    4
-
-    To pretty print the options
-
-    >>> print(optRoot)
-    root
-     |- test
-     |   |- key = 4
-
+    file : str or path-like object
+        Path to file from which to read input options.
+    lower : bool, optional (default: False)
+        If true, converts all strings to lowercase on reading.
     """
 
-    # TODO instead of storing itself, make sections separate classes?
-    def __init__(self, name="root", parent=None):
-        self._sections = {}
-        self._keys = {}
-        self._name = name
-        self._parent = parent
+    # TODO gridfile stuff?
 
-    # TODO get_section should not also be a setter!
-    # separate set_section method?
-    def get_section(self, name):
-        """
-        Return a section object. If the section does not exist then it is
-        created.
+    def __init__(self, file, lower=False):
+        contents, self.file = self._read(Path(file), lower)
+        super().__init__(data=contents)
 
-        Parameters
-        ----------
-        name : str
-            Name of the section to get/create
-
-        Returns
-        -------
-        BoutOptions
-            A new section with the original object as the parent
-        """
-        name = name.lower()
-
-        if name in self._sections:
-            return self._sections[name]
-        else:
-            newsection = BoutOptions(name, self)
-            self._sections[name] = newsection
-            return newsection
-
-    def getSection(self, name):
-        """
-        Return a section object. If the section does not exist then it is
-        created
-
-        (non-PEP8 compliant alias for get_section, for backwards compatibility)
-
-        Parameters
-        ----------
-        name : str
-            Name of the section to get/create
-
-        Returns
-        -------
-        BoutOptions
-            A new section with the original object as the parent
-
-        """
-        return self.get_section(name)
-
-    # TODO .get() method with optional evaluation
-
-    # TODO comment stripping here
-    def __getitem__(self, key):
-        """
-        First check if it's a section, then a value
-        """
-        key = key.lower()
-        if key in self._sections:
-            return self._sections[key]
-
-        if key not in self._keys:
-            raise KeyError(f"Key {key} not in section {self.path()}")
-        return self._keys[key]
-
-    def __setitem__(self, key, value):
-        """
-        Set a key
-        """
-        if len(key) == 0:
-            return
-        self._keys[key.lower()] = value
-
-    # TODO give this a new name which can't be confused with filepath
-    def path(self):
-        """
-        Returns the path of this section, joining together names of
-        parents
-        """
-
-        if self._parent:
-            return self._parent.path() + ":" + self._name
-        return self._name
-
-    # TODO this should return a dict of pairs: (section, list of keys)
-    def keys(self):
-        """Returns all keys, including sections and values
-
-        """
-        return list(self._sections) + list(self._keys)
-
-    def sections(self):
-        """Return a list of sub-sections
-
-        """
-        return self._sections.keys()
-
-    def values(self):
-        """Return a list of values
-
-        """
-        return self._keys.keys()
-
-    # TODO an .items() method like configparser
-
-    def as_dict(self):
-        """Return a nested dictionary of all the options.
-
-        """
-        dicttree = {name:self[name] for name in self.values()}
-        dicttree.update({name:self[name].as_dict() for name in self.sections()})
-        return dicttree
-
-    # TODO more intuitive definition of length
-    def __len__(self):
-        return len(self._sections) + len(self._keys)
-
-    # TODO this should yield pairs: (section key, section)
-    def __iter__(self):
-        """Iterates over all keys. First values, then sections
-
-        """
-        for k in self._keys:
-            yield k
-        for s in self._sections:
-            yield s
-
-    def __str__(self, indent=""):
-        """Print a pretty version of the options tree
-
-        """
-        text = self._name + "\n"
-
-        for k in self._keys:
-            text += indent + " |- " + k + " = " + str(self._keys[k]) + "\n"
-
-        for s in self._sections:
-            text += indent + " |- " + self._sections[s].__str__(indent+" |  ")
-        return text
-
-    # TODO import configparser's interpolation classes?
-    def evaluate_scalar(self, name):
-        """
-        Evaluate (recursively) scalar expressions
-        """
-        expression = self._substitute_expressions(name)
-
-        # replace ^ with ** so that Python evaluates exponentiation
-        expression = expression.replace("^", "**")
-
-        return eval(expression)
-
-    def _substitute_expressions(self, name):
-        expression = str(self[name]).lower()
-        expression = self._evaluate_section(expression, "")
-        parent = self._parent
-        while parent is not None:
-            sectionname = parent._name
-            if sectionname is "root":
-                sectionname = ""
-            expression = parent._evaluate_section(expression, sectionname)
-            parent = parent._parent
-
-        return expression
-
-    def _evaluate_section(self, expression, nested_sectionname):
-        # pass a nested section name so that we can traverse the options tree
-        # rooted at our own level and each level above us so that we can use
-        # relatively qualified variable names, e.g. if we are in section
-        # 'foo:bar:baz' then a variable 'x' from section 'bar' could be called
-        # 'bar:x' (found traversing the tree starting from 'bar') or
-        # 'foo:bar:x' (found when traversing tree starting from 'foo').
-        for var in self.values():
-            if nested_sectionname is not "":
-                nested_name = nested_sectionname + ":" + var
-            else:
-                nested_name = var
-            if re.search(r"(?<!:)\b"+re.escape(nested_name.lower())+r"\b", expression.lower()):
-                # match nested_name only if not preceded by colon (which indicates more nesting)
-                expression = re.sub(r"(?<!:)\b" + re.escape(nested_name.lower()) + r"\b",
-                                    "(" + self._substitute_expressions(var) + ")",
-                                    expression)
-
-        for subsection in self.sections():
-            if nested_sectionname is not "":
-                nested_name = nested_sectionname + ":" + subsection
-            else:
-                nested_name = subsection
-            expression = self.getSection(subsection)._evaluate_section(expression, nested_name)
-
-        return expression
-
-    # TODO option to write out comments - would allow for roundtripping
-    def write(self, filename=None, overwrite=False):
-        """ Write to BOUT++ options file
-
-        This method will throw an error rather than overwriting an existing
-        file unless the overwrite argument is set to true.
-        Note, no comments from the original input file are transferred to the
-        new one.
-
-        Parameters
-        ----------
-        filename : str
-            Path of the file to write
-            (defaults to path of the file that was read in)
-        overwrite : bool
-            If False then throw an exception if 'filename' already exists.
-            Otherwise, just overwrite without asking.
-            (default False)
-        """
-        if filename is None:
-            filename = self.filename
-
-        if not overwrite and os.path.exists(filename):
-            raise ValueError("Not overwriting existing file, cannot write "
-                             f"output to {filename}")
-
-        def write_section(basename, opts, f):
-            if basename:
-                f.write("["+basename+"]\n")
-            for key, value in opts._keys.items():
-                f.write(key+" = "+str(value)+"\n")
-            for section in opts.sections():
-                section_name = basename+":"+section if basename else section
-                write_section(section_name, opts[section], f)
-
-        with open(filename, "w") as f:
-            write_section("", self, f)
-
-
-class BoutOptionsFile(BoutOptions):
-    """Parses a BOUT.inp configuration file, producing a tree of
-    BoutOptions.
-
-    Slight differences from ConfigParser, including allowing values
-    before the first section header, and supporting nested section headers.
-    Nesting uses the syntax [header:subheader].
-
-    Parameters
-    ----------
-    filename : str, optional
-        Path to file to read
-    name : str, optional
-        Name of root section (default: "root")
-    gridfilename : str, optional
-        If present, path to gridfile from which to read grid sizes (nx, ny, nz)
-    nx, ny : int, optional
-        - Specify sizes of grid, used when evaluating option strings
-        - Cannot be given if gridfilename is specified
-        - Must both be given if either is
-        - If neither gridfilename nor nx, ny are given then will try to
-          find nx, ny from (in order) the 'mesh' section of options,
-          outputfiles in the same directory is the input file, or the grid
-          file specified in the options file (used as a path relative to
-          the current directory)
-    nz : int, optional
-        Use this value for nz when evaluating option expressions, if given.
-        Overrides values found from input file, output files or grid files
-
-    Examples
-    --------
-
-    >>> opts = BoutOptionsFile("BOUT.inp")
-    >>> print(opts)   # Print all options in a tree
-    root
-    |- nout = 100
-    |- timestep = 2
-    ...
-
-    >>> opts["All"]["scale"] # Value "scale" in section "All"
-    1.0
-
-    """
-
-    # TODO options to read grid size from Dataset
-    def __init__(self, filename="BOUT.inp", name="root",
-                 gridfilename=None, nx=None, ny=None, nz=None):
-        super().__init__(self, name)
-
-        # Open the file
-        self.filepath = Path(filename)
-        with open(self.filepath, "r") as f:
-            self._read_file(f)
-
-        # TODO
-        #self.nx, self.ny, self.nz = self._read_grid(gridfilename, nx, ny, nz)
-
-    # TODO needs to be changed: DataFile -> Dataset
-    def _read_grid(self, gridfilename=None, nx=None, ny=None, nz=None):
-        try:
-            # define arrays of x, y, z to be used for substitutions
-            gridfile = None
-            nzfromfile = None
-            if gridfilename:
-                if nx is not None or ny is not None:
-                    raise ValueError("nx or ny given as inputs even though "
-                                     "gridfilename was given explicitly, "
-                                     "don't know which parameters to choose")
-                with DataFile(gridfilename) as gridfile:
-                    self.nx = float(gridfile["nx"])
-                    self.ny = float(gridfile["ny"])
-                    try:
-                        nzfromfile = gridfile["MZ"]
-                    except KeyError:
-                        pass
-            elif nx or ny:
-                errmsg = "{} not specified. If either nx or ny are given, " \
-                         "then both must be."
-                if nx is None:
-                    raise ValueError(errmsg.format(nx))
-                if ny is None:
-                    raise ValueError(errmsg.format(ny))
-                self.nx = nx
-                self.ny = ny
-            else:
-                try:
-                    self.nx = self["mesh"].evaluate_scalar("nx")
-                    self.ny = self["mesh"].evaluate_scalar("ny")
-                except KeyError:
-                    try:
-                        # get nx, ny, nz from output files
-                        from boutdata.collect import findFiles
-                        file_list = findFiles(path=os.path.dirname(), prefix="BOUT.dmp")
-                        with DataFile(file_list[0]) as f:
-                            self.nx = f["nx"]
-                            self.ny = f["ny"]
-                            nzfromfile = f["MZ"]
-                    except (IOError, KeyError):
-                        try:
-                            gridfilename = self["mesh"]["file"]
-                        except KeyError:
-                            gridfilename = self["grid"]
-                        with DataFile(gridfilename) as gridfile:
-                            self.nx = float(gridfile["nx"])
-                            self.ny = float(gridfile["ny"])
-                            try:
-                                nzfromfile = float(gridfile["MZ"])
-                            except KeyError:
-                                pass
-            if nz is not None:
-                self.nz = nz
-            else:
-                try:
-                    self.nz = self["mesh"].evaluate_scalar("nz")
-                except KeyError:
-                    try:
-                        self.nz = self.evaluate_scalar("mz")
-                    except KeyError:
-                        if nzfromfile is not None:
-                            self.nz = nzfromfile
-            mxg = self._keys.get("MXG", 2)
-            myg = self._keys.get("MYG", 2)
-
-            # make self.x, self.y, self.z three dimensional now so
-            # that expressions broadcast together properly.
-            self.x = numpy.linspace((0.5 - mxg)/(self.nx - 2*mxg),
-                                    1. - (0.5 - mxg)/(self.nx - 2*mxg),
-                                    self.nx)[:, numpy.newaxis, numpy.newaxis]
-            self.y = 2.*numpy.pi*numpy.linspace((0.5 - myg)/self.ny,
-                                                1.-(0.5 - myg)/self.ny,
-                                                self.ny + 2*myg)[numpy.newaxis, :, numpy.newaxis]
-            self.z = 2.*numpy.pi*numpy.linspace(0.5/self.nz,
-                                                1.-0.5/self.nz,
-                                                self.nz)[numpy.newaxis, numpy.newaxis, :]
-        except Exception as msg:
-            raise BaseException("While building x, y, z coordinate arrays, an "
-                                f"exception occured: {str(msg)}\n"
-                                "Evaluating non-scalar options not available")
-
-    # TODO better exception handling (import from configparser?)
-    def _read_file(self, f):
-        # Go through each line in the file
-        section = self  # Start with root section
-        for linenr, line in enumerate(f.readlines()):
-            # First remove comments, either # or ;
-            startpos = line.find("#")
-            if startpos != -1:
-                line = line[:startpos]
-            startpos = line.find(";")
-            if startpos != -1:
-                line = line[:startpos]
-
-            # Check section headers
-            startpos = line.find("[")
-            endpos = line.find("]")
-            if startpos != -1:
-                # A section heading
-                if endpos == -1:
-                    raise SyntaxError("Missing ']' on line %d" % (linenr,))
-                line = line[(startpos + 1):endpos].strip()
-
-                section = self
-                while True:
-                    scorepos = line.find(":")
-                    if scorepos == -1:
-                        break
-                    sectionname = line[0:scorepos]
-                    line = line[(scorepos + 1):]
-                    section = section.getSection(sectionname)
-                section = section.getSection(line)
-            else:
-                # A key=value pair
-
-                eqpos = line.find("=")
-                if eqpos == -1:
-                    # No '=', so just set to true
-                    section[line.strip()] = True
-                else:
-                    value = line[(eqpos + 1):].strip()
-                    try:
-                        # Try to convert to an integer
-                        value = int(value)
-                    except ValueError:
-                        try:
-                            # Try to convert to float
-                            value = float(value)
-                        except ValueError:
-                            # Leave as a string
-                            pass
-
-                    section[line[:eqpos].strip()] = value
+    def _read(self, filepath, lower):
+        return data, str(filepath.resolve())
 
     def __repr__(self):
         # TODO Add grid-related options
-        return f"BoutOptionsFile('{self.filepath}')"
-
-    def evaluate(self, name):
-        """Evaluate (recursively) expressions
-
-        Sections and subsections must be given as part of 'name',
-        separated by colons
-
-        Parameters
-        ----------
-        name : str
-            Name of variable to evaluate, including sections and
-            subsections
-
-        """
-        section = self
-        split_name = name.split(":")
-        for subsection in split_name[:-1]:
-            section = section.getSection(subsection)
-        expression = section._substitute_expressions(split_name[-1])
-
-        # replace ^ with ** so that Python evaluates exponentiation
-        expression = expression.replace("^", "**")
-
-        # substitute for x, y and z coordinates
-        for coord in ["x", "y", "z"]:
-            expression = re.sub(r"\b"+coord.lower()+r"\b", "self."+coord, expression)
-
-        return eval(expression)
+        return f"BoutOptionsFile('{self.file}')"

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -15,10 +15,7 @@ from numpy import (pi, sin, cos, tan, arccos as acos, arcsin as asin,
 
 SECTION_DELIM = ':'
 COMMENT_DELIM = '#'
-
-
-from pprint import PrettyPrinter
-pp = PrettyPrinter()
+INDENT_STR = '|-- '
 
 
 class Section(UserDict):
@@ -151,16 +148,16 @@ class Section(UserDict):
         return self._find_sections([self])
 
     def __str__(self):
-        # TODO this needs to know the overall depth
+        depth = self.lineage().count(SECTION_DELIM)
+        indent = INDENT_STR * depth
 
-        namestr = f"[{self.name}]\n"
-        indent = "|-- "
+        text = indent + f"[{self.name}]\n"
         for key, val in self.items():
             if isinstance(val, Section):
-                datastr
+                text += str(val)
             else:
-                datastr = indent.join(indent + f"{key} = {val}\n")
-        return namestr + datastr
+                text += indent + INDENT_STR + f"{key} = {val}\n"
+        return text
 
     def _write(self, file, evaluate=False, keep_comments=True):
         """
@@ -185,6 +182,19 @@ class Section(UserDict):
             else:
                 line = f"{key} = {val}\n"
                 file.write(line)
+
+
+    #def _write(self):
+        """
+        text = f"[{self.lineage()}]\n"
+        indent = "|-- "
+        for key, val in self.items():
+            if not isinstance(val, Section):
+                text += indent + f"{key} = {val}\n"
+            else:
+                text += str(val)
+        return text
+        """
 
     def __repr__(self):
         return f"Section(name='{self.name}', parent='{self._parent}', " \

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -124,9 +124,9 @@ class Section(UserDict):
         str
         """
         if self._parent is None or self._parent == 'root':
-            return self.name + SECTION_DELIM
+            return self.name
         else:
-            return self._parent.lineage() + self.name
+            return self._parent.lineage() + SECTION_DELIM + self.name
 
     def _find_sections(self, sections):
         """
@@ -136,10 +136,19 @@ class Section(UserDict):
         for key in self.keys():
             val = self[key]
             if isinstance(val, Section):
-                #print(repr(val))
                 sections.append(val)
                 sections = val._find_sections(sections)
         return sections
+
+    def sections(self):
+        """
+        Returns a list of all sections contained, including nested ones.
+
+        Returns
+        -------
+        list of Section objects
+        """
+        return self._find_sections([self])
 
     def __str__(self):
         # TODO this needs to know the overall depth
@@ -218,18 +227,6 @@ class OptionsTree(Section):
         super().__init__(name='root', data=data, parent=None)
 
     # TODO .sections(), .as_dict(), str,
-
-    def sections(self):
-        """
-        Returns a list of all sections contained, including nested ones.
-
-        Returns
-        -------
-        list of Section objects
-        """
-        sections = self._find_sections([self])
-        #pp.pprint(sections)
-        return [section.lineage() for section in sections]
 
     def write_to(self, file, evaluate=False, keep_comments=True):
         """

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -17,10 +17,11 @@ class BoutOptions(BoutOptionsParser):
         super().__init__()
 
         # Initialise options by reading file
-        absfilepaths = self.read(filepath)
-        if len(absfilepaths) == 0:
-            raise FileNotFoundError(f"No file found at {Path(filepath)}")
-        self.filepath = Path(absfilepaths[0])
+        # Insert section header on 1st line to avoid MissingSectionHeaderError
+        with open(filepath, 'r') as original:
+            modified = "[top]\n" + original.read()
+            self.read_string(modified)
+        self.filepath = Path(filepath)
 
     def to_flat_dict(self):
         return {section: self.items(section) for section in self.sections()}

--- a/xbout/options.py
+++ b/xbout/options.py
@@ -30,8 +30,8 @@ class Section(UserDict):
     name : str
         Name of the section
     data : dict, optional
-    parent : str or Section
-        A parent section
+    parent : str, Section or None
+        The parent Section
     """
 
     # Inheriting from UserDict gives keys, items, values, iter, del, & len
@@ -149,14 +149,12 @@ class Section(UserDict):
 
     def __str__(self):
         depth = self.lineage().count(SECTION_DELIM)
-        indent = INDENT_STR * depth
-
-        text = indent + f"[{self.name}]\n"
+        text = INDENT_STR * depth + f"[{self.name}]\n"
         for key, val in self.items():
             if isinstance(val, Section):
                 text += str(val)
             else:
-                text += indent + INDENT_STR + f"{key} = {val}\n"
+                text += INDENT_STR * (depth+1) + f"{key} = {val}\n"
         return text
 
     def _write(self, file, evaluate=False, keep_comments=True):
@@ -197,7 +195,7 @@ class Section(UserDict):
         """
 
     def __repr__(self):
-        return f"Section(name='{self.name}', parent='{self._parent}', " \
+        return f"Section(name='{self.name}', parent='{self.parent}', " \
                f"data={self.data})"
 
 
@@ -238,7 +236,7 @@ class OptionsTree(Section):
 
     # TODO .sections(), .as_dict(), str,
 
-    def write_to(self, file, evaluate=False, keep_comments=True):
+    def write_to(self, file, evaluate=False, keep_comments=True, lower=False):
         """
         Writes out contents to a file, following the format of a BOUT.inp file.
 

--- a/xbout/tests/data/options/BOUT.inp
+++ b/xbout/tests/data/options/BOUT.inp
@@ -1,0 +1,143 @@
+timestep              = 80                 # Timestep length of outputted data
+nout                  = 2000                # Number of outputted timesteps
+
+#nxpe = 4
+
+MZ                    = 256                 # Number of Z points
+zmin                  = 0
+zmax                  = 23.873241           # 23.873241*2pi = 150, z is fracs of 2pi, so Lz = 150
+myg                   = 0                   # No need for Y communications
+
+[mesh:ddx]
+first                 = C2
+second                = C2
+upwind                = C2
+
+[mesh:ddz]
+first                 = C2
+second                = C2
+upwind                = C2
+
+[mesh]
+Ly                    = 2000.0             # ~4m
+Lx                    = 400.0
+
+nx                    = 484                # including 4 guard cells
+ny                    = 1                  # excluding guard cells
+dx                    = Lx/(nx-4)
+dy                    = Ly/ny 
+
+[laplace]
+type                  = cyclic
+global_flags          = 0 
+inner_boundary_flags  = 1
+outer_boundary_flags  = 16
+include_yguards       = false
+
+[solver]
+type=cvode
+#timestep = 0.00000001    # Suggested init timestep for numerical methods
+mxstep = 100000000       # max steps before result is deemed not to converge
+#ATOL =   1e-12          # Absolute tolerance
+#RTOL =   1e-5           # Relative tolerance
+
+[storm]
+B_0                   = 0.24                # Tesla
+T_e0                  = 15                  # eV
+T_i0                  = 30                  # eV
+m_i                   = 2                   # Atomic Units
+q                     = 6.2                 # Dimensionless
+R_c                   = 1.5                 # m
+n_0                   = 0.5e13              # m-3
+Z                     = 1                   # Dimensionless
+loglambda             = -1                  # Dimensionless
+
+# If these parameters are specified, they will be used instead of the values calculated from the primary parameters above.
+# Using ESEL-like dissipation parameters form Militello 2013
+#mu_n0                 = 0.0121  # Will use nominal value of ~0.01
+#mu_vort0              = 5.0
+mu_vort_core           = 5.0
+#mu                    = 1000
+#nu_parallel0          = 0.07
+#kappa0                = 0.0440
+#kappa0_perp           = 0.0440
+#g0                    = 0.002862
+
+ixsep                 = 200                  # Radial position of separatrix
+
+n_bg                  = 0.01
+T_bg                  = 0.01
+
+L                     = mesh:Ly
+bracket               = 2                   # 0 = std, 1 = simple, 2 = arakawa
+isothermal            = false                # switch for isothermal simulations
+boussinesq            = true                # switch for solution with boussinesq approx (without requires multigrid)
+blob_sim              = false               # switch for blob_sim
+SOL_closure           = heuristic           # choice of 2d closure
+sheath_linear         = false               # switch to linearise sheath terms
+unit_bg               = false                # loss terms cause decay of fluctuations back to a background of n=1
+initial_noise         = true                # switch to add random noise to trigger instabilities
+uniform_diss_paras    = true
+driftwaves            = false
+
+[All]
+#scale = 0.0 
+#xs_opt = 3
+#zs_opt = 3
+#bndry_all = neumann
+
+[n]
+scale = 1.0
+sep_loc = 0.33333
+#sep_loc = storm:ixsep/(mesh:nx-4)
+falloff = 0.20
+bg = storm:n_bg
+#         initial bg in core  initial bg in sep     initial exp decay in sep
+function = H(sep_loc-x)*1.0 + H(x-sep_loc)*(bg + (1-bg)*exp(-(x-sep_loc)/falloff))
+bndry_xin = neumann_o2(0.0)
+bndry_xout = neumann_o2(0.0)
+
+[T]
+scale = 1.0
+sep_loc = 0.33333
+#sep_loc = storm:ixsep/(mesh:nx-4)
+falloff = 0.20
+bg = storm:T_bg
+#   	     initial bg in core  initial bg in sep     initial exp decay in sep
+function = H(sep_loc-x)*1.0 + H(x-sep_loc)*(bg + (1-bg)*exp(-(x-sep_loc)/falloff))
+bndry_xin = neumann_o2(0.0)     # Fix logT = 0.0, so T = 1.0 on inner boundary
+bndry_xout = neumann_o2(0.0)
+
+[vort]
+scale = 1.0
+function = 0.0
+#xs_opt = 3
+#zs_opt = 3
+bndry_xin = neumann(0.0)
+bndry_xout = neumann(0.0) 
+
+[B]         # Magnetic field 
+scale = 1.0
+function = 1.0 ; 
+
+##################################################################
+[S]       # Density source
+Ly                    = mesh:Ly
+scale                 = 1.0             # No sources, instead n & T are fixed to non-zero values on inner boundary
+turb_smag             = 11.0
+turb_swidth           = 0.01666666
+s_loc                 = 0.1                                                                                    # Fraction of distance along x to place centre of turbulence source
+function              = turb_smag*exp(-((x-s_loc)/turb_swidth)^2.0) / Ly
+
+[S_E]       # Temperature source
+Ly                    = mesh:Ly
+scale                 = 1.0             # No sources, instead n	& T are	fixed to non-zero values on inner boundary
+turb_smag             = 20.0    
+turb_swidth           = 0.01666666
+s_loc                 = 0.1                                                                                    # Fraction of distance along x to place centre of turbulence source
+function              = turb_smag*exp(-((x-s_loc)/turb_swidth)^2.0) / Ly
+
+[uE]
+bndry_xin             = neumann_o2
+bndry_xout            = neumann_o2
+

--- a/xbout/tests/test_options.py
+++ b/xbout/tests/test_options.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import pytest
+
+from xbout.options import BoutOptionsParser, BoutOptions
+
+
+@pytest.fixture
+def example_options_file(tmpdir_factory):
+    """
+    Mocks up a temporary example BOUT.inp (or BOUT.settings) file, and returns
+    the path to it.
+    """
+
+    # Create options file
+    options = BoutOptionsParser()
+
+    # Fill it with example data
+    options['top'] = {'timestep': '80',
+                      'nout': '2000    # Number of outputted timesteps'}
+    options['mesh'] = {'Ly': '2000.0   # ~4m',
+                       'Lx': '400.0',
+                       'nx': '484      # including 4 guard cells',
+                       'ny': '1        # excluding guard cells',
+                       'dx': 'Lx/(nx-4)',
+                       'dy': 'Ly/ny'}
+    options['mesh:ddx'] = {'first': 'C2',
+                           'second': 'C2',
+                           'upwind': 'C2'}
+    options['laplace'] = {'type': 'cyclic',
+                          'global_flags': '0',
+                          'inner_boundary_flags': '1',
+                          'outer_boundary_flags': '16',
+                          'include_yguards': 'false'}
+    options['storm'] = {'B_0': '0.24   # Tesla',
+                        'T_e0': '15    # eV'}
+
+    # Create temporary directory
+    save_dir = tmpdir_factory.mktemp("inputdata")
+
+    # Save
+    optionsfilepath = save_dir.join('BOUT.inp')
+    with open(optionsfilepath, 'w') as optionsfile:
+        options.write(optionsfile)
+
+    return Path(optionsfilepath)
+
+
+class TestReadFile:
+    def test_no_file(self):
+        with pytest.raises(FileNotFoundError):
+            BoutOptions('./')
+
+    def test_open_real_example(self):
+        # TODO this absolute filepath is sensitive to the directory the tests are run from?
+        example_inp_path = Path.cwd() / './xbout/tests/data/options/BOUT.inp'
+        opts = BoutOptions(example_inp_path)
+        assert opts.filepath.name == 'BOUT.inp'
+
+    def test_open(self, example_options_file):
+        opts = BoutOptions(example_options_file)
+        assert opts.filepath.name == 'BOUT.inp'
+
+    def test_repr(self, example_options_file):
+        opts_repr = repr(BoutOptions(example_options_file))
+        assert opts_repr == f"BoutOptions('{example_options_file}')"
+
+
+@pytest.mark.skip
+class TestAccess:
+    def test_get_sections(self):
+        ...
+
+    def test_get_values(self):
+        ...
+
+    def test_get_nested_section(self):
+        ...
+
+
+@pytest.mark.skip
+class TestWriting:
+    ...
+
+
+@pytest.mark.skip
+class TestRoundTrip:
+    ...
+
+
+@pytest.mark.skip
+class TestEval:
+    ...
+
+
+@pytest.mark.skip
+class TestSubstitution:
+    ...

--- a/xbout/tests/test_options.py
+++ b/xbout/tests/test_options.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from xbout.options import BoutOptions, BoutOptionsFile
+from xbout.options import OptionsTree, OptionsFile
 
 
 @pytest.fixture
@@ -13,7 +13,7 @@ def example_options_file(tmpdir_factory):
     """
 
     # Create options file
-    options = BoutOptions()
+    options = OptionsTree()
 
     # Fill it with example data
     options['top'] = {'timestep': '80',

--- a/xbout/tests/test_options.py
+++ b/xbout/tests/test_options.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 
@@ -80,7 +81,17 @@ class TestSection:
     def test_print(self, example_section):
         sect = example_section
         sect['naulin'] = {'iterations': '1000'}
-
+        expected = dedent("""\
+                          [laplace]
+                          |-- type = cyclic
+                          |-- global_flags = 0
+                          |-- inner_boundary_flags = 1
+                          |-- outer_boundary_flags = 16
+                          |-- include_yguards = false
+                          |-- [naulin]
+                          |-- |-- iterations = 1000
+                          """)
+        assert str(sect) == expected
 
 @pytest.fixture
 def example_options_tree():

--- a/xbout/tests/test_options.py
+++ b/xbout/tests/test_options.py
@@ -77,6 +77,10 @@ class TestSection:
 
         assert sect['naulin'].lineage() == 'laplace:naulin'
 
+    def test_print(self, example_section):
+        sect = example_section
+        sect['naulin'] = {'iterations': '1000'}
+
 
 @pytest.fixture
 def example_options_tree():
@@ -143,7 +147,6 @@ class TestAccess:
         assert opts['laplace']['type'] == 'cyclic'
         assert opts['laplace'].get('type') == 'cyclic'
 
-    @pytest.mark.xfail(reason="Nesting not yet implemented")
     def test_get_nested_section_values(self, example_options_tree):
         opts = OptionsTree(example_options_tree)
         assert opts['mesh']['ddx']['upwind'] == 'C2'

--- a/xbout/tests/test_options.py
+++ b/xbout/tests/test_options.py
@@ -5,52 +5,9 @@ import pytest
 from xbout.options import Section, OptionsTree, OptionsFile
 
 
-@pytest.fixture
-def example_options_file(tmpdir_factory):
-    """
-    Mocks up a temporary example BOUT.inp (or BOUT.settings) file, and returns
-    the path to it.
-    """
+from pprint import PrettyPrinter
 
-    # Create options file
-    options = OptionsTree()
-
-    # Fill it with example data
-    options['top'] = {'timestep': '80',
-                      'nout': '2000    # Number of outputted timesteps'}
-    options['mesh'] = {'Ly': '2000.0   # ~4m',
-                       'Lx': '400.0',
-                       'nx': '484      # including 4 guard cells',
-                       'ny': '1        # excluding guard cells',
-                       'dx': 'Lx/(nx-4)',
-                       'dy': 'Ly/ny'}
-    options['mesh:ddx'] = {'first': 'C2',
-                           'second': 'C2',
-                           'upwind': 'C2'}
-    options['laplace'] = {'type': 'cyclic',
-                          'global_flags': '0',
-                          'inner_boundary_flags': '1',
-                          'outer_boundary_flags': '16',
-                          'include_yguards': 'false'}
-    options['storm'] = {'B_0': '0.24          # Tesla',
-                        'T_e0': '15           # eV',
-                        'isothermal': 'true   # switch'}
-
-    # Create temporary directory
-    save_dir = tmpdir_factory.mktemp("inputdata")
-
-    # Save
-    optionsfilepath = save_dir.join('BOUT.inp')
-    options.write(optionsfilepath)
-
-    # Remove the first (and default) section headers to emulate BOUT.inp file format
-    # TODO do this without opening file 3 times
-    with open(optionsfilepath, 'r') as fin:
-        data = fin.read().splitlines(True)
-    with open(optionsfilepath, 'w') as fout:
-        fout.writelines(data[4:])
-
-    return Path(optionsfilepath)
+pp = PrettyPrinter()
 
 
 @pytest.fixture
@@ -82,7 +39,6 @@ class TestSection:
                                 keep_comments=True)
         assert with_comment == '16  # dirichlet'
 
-
     @pytest.mark.xfail(reason="Evaluate not yet implemented")
     def test_getitem(self, example_section):
         sect = example_section
@@ -97,17 +53,103 @@ class TestSection:
         sect['min'] = '100'
         assert sect.get('min', evaluate=False) == '100'
 
-    def test_nested(self, example_section):
+    def test_set_nested(self, example_section):
         sect = example_section
-        nested = Section('naulin', {'iterations': '1000'})
+        nested = Section('naulin', data={'iterations': '1000'})
         sect['naulin'] = nested
 
         assert isinstance(sect.get('naulin'), Section)
         assert sect.get('naulin').get('iterations', evaluate=False) == '1000'
+        assert sect['naulin']['iterations'] == '1000'
 
-        with pytest.raises(NotImplementedError):
-            assert sect['naulin']['iterations'] == '1000'
+    def test_set_nested_as_dict(self, example_section):
+        sect = example_section
+        sect['naulin'] = {'iterations': '1000'}
 
+        assert isinstance(sect.get('naulin'), Section)
+        assert sect.get('naulin').get('iterations', evaluate=False) == '1000'
+        assert sect['naulin']['iterations'] == '1000'
+        assert sect['naulin'].parent == 'laplace'
+
+    def test_find_parents(self, example_section):
+        sect = example_section
+        sect['naulin'] = {'iterations': '1000'}
+
+        assert sect['naulin'].lineage() == 'laplace:naulin'
+
+
+@pytest.fixture
+def example_options_tree():
+    """
+    Mocks up a temporary example BOUT.inp (or BOUT.settings) file, and returns
+    the path to it.
+    """
+
+    # Create options file
+    options = OptionsTree()
+
+    # Fill it with example data
+    options.data = {'timestep': '80',
+                    'nout': '2000    # Number of outputted timesteps'}
+    options['mesh'] = {'Ly': '2000.0   # ~4m',
+                       'Lx': '400.0',
+                       'nx': '484      # including 4 guard cells',
+                       'ny': '1        # excluding guard cells',
+                       'dx': 'Lx/(nx-4)',
+                       'dy': 'Ly/ny'}
+    options['mesh']['ddx'] = {'first': 'C2',
+                              'second': 'C2',
+                              'upwind': 'C2'}
+    options['laplace'] = {'type': 'cyclic',
+                          'global_flags': '0',
+                          'inner_boundary_flags': '1',
+                          'outer_boundary_flags': '16',
+                          'include_yguards': 'false'}
+    options['storm'] = {'B_0': '0.24          # Tesla',
+                        'T_e0': '15           # eV',
+                        'isothermal': 'true   # switch'}
+
+    return options
+
+"""
+def example_options_file():
+    # Create temporary directory
+    save_dir = tmpdir_factory.mktemp("inputdata")
+
+    # Save
+    optionsfilepath = save_dir.join('BOUT.inp')
+    options.write_to(optionsfilepath)
+
+    # Remove the first (and default) section headers to emulate BOUT.inp file format
+    # TODO do this without opening file 3 times
+    with open(optionsfilepath, 'r') as fin:
+        data = fin.read().splitlines(True)
+    with open(optionsfilepath, 'w') as fout:
+        fout.writelines(data[4:])
+
+    return Path(optionsfilepath)
+"""
+
+
+class TestAccess:
+    def test_get_sections(self, example_options_tree):
+        sections = OptionsTree(example_options_tree).sections()
+        sect_names = [section.lineage() for section in sections]
+        assert sect_names == ['root', 'mesh', 'mesh:ddx', 'laplace', 'storm']
+
+    def test_get_str_values(self, example_options_tree):
+        opts = OptionsTree(example_options_tree)
+        assert opts['laplace']['type'] == 'cyclic'
+        assert opts['laplace'].get('type') == 'cyclic'
+
+    @pytest.mark.xfail(reason="Nesting not yet implemented")
+    def test_get_nested_section_values(self, example_options_tree):
+        opts = OptionsTree(example_options_tree)
+        assert opts['mesh']['ddx']['upwind'] == 'C2'
+        assert opts['mesh']['ddx'].get('upwind') == 'C2'
+
+
+@pytest.mark.xfail
 class TestReadFile:
     def test_no_file(self):
         with pytest.raises(FileNotFoundError):
@@ -128,40 +170,21 @@ class TestReadFile:
         assert opts_repr == f"OptionsFile('{example_options_file}')"
 
 
-class TestAccess:
-    def test_get_sections(self, example_options_file):
-        sections = OptionsFile(example_options_file).sections()
-
-        # TODO for now ignore problem of nesting
-        #sections.remove('mesh:ddx')
-        assert sections == ['top', 'mesh', 'laplace', 'storm']
-
-    def test_get_str_values(self, example_options_file):
-        opts = OptionsFile(example_options_file)
-        assert opts['laplace']['type'] == 'cyclic'
-        assert opts['laplace'].get('type') == 'cyclic'
-
-    @pytest.mark.xfail(reason="Nesting not yet implemented")
-    def test_get_nested_section_values(self, example_options_file):
-        opts = OptionsFile(example_options_file)
-        assert opts['mesh']['ddx']['upwind'] == 'C2'
-        assert opts['mesh']['ddx'].get('upwind') == 'C2'
-
 
 @pytest.mark.xfail(reason='Type conversions not yet implemented')
 class TestTypeConversion:
-    def test_get_int_values(self, example_options_file):
-        opts = OptionsFile(example_options_file)
+    def test_get_int_values(self, example_options_tree):
+        opts = OptionsFile(example_options_tree)
         assert opts['mesh']['nx'] == 484
         assert opts['mesh'].get('nx') == 484
 
-    def test_get_float_values(self, example_options_file):
-        opts = OptionsFile(example_options_file)
+    def test_get_float_values(self, example_options_tree):
+        opts = OptionsFile(example_options_tree)
         assert opts['mesh']['Lx'] == 400.0
         assert opts['mesh'].get('Lx') == 400.0
 
-    def test_get_bool_values(self, example_options_file):
-        opts = OptionsFile(example_options_file)
+    def test_get_bool_values(self, example_options_tree):
+        opts = OptionsFile(example_options_tree)
         assert opts['storm']['isothermal'] == True
         assert opts['storm'].get('isothermal') == True
 

--- a/xbout/tests/test_options.py
+++ b/xbout/tests/test_options.py
@@ -14,7 +14,7 @@ def example_section():
                 'global_flags': '0',
                 'inner_boundary_flags': '1',
                 'outer_boundary_flags': '16  # dirichlet',
-                'include_yguards': 'false'}
+                'include_yguards': 'false  ; another comment'}
     return Section(name='laplace', data=contents)
 
 
@@ -26,16 +26,25 @@ class TestSection:
                              'global_flags': '0',
                              'inner_boundary_flags': '1',
                              'outer_boundary_flags': '16  # dirichlet',
-                             'include_yguards': 'false'}
+                             'include_yguards': 'false  ; another comment'}
 
     def test_get(self, example_section):
         sect = example_section
         assert sect.get('type') == 'cyclic'
 
+    def test_get_comments(self, example_section):
+        sect = example_section
+        # Comments marked by '#'
         assert sect.get('outer_boundary_flags') == '16'
         with_comment = sect.get('outer_boundary_flags', evaluate=False,
                                 keep_comments=True)
         assert with_comment == '16  # dirichlet'
+
+        # Comments marked by ';'
+        assert sect.get('include_yguards') == 'false'
+        with_other_comment = sect.get('include_yguards', evaluate=False,
+                                      keep_comments=True)
+        assert with_other_comment == 'false  ; another comment'
 
     def test_getitem(self, example_section):
         sect = example_section
@@ -105,7 +114,7 @@ class TestSection:
                           global_flags = 0
                           inner_boundary_flags = 1
                           outer_boundary_flags = 16  # dirichlet
-                          include_yguards = false
+                          include_yguards = false  ; another comment
                           
                           [laplace:naulin]
                           iterations = 1000

--- a/xbout/tests/test_options.py
+++ b/xbout/tests/test_options.py
@@ -78,7 +78,7 @@ class TestAccess:
         sections = BoutOptionsFile(example_options_file).sections()
 
         # TODO for now ignore problem of nesting
-        sections.remove('mesh:ddx')
+        #sections.remove('mesh:ddx')
         assert sections == ['top', 'mesh', 'laplace', 'storm']
 
     def test_get_str_values(self, example_options_file):

--- a/xbout/tests/test_options.py
+++ b/xbout/tests/test_options.py
@@ -134,8 +134,9 @@ def example_options_file():
 class TestAccess:
     def test_get_sections(self, example_options_tree):
         sections = OptionsTree(example_options_tree).sections()
-        sect_names = [section.lineage() for section in sections]
-        assert sect_names == ['root', 'mesh', 'mesh:ddx', 'laplace', 'storm']
+        lineages = [section.lineage() for section in sections]
+        assert lineages == ['root', 'root:mesh', 'root:mesh:ddx',
+                            'root:laplace', 'root:storm']
 
     def test_get_str_values(self, example_options_tree):
         opts = OptionsTree(example_options_tree)

--- a/xbout/tests/test_options.py
+++ b/xbout/tests/test_options.py
@@ -76,31 +76,36 @@ class TestReadFile:
 
 class TestAccess:
     def test_get_sections(self, example_options_file):
-        opts = BoutOptions(example_options_file)
-        assert opts.sections() == ['top', 'mesh', 'mesh:ddx',
-                                   'laplace', 'storm']
+        sections = BoutOptions(example_options_file).sections()
 
-    def test_get_nested_section(self):
-        ...
+        # TODO for now ignore problem of nesting
+        sections.remove('mesh:ddx')
+        assert sections == ['top', 'mesh', 'laplace', 'storm']
 
     def test_get_str_values(self, example_options_file):
         opts = BoutOptions(example_options_file)
         assert opts['laplace']['type'] == 'cyclic'
         assert opts['laplace'].get('type') == 'cyclic'
 
-    @pytest.mark.xfail(reason='Type conversions not yet implemented')
+    @pytest.mark.xfail(reason="Nesting not yet implemented")
+    def test_get_nested_section_values(self, example_options_file):
+        opts = BoutOptions(example_options_file)
+        assert opts['mesh']['ddx']['upwind'] == 'C2'
+        assert opts['mesh']['ddx'].get('upwind') == 'C2'
+
+
+@pytest.mark.xfail(reason='Type conversions not yet implemented')
+class TestTypeConversion:
     def test_get_int_values(self, example_options_file):
         opts = BoutOptions(example_options_file)
         assert opts['mesh']['nx'] == 484
         assert opts['mesh'].get('nx') == 484
 
-    @pytest.mark.xfail(reason='Type conversions not yet implemented')
     def test_get_float_values(self, example_options_file):
         opts = BoutOptions(example_options_file)
         assert opts['mesh']['Lx'] == 400.0
         assert opts['mesh'].get('Lx') == 400.0
 
-    @pytest.mark.xfail(reason='Type conversions not yet implemented')
     def test_get_bool_values(self, example_options_file):
         opts = BoutOptions(example_options_file)
         assert opts['storm']['isothermal'] == True


### PR DESCRIPTION
I'm trying to write a replacement BOUT Options File Parser to replace the [`boutdata.BoutOptionsFile`](https://github.com/boutproject/BOUT-dev/blob/master/tools/pylib/boutdata/data.py) class, which solves the issues in #94. The biggest difference is that this version has lots of tests.

Due to the bespoke structure of `BOUT.inp` files, I've ended up writing it from scratch, taking a lot of inspiration from the old class. For BOUT v5 I think the options file format should be changed to follow YAML strictly, but this is for until then.

Currently a work-in-progress, but feedback is welcome.