### PR TITLE
Save by pre-loading

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -3,6 +3,7 @@ from pprint import pformat as prettyformat
 from functools import partial
 from pathlib import Path
 import warnings
+import gc
 
 from xarray import register_dataset_accessor, save_mfdataset, merge
 import animatplot as amp
@@ -149,6 +150,11 @@ class BoutDatasetAccessor:
                 with ProgressBar():
                     single_var_ds.to_netcdf(path=str(var_savepath),
                                             format=filetype, compute=True)
+
+                # Force memory deallocation to limit RAM usage
+                single_var_ds.close()
+                del single_var_ds
+                gc.collect()
         else:
             # Save data to a single file
             print('Saving data...')

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -49,7 +49,7 @@ class BoutDatasetAccessor:
     #  self.prefix)
 
     def save(self, savepath='./boutdata.nc', filetype='NETCDF4',
-             variables=None, save_dtype=None, separate_vars=False):
+             variables=None, save_dtype=None, separate_vars=False, pre_load=False):
         """
         Save data variables to a netCDF file.
 
@@ -63,6 +63,9 @@ class BoutDatasetAccessor:
             If this is true then every variable which depends on time will be saved into a different output file.
             The files are labelled by the name of the variable. Variables which don't depend on time will be present in
             every output file.
+        pre_load : bool, optional
+            When saving separate variables, will load each variable into memory before
+            saving to file, which can be considerably faster.
         """
 
         if variables is None:
@@ -112,12 +115,16 @@ class BoutDatasetAccessor:
                   .format(str(time_dependent_vars)))
 
             # Save each one to separate file
+            # TODO perform the save in parallel with save_mfdataset?
             for var in time_dependent_vars:
                 # Group variables so that there is only one time-dependent
                 # variable saved in each file
                 time_independent_data = [to_save[time_ind_var] for
                                          time_ind_var in time_independent_vars]
                 single_var_ds = merge([to_save[var], *time_independent_data])
+
+                if pre_load:
+                    single_var_ds.load()
 
                 # Include the name of the variable in the name of the saved
                 # file

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -1,6 +1,7 @@
 import collections
 from pprint import pformat as prettyformat
 from functools import partial
+from pathlib import Path
 
 from xarray import register_dataset_accessor, save_mfdataset, merge
 import animatplot as amp
@@ -66,6 +67,13 @@ class BoutDatasetAccessor:
         pre_load : bool, optional
             When saving separate variables, will load each variable into memory before
             saving to file, which can be considerably faster.
+
+        Examples
+        --------
+        If `separate_vars=True`, then multiple files will be created. These can
+        all be opened and merged in one go using a call of the form:
+        
+        ds = xr.open_mfdataset('boutdata_*.nc', combine='nested', concat_dim=None)
         """
 
         if variables is None:
@@ -122,6 +130,9 @@ class BoutDatasetAccessor:
                 time_independent_data = [to_save[time_ind_var] for
                                          time_ind_var in time_independent_vars]
                 single_var_ds = merge([to_save[var], *time_independent_data])
+
+                # Add the attrs back on
+                single_var_ds.attrs = to_save.attrs
 
                 if pre_load:
                     single_var_ds.load()

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -13,8 +13,9 @@ from .utils import _set_attrs_on_all_vars, _separate_metadata, _check_filetype
 
 _BOUT_PER_PROC_VARIABLES = ['wall_time', 'wtime', 'wtime_rhs', 'wtime_invert',
                             'wtime_comms', 'wtime_io', 'wtime_per_rhs',
-                            'wtime_per_rhs_e', 'wtime_per_rhs_i', 'PE_XIND', 'PE_YIND',
-                            'MYPE']
+                            'wtime_per_rhs_e', 'wtime_per_rhs_i', 
+                            'iteration', 'hist_hi', 'tt',
+                            'PE_XIND', 'PE_YIND', 'MYPE']
 
 
 # This code should run whenever any function from this module is imported


### PR DESCRIPTION
Intended as a temporary solution to #69.

Calling `.load()` before `.to_netcdf()` is considerably quicker (for reasons I don't really understand), but loads data into memory. Therefore this PR basically does what the old squashoutput does: iterates over variables, loading each one into memory fully before saving it.