### PR TITLE
Reload squashed files

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -128,8 +128,8 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
         for var in _BOUT_TIME_DEPENDENT_META_VARS:
             if var in ds:
                 # Assume different processors in x & y have same iteration etc.
-                top_left = {dim: 0 for dim in ds[var].dims if dim != 't'}
-                ds[var] = ds[var].isel(top_left).squeeze(drop=True)
+                latest_top_left = {dim: 0 for dim in ds[var].dims}
+                ds[var] = ds[var].isel(latest_top_left).squeeze(drop=True)
 
     if inputfilepath:
         # Use Ben's options class to store all input file options
@@ -256,8 +256,8 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
         version = 0
 
     # Collect just stores iteration from BOUT.dmp.0 as a scalar
-    top_left = {dim: 0 for dim in ds['iteration'].dims if dim != 't'}
-    ds['iteration'] = ds['iteration'].isel(top_left).squeeze(drop=True)
+    latest_top_left = {dim: 0 for dim in ds['iteration'].dims}
+    ds['iteration'] = ds['iteration'].isel(latest_top_left).squeeze(drop=True)
 
     # Subtraction of z-dimensional data occurs in boutdata.collect
     # if BOUT++ version is old - same feature added here

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -126,7 +126,7 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
         if 'iteration' in ds:
             # Collect just stores most recent iteration as a scalar
             metadata['iteration'] = int(ds['iteration'].max())
-            ds =  ds.drop('iteration')
+            ds = ds.drop('iteration')
         ds = _set_attrs_on_all_vars(ds, 'metadata', metadata)
 
     if inputfilepath:

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -129,6 +129,8 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
             if var in ds:
                 # Assume different processors in x & y have same iteration etc.
                 latest_top_left = {dim: 0 for dim in ds[var].dims}
+                if 't' in ds[var].dims:
+                    latest_top_left['t'] = -1
                 ds[var] = ds[var].isel(latest_top_left).squeeze(drop=True)
 
     if inputfilepath:
@@ -254,10 +256,6 @@ def collect(varname, xind=None, yind=None, zind=None, tind=None,
     except KeyError:
         # If BOUT Version is not saved in the dataset
         version = 0
-
-    # Collect just stores iteration from BOUT.dmp.0 as a scalar
-    latest_top_left = {dim: 0 for dim in ds['iteration'].dims}
-    ds['iteration'] = ds['iteration'].isel(latest_top_left).squeeze(drop=True)
 
     # Subtraction of z-dimensional data occurs in boutdata.collect
     # if BOUT++ version is old - same feature added here

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -13,7 +13,8 @@ from natsort import natsorted
 
 from xbout.load import (_check_filetype, _expand_wildcards, _expand_filepaths,
                         _arrange_for_concatenation, _trim, _infer_contains_boundaries,
-                        open_boutdataset, _BOUT_PER_PROC_VARIABLES)
+                        open_boutdataset, _BOUT_PER_PROC_VARIABLES,
+                        _BOUT_TIME_DEPENDENT_META_VARS)
 from xbout.utils import _separate_metadata
 
 
@@ -400,7 +401,7 @@ def create_bout_grid_ds(xsize=2, ysize=4, guards={}):
 METADATA_VARS = ['BOUT_VERSION', 'NXPE', 'NYPE', 'NZPE', 'MXG', 'MYG', 'nx', 'ny', 'nz',
                  'MZ', 'MXSUB', 'MYSUB', 'MZSUB', 'ixseps1', 'ixseps2', 'jyseps1_1',
                  'jyseps1_2', 'jyseps2_1', 'jyseps2_2', 'ny_inner', 'zperiod', 'ZMIN',
-                 'ZMAX', 'dz', 'iteration']
+                 'ZMAX', 'dz']
 
 
 class TestStripMetadata():
@@ -411,7 +412,8 @@ class TestStripMetadata():
 
         ds, metadata = _separate_metadata(original)
 
-        assert original.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES,
+        assert original.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES
+                             + _BOUT_TIME_DEPENDENT_META_VARS,
                              errors='ignore').equals(ds)
         assert metadata['NXPE'] == 1
 
@@ -423,7 +425,8 @@ class TestOpen:
         actual = open_boutdataset(datapath=path, keep_xboundaries=False)
         expected = create_bout_ds()
         xrt.assert_equal(actual.load(),
-                         expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES,
+                         expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES
+                                       + _BOUT_TIME_DEPENDENT_META_VARS,
                                        errors='ignore'))
 
     def test_squashed_file(self, tmpdir_factory, bout_xyt_example_files):
@@ -432,7 +435,8 @@ class TestOpen:
         actual = open_boutdataset(datapath=path, keep_xboundaries=False)
         expected = create_bout_ds()
         xrt.assert_equal(actual.load(),
-                         expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES,
+                         expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES
+                                       + _BOUT_TIME_DEPENDENT_META_VARS,
                                        errors='ignore'))
 
     def test_combine_along_x(self, tmpdir_factory, bout_xyt_example_files):


### PR DESCRIPTION
Additional option for loading from files which were previously squashed using `ds.bout.save(separate_vars=True)`.