### PR TITLE
Bump minimum xarray version to 0.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
 env:
   - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0"
-  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.12.2 dask==1.0.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.13.0 dask==1.0.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages
 install:
   - pip install --upgrade ${PIP_PACKAGES}
   - pip install -r requirements.txt

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Requirements
 - :py:mod:`xbout` requires Python 3
 
 - The following modules are also needed:
-  - ``xarray >= v0.12.2``
+  - ``xarray >= v0.13.0``
   - ``dask[array] >= 1.0.0``
   - ``natsort >= 5.5.0``
   - ``matplotlib >= 2.2``

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-xarray >= 0.12.2
+xarray >= 0.13.0
 dask[array] >= 1.0.0
 natsort >= 5.5.0
 matplotlib >= 3.1.1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     license="Apache",
     python_requires='>=3.6',
     install_requires=[
-        'xarray>=v0.12.2',
+        'xarray>=v0.13.0',
         'dask[array]>=1.0.0',
         'natsort>=5.5.0',
         'matplotlib>=3.1.1',


### PR DESCRIPTION
I propose bumping the minimum version of xarray to 0.13.0. I want to use the 'join' kwarg for `concat` which was introduced in 0.13.0.