### PR TITLE
Define Regions and add method to get BoutDataArrays in a region

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0"
-  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.13.0 dask==1.0.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.13.0 dask==1.0.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3.
 install:
   - pip install --upgrade ${PIP_PACKAGES}
   - pip install -r requirements.txt

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -191,6 +191,9 @@ class BoutDataArrayAccessor:
                     da_inner = da_inner.assign_coords(**{xcoord: new_xcoord})
 
                 da = xr.concat((da_inner, da), xcoord, join='exact')
+                # xr.concat takes attributes from the first variable, but da should not
+                # have a region yet
+                del da.attrs['region']
             if region.connection_outer is not None:
                 da_outer = self.data.bout.fromRegion(region.connection_outer,
                                                      with_guards={xcoord: 0, ycoord:0})
@@ -208,6 +211,7 @@ class BoutDataArrayAccessor:
                     da_outer = da_outer.assign_coords(**{xcoord: new_xcoord})
 
                 da = xr.concat((da, da_outer), xcoord, join='exact')
+                # xr.concat takes attributes from the first variable, so region is OK
 
         if myg > 0:
             # get guard cells from y-neighbour regions
@@ -234,6 +238,9 @@ class BoutDataArrayAccessor:
                     da_lower = da_lower.assign_coords(**{ycoord: new_ycoord})
 
                 da = xr.concat((da_lower, da), ycoord, join='exact')
+                # xr.concat takes attributes from the first variable, but da should not
+                # have a region yet
+                del da.attrs['region']
             if region.connection_upper is not None:
                 da_upper = self.data.bout.fromRegion(region.connection_upper,
                                                      with_guards={xcoord: mxg, ycoord: 0})
@@ -256,6 +263,7 @@ class BoutDataArrayAccessor:
                     da_upper = da_upper.assign_coords(**{ycoord: new_ycoord})
 
                 da = xr.concat((da, da_upper), ycoord, join='exact')
+                # xr.concat takes attributes from the first variable, so region is OK
 
         da.attrs['region'] = region
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -221,6 +221,15 @@ class BoutDataArrayAccessor:
                 if ycoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated ones
                     xslice, yslice = region.getLowerGuardsSlices(myg)
+
+                    if yslice.start < 0:
+                        # For core-only or limiter topologies, the lower-y slice may be out of
+                        # the global array bounds
+                        raise ValueError('Trying to fill a slice which is not present '
+                                + 'in the global array, so do not have coordinate '
+                                + 'values for it. Try setting keep_yboundaries=True '
+                                + 'when calling open_boutdataset.')
+
                     new_ycoord = self.data[ycoord].isel(**{ycoord:yslice})
                     da_lower = da_lower.assign_coords(**{ycoord: new_ycoord})
 
@@ -235,6 +244,15 @@ class BoutDataArrayAccessor:
                 if ycoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated ones
                     xslice, yslice = region.getUpperGuardsSlices(myg)
+
+                    if yslice.stop > self.data.sizes[ycoord]:
+                        # For core-only or limiter topologies, the upper-y slice may be out of
+                        # the global array bounds
+                        raise ValueError('Trying to fill a slice which is not present '
+                                + 'in the global array, so do not have coordinate '
+                                + 'values for it. Try setting keep_yboundaries=True '
+                                + 'when calling open_boutdataset.')
+
                     new_ycoord = self.data[ycoord].isel(**{ycoord:yslice})
                     da_upper = da_upper.assign_coords(**{ycoord: new_ycoord})
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -165,8 +165,7 @@ class BoutDataArrayAccessor:
                 mxg = with_guards
                 myg = with_guards
 
-        xslice, yslice = region.get_slices()
-        da = self.data.isel(**{xcoord: xslice, ycoord: yslice})
+        da = self.data.isel(region.get_slices())
 
         if mxg > 0:
             myg_da = self.data.metadata['MYG']
@@ -223,9 +222,9 @@ class BoutDataArrayAccessor:
                 if xcoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated
                     # ones
-                    xslice, yslice = region.get_inner_guards_slices(mxg=mxg)
-                    new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
-                    new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
+                    slices = region.get_inner_guards_slices(mxg=mxg)
+                    new_xcoord = self.data[xcoord].isel(**{xcoord: slices[xcoord]})
+                    new_ycoord = self.data[ycoord].isel(**{ycoord: slices[ycoord]})
                     da_inner = da_inner.assign_coords(
                             **{xcoord: new_xcoord, ycoord: new_ycoord})
 
@@ -288,9 +287,9 @@ class BoutDataArrayAccessor:
                 if xcoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated
                     # ones
-                    xslice, yslice = region.get_outer_guards_slices(mxg=mxg)
-                    new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
-                    new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
+                    slices = region.get_outer_guards_slices(mxg=mxg)
+                    new_xcoord = self.data[xcoord].isel(**{xcoord: slices[xcoord]})
+                    new_ycoord = self.data[ycoord].isel(**{ycoord: slices[ycoord]})
                     da_outer = da_outer.assign_coords(
                             **{xcoord: new_xcoord, ycoord: new_ycoord})
 
@@ -309,9 +308,9 @@ class BoutDataArrayAccessor:
                 if ycoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated
                     # ones
-                    xslice, yslice = region.get_lower_guards_slices(mxg=mxg, myg=myg)
+                    slices = region.get_lower_guards_slices(mxg=mxg, myg=myg)
 
-                    if yslice.start < 0:
+                    if slices[ycoord].start < 0:
                         # For core-only or limiter topologies, the lower-y slice may be
                         # out of the global array bounds
                         raise ValueError('Trying to fill a slice which is not present '
@@ -320,8 +319,8 @@ class BoutDataArrayAccessor:
                                          + 'keep_yboundaries=True when calling '
                                          + 'open_boutdataset.')
 
-                    new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
-                    new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
+                    new_xcoord = self.data[xcoord].isel(**{xcoord: slices[xcoord]})
+                    new_ycoord = self.data[ycoord].isel(**{ycoord: slices[ycoord]})
                     da_lower = da_lower.assign_coords(
                             **{xcoord: new_xcoord, ycoord: new_ycoord})
 
@@ -341,9 +340,9 @@ class BoutDataArrayAccessor:
                 if ycoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated
                     # ones
-                    xslice, yslice = region.get_upper_guards_slices(mxg=mxg, myg=myg)
+                    slices = region.get_upper_guards_slices(mxg=mxg, myg=myg)
 
-                    if yslice.stop > self.data.sizes[ycoord]:
+                    if slices[ycoord].stop > self.data.sizes[ycoord]:
                         # For core-only or limiter topologies, the upper-y slice may be
                         # out of the global array bounds
                         raise ValueError('Trying to fill a slice which is not present '
@@ -352,8 +351,8 @@ class BoutDataArrayAccessor:
                                          + 'keep_yboundaries=True when calling '
                                          + 'open_boutdataset.')
 
-                    new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
-                    new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
+                    new_xcoord = self.data[xcoord].isel(**{xcoord: slices[xcoord]})
+                    new_ycoord = self.data[ycoord].isel(**{ycoord: slices[ycoord]})
                     da_upper = da_upper.assign_coords(
                             **{xcoord: new_xcoord, ycoord: new_ycoord})
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -190,7 +190,7 @@ class BoutDataArrayAccessor:
                     new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
                     da_inner = da_inner.assign_coords(**{xcoord: new_xcoord})
 
-                da = xr.concat((da_inner, da), xcoord)
+                da = xr.concat((da_inner, da), xcoord, join='exact')
             if region.connection_outer is not None:
                 da_outer = self.data.bout.fromRegion(region.connection_outer,
                                                      with_guards={xcoord: 0, ycoord:0})
@@ -207,7 +207,7 @@ class BoutDataArrayAccessor:
                     new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
                     da_outer = da_outer.assign_coords(**{xcoord: new_xcoord})
 
-                da = xr.concat((da, da_outer), xcoord)
+                da = xr.concat((da, da_outer), xcoord, join='exact')
 
         if myg > 0:
             # get guard cells from y-neighbour regions
@@ -233,7 +233,7 @@ class BoutDataArrayAccessor:
                     new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
                     da_lower = da_lower.assign_coords(**{ycoord: new_ycoord})
 
-                da = xr.concat((da_lower, da), ycoord)
+                da = xr.concat((da_lower, da), ycoord, join='exact')
             if region.connection_upper is not None:
                 da_upper = self.data.bout.fromRegion(region.connection_upper,
                                                      with_guards={xcoord: mxg, ycoord: 0})
@@ -255,7 +255,7 @@ class BoutDataArrayAccessor:
                     new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
                     da_upper = da_upper.assign_coords(**{ycoord: new_ycoord})
 
-                da = xr.concat((da, da_upper), ycoord)
+                da = xr.concat((da, da_upper), ycoord, join='exact')
 
         da.attrs['region'] = region
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from pprint import pformat as prettyformat
 from functools import partial
+import packaging.version
 
 import numpy as np
 
@@ -236,9 +237,12 @@ class BoutDataArrayAccessor:
                             **{xcoord: new_xcoord, ycoord: new_ycoord})
 
                 da = xr.concat((da_inner, da), xcoord, join='exact')
-                # xr.concat takes attributes from the first variable, but da should not
-                # have a region yet
-                del da.attrs['region']
+                # xr.concat takes attributes from the first variable (for xarray>=0.15.0,
+                # keeps attrs that are the same in all objects for xarray<0.15.0), but da
+                # should not have a region yet
+                if (packaging.version.parse(xr.__version__)
+                        >= packaging.version.parse("0.15.0")):
+                    del da.attrs['region']
             if region.connection_outer is not None:
                 da_outer = self.data.bout.fromRegion(region.connection_outer,
                                                      with_guards=0)
@@ -330,9 +334,12 @@ class BoutDataArrayAccessor:
                             **{xcoord: new_xcoord, ycoord: new_ycoord})
 
                 da = xr.concat((da_lower, da), ycoord, join='exact')
-                # xr.concat takes attributes from the first variable, but da should not
-                # have a region yet
-                del da.attrs['region']
+                # xr.concat takes attributes from the first variable (for xarray>=0.15.0,
+                # keeps attrs that are the same in all objects for xarray<0.15.0), but da
+                # should not have a region yet
+                if (packaging.version.parse(xr.__version__)
+                        >= packaging.version.parse("0.15.0")):
+                    del da.attrs['region']
             if region.connection_upper is not None:
                 da_upper = self.data.bout.fromRegion(
                         region.connection_upper, with_guards={xcoord: mxg, ycoord: 0})

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -172,8 +172,7 @@ class BoutDataArrayAccessor:
             myg_da = self.data.metadata['MYG']
             # get guard cells from x-neighbour regions
             if region.connection_inner is not None:
-                da_inner = self.data.bout.from_region(region.connection_inner,
-                                                     with_guards=0)
+                da_inner = self.from_region(region.connection_inner, with_guards=0)
 
                 if (myg_da > 0 and keep_yboundaries
                         and region.connection_lower is not None
@@ -197,8 +196,8 @@ class BoutDataArrayAccessor:
                     # da_inner may have fewer points in the y-direction, because it has a
                     # connection, not an actual boundary. Need to get the extra points
                     # from its connection
-                    da_inner_lower = self.data.bout.from_region(
-                                       da_inner.region.connection_lower, with_guards=0)
+                    da_inner_lower = self.from_region(da_inner.region.connection_lower,
+                                                      with_guards=0)
                     da_inner_lower = da_inner_lower.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(-myg_da, None)})
                     save_region = da_inner.region
@@ -213,8 +212,8 @@ class BoutDataArrayAccessor:
                     # da_inner may have fewer points in the y-direction, because it has a
                     # connection, not an actual boundary. Need to get the extra points
                     # from its connection
-                    da_inner_upper = self.data.bout.from_region(
-                                       da_inner.region.connection_upper, with_guards=0)
+                    da_inner_upper = self.from_region(da_inner.region.connection_upper,
+                                                      with_guards=0)
                     da_inner_upper = da_inner_upper.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(myg_da)})
                     da_inner = xr.concat((da_inner, da_inner_upper), ycoord,
@@ -238,8 +237,7 @@ class BoutDataArrayAccessor:
                         >= packaging.version.parse("0.15.0")):
                     del da.attrs['region']
             if region.connection_outer is not None:
-                da_outer = self.data.bout.from_region(region.connection_outer,
-                                                     with_guards=0)
+                da_outer = self.from_region(region.connection_outer, with_guards=0)
 
                 if (myg_da > 0 and keep_yboundaries
                         and region.connection_lower is not None
@@ -263,8 +261,8 @@ class BoutDataArrayAccessor:
                     # da_outer may have fewer points in the y-direction, because it has a
                     # connection, not an actual boundary. Need to get the extra points
                     # from its connection
-                    da_outer_lower = self.data.bout.from_region(
-                                       da_outer.region.connection_lower, with_guards=0)
+                    da_outer_lower = self.from_region(da_outer.region.connection_lower,
+                                                      with_guards=0)
                     da_outer_lower = da_outer_lower.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(-myg_da, None)})
                     save_region = da_outer.region
@@ -279,8 +277,8 @@ class BoutDataArrayAccessor:
                     # da_outer may have fewer points in the y-direction, because it has a
                     # connection, not an actual boundary. Need to get the extra points
                     # from its connection
-                    da_outer_upper = self.data.bout.from_region(
-                                       da_outer.region.connection_upper, with_guards=0)
+                    da_outer_upper = self.from_region(da_outer.region.connection_upper,
+                                                      with_guards=0)
                     da_outer_upper = da_outer_upper.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(myg_da)})
                     da_outer = xr.concat((da_outer, da_outer_upper), ycoord,
@@ -302,8 +300,8 @@ class BoutDataArrayAccessor:
         if myg > 0:
             # get guard cells from y-neighbour regions
             if region.connection_lower is not None:
-                da_lower = self.data.bout.from_region(
-                        region.connection_lower, with_guards={xcoord: mxg, ycoord: 0})
+                da_lower = self.from_region(region.connection_lower,
+                                            with_guards={xcoord: mxg, ycoord: 0})
 
                 # select just the points we need to fill the guard cells of da
                 da_lower = da_lower.isel(**{ycoord: slice(-myg, None)})
@@ -335,8 +333,8 @@ class BoutDataArrayAccessor:
                         >= packaging.version.parse("0.15.0")):
                     del da.attrs['region']
             if region.connection_upper is not None:
-                da_upper = self.data.bout.from_region(
-                        region.connection_upper, with_guards={xcoord: mxg, ycoord: 0})
+                da_upper = self.from_region(region.connection_upper,
+                                            with_guards={xcoord: mxg, ycoord: 0})
                 # select just the points we need to fill the guard cells of da
                 da_upper = da_upper.isel(**{ycoord: slice(myg)})
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -135,21 +135,21 @@ class BoutDataArrayAccessor:
         result["direction_y"] = "Standard"
         return result
 
-    def fromRegion(self, region, with_guards=None):
+    def fromRegion(self, name, with_guards=None):
         """
         Get a logically-rectangular section of data from a certain region.
         Includes guard cells from neighbouring regions.
 
         Parameters
         ----------
-        region : str
+        name : str
             Region to get data for
         with_guards : int or dict of int, optional
             Number of guard cells to include, by default use MXG and MYG from BOUT++.
             Pass a dict to set different numbers for different coordinates.
         """
 
-        region = self.data.regions[region]
+        region = self.data.regions[name]
         xcoord = self.data.metadata['bout_xdim']
         ycoord = self.data.metadata['bout_ydim']
         keep_yboundaries = self.data.metadata['keep_yboundaries']

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -135,7 +135,7 @@ class BoutDataArrayAccessor:
         result["direction_y"] = "Standard"
         return result
 
-    def fromRegion(self, name, with_guards=None):
+    def from_region(self, name, with_guards=None):
         """
         Get a logically-rectangular section of data from a certain region.
         Includes guard cells from neighbouring regions.
@@ -172,7 +172,7 @@ class BoutDataArrayAccessor:
             myg_da = self.data.metadata['MYG']
             # get guard cells from x-neighbour regions
             if region.connection_inner is not None:
-                da_inner = self.data.bout.fromRegion(region.connection_inner,
+                da_inner = self.data.bout.from_region(region.connection_inner,
                                                      with_guards=0)
 
                 if (myg_da > 0 and keep_yboundaries
@@ -197,7 +197,7 @@ class BoutDataArrayAccessor:
                     # da_inner may have fewer points in the y-direction, because it has a
                     # connection, not an actual boundary. Need to get the extra points
                     # from its connection
-                    da_inner_lower = self.data.bout.fromRegion(
+                    da_inner_lower = self.data.bout.from_region(
                                        da_inner.region.connection_lower, with_guards=0)
                     da_inner_lower = da_inner_lower.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(-myg_da, None)})
@@ -213,7 +213,7 @@ class BoutDataArrayAccessor:
                     # da_inner may have fewer points in the y-direction, because it has a
                     # connection, not an actual boundary. Need to get the extra points
                     # from its connection
-                    da_inner_upper = self.data.bout.fromRegion(
+                    da_inner_upper = self.data.bout.from_region(
                                        da_inner.region.connection_upper, with_guards=0)
                     da_inner_upper = da_inner_upper.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(myg_da)})
@@ -238,7 +238,7 @@ class BoutDataArrayAccessor:
                         >= packaging.version.parse("0.15.0")):
                     del da.attrs['region']
             if region.connection_outer is not None:
-                da_outer = self.data.bout.fromRegion(region.connection_outer,
+                da_outer = self.data.bout.from_region(region.connection_outer,
                                                      with_guards=0)
 
                 if (myg_da > 0 and keep_yboundaries
@@ -263,7 +263,7 @@ class BoutDataArrayAccessor:
                     # da_outer may have fewer points in the y-direction, because it has a
                     # connection, not an actual boundary. Need to get the extra points
                     # from its connection
-                    da_outer_lower = self.data.bout.fromRegion(
+                    da_outer_lower = self.data.bout.from_region(
                                        da_outer.region.connection_lower, with_guards=0)
                     da_outer_lower = da_outer_lower.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(-myg_da, None)})
@@ -279,7 +279,7 @@ class BoutDataArrayAccessor:
                     # da_outer may have fewer points in the y-direction, because it has a
                     # connection, not an actual boundary. Need to get the extra points
                     # from its connection
-                    da_outer_upper = self.data.bout.fromRegion(
+                    da_outer_upper = self.data.bout.from_region(
                                        da_outer.region.connection_upper, with_guards=0)
                     da_outer_upper = da_outer_upper.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(myg_da)})
@@ -302,7 +302,7 @@ class BoutDataArrayAccessor:
         if myg > 0:
             # get guard cells from y-neighbour regions
             if region.connection_lower is not None:
-                da_lower = self.data.bout.fromRegion(
+                da_lower = self.data.bout.from_region(
                         region.connection_lower, with_guards={xcoord: mxg, ycoord: 0})
 
                 # select just the points we need to fill the guard cells of da
@@ -335,7 +335,7 @@ class BoutDataArrayAccessor:
                         >= packaging.version.parse("0.15.0")):
                     del da.attrs['region']
             if region.connection_upper is not None:
-                da_upper = self.data.bout.fromRegion(
+                da_upper = self.data.bout.from_region(
                         region.connection_upper, with_guards={xcoord: mxg, ycoord: 0})
                 # select just the points we need to fill the guard cells of da
                 da_upper = da_upper.isel(**{ycoord: slice(myg)})

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -223,7 +223,7 @@ class BoutDataArrayAccessor:
                 if xcoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated
                     # ones
-                    xslice, yslice = region.getInnerGuardsSlices(mxg=mxg)
+                    xslice, yslice = region.get_inner_guards_slices(mxg=mxg)
                     new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
                     new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
                     da_inner = da_inner.assign_coords(
@@ -288,7 +288,7 @@ class BoutDataArrayAccessor:
                 if xcoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated
                     # ones
-                    xslice, yslice = region.getOuterGuardsSlices(mxg=mxg)
+                    xslice, yslice = region.get_outer_guards_slices(mxg=mxg)
                     new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
                     new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
                     da_outer = da_outer.assign_coords(
@@ -309,7 +309,7 @@ class BoutDataArrayAccessor:
                 if ycoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated
                     # ones
-                    xslice, yslice = region.getLowerGuardsSlices(mxg=mxg, myg=myg)
+                    xslice, yslice = region.get_lower_guards_slices(mxg=mxg, myg=myg)
 
                     if yslice.start < 0:
                         # For core-only or limiter topologies, the lower-y slice may be
@@ -341,7 +341,7 @@ class BoutDataArrayAccessor:
                 if ycoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated
                     # ones
-                    xslice, yslice = region.getUpperGuardsSlices(mxg=mxg, myg=myg)
+                    xslice, yslice = region.get_upper_guards_slices(mxg=mxg, myg=myg)
 
                     if yslice.stop > self.data.sizes[ycoord]:
                         # For core-only or limiter topologies, the upper-y slice may be

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -230,14 +230,13 @@ class BoutDataArrayAccessor:
                                 + 'values for it. Try setting keep_yboundaries=True '
                                 + 'when calling open_boutdataset.')
 
-                    new_ycoord = self.data[ycoord].isel(**{ycoord:yslice})
+                    new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
                     da_lower = da_lower.assign_coords(**{ycoord: new_ycoord})
 
                 da = xr.concat((da_lower, da), ycoord)
             if region.connection_upper is not None:
                 da_upper = self.data.bout.fromRegion(region.connection_upper,
-                                                     with_guards={xcoord: mxg, ycoord:0})
-
+                                                     with_guards={xcoord: mxg, ycoord: 0})
                 # select just the points we need to fill the guard cells of da
                 da_upper = da_upper.isel(**{ycoord: slice(myg)})
 
@@ -253,7 +252,7 @@ class BoutDataArrayAccessor:
                                 + 'values for it. Try setting keep_yboundaries=True '
                                 + 'when calling open_boutdataset.')
 
-                    new_ycoord = self.data[ycoord].isel(**{ycoord:yslice})
+                    new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
                     da_upper = da_upper.assign_coords(**{ycoord: new_ycoord})
 
                 da = xr.concat((da, da_upper), ycoord)

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -178,7 +178,7 @@ class BoutDataArrayAccessor:
             # get guard cells from x-neighbour regions
             if region.connection_inner is not None:
                 da_inner = self.data.bout.fromRegion(region.connection_inner,
-                                                     with_guards={xcoord: 0, ycoord:0})
+                                                     with_guards=0)
 
                 if (myg_da > 0 and keep_yboundaries
                         and region.connection_lower is not None
@@ -238,7 +238,7 @@ class BoutDataArrayAccessor:
                 del da.attrs['region']
             if region.connection_outer is not None:
                 da_outer = self.data.bout.fromRegion(region.connection_outer,
-                                                     with_guards={xcoord: 0, ycoord:0})
+                                                     with_guards=0)
 
                 if (myg_da > 0 and keep_yboundaries
                         and region.connection_lower is not None

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -10,6 +10,7 @@ from xarray import register_dataarray_accessor
 from .plotting.animate import animate_poloidal, animate_pcolormesh, animate_line
 from .plotting import plotfuncs
 from .plotting.utils import _create_norm
+from .region import Region
 
 
 @register_dataarray_accessor('bout')
@@ -239,8 +240,9 @@ class BoutDataArrayAccessor:
 
                 da = xr.concat((da, da_upper), ycoord)
 
-        return da
+        da.attrs['region'] = region
 
+        return da
 
     def animate2D(self, animate_over='t', x=None, y=None, animate=True, fps=10,
                   save_as=None, ax=None, poloidal_plot=False, logscale=None, **kwargs):

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from pprint import pformat as prettyformat
 from functools import partial
-import packaging.version
 
 import numpy as np
 
@@ -11,7 +10,8 @@ from xarray import register_dataarray_accessor
 from .plotting.animate import animate_poloidal, animate_pcolormesh, animate_line
 from .plotting import plotfuncs
 from .plotting.utils import _create_norm
-from .region import Region
+from .region import (Region, _concat_inner_guards, _concat_outer_guards,
+                     _concat_lower_guards, _concat_upper_guards)
 
 
 @register_dataarray_accessor('bout')
@@ -152,7 +152,6 @@ class BoutDataArrayAccessor:
         region = self.data.regions[name]
         xcoord = self.data.metadata['bout_xdim']
         ycoord = self.data.metadata['bout_ydim']
-        keep_yboundaries = self.data.metadata['keep_yboundaries']
 
         if with_guards is None:
             mxg = self.data.metadata['MXG']
@@ -166,200 +165,23 @@ class BoutDataArrayAccessor:
                 myg = with_guards
 
         da = self.data.isel(region.get_slices())
+        da.attrs['region'] = region
 
         if mxg > 0:
-            myg_da = self.data.metadata['MYG']
-            # get guard cells from x-neighbour regions
             if region.connection_inner is not None:
-                da_inner = self.from_region(region.connection_inner, with_guards=0)
-
-                if (myg_da > 0 and keep_yboundaries
-                        and region.connection_lower is not None
-                        and da_inner.region.connection_lower is None):
-                    # da_inner may have more points in the y-direction, because it has an
-                    # actual boundary, not a connection. Need to remove any extra points
-                    da_inner = da_inner.isel(**{ycoord: slice(myg_da, None)})
-                if (myg_da > 0 and keep_yboundaries
-                        and region.connection_upper is not None
-                        and da_inner.region.connection_upper is None):
-                    # da_inner may have more points in the y-direction, because it has an
-                    # actual boundary, not a connection. Need to remove any extra points
-                    da_inner = da_inner.isel(**{ycoord: slice(None, -myg_da)})
-
-                # select just the points we need to fill the guard cells of da
-                da_inner = da_inner.isel(**{xcoord: slice(-mxg, None)})
-
-                if (myg_da > 0 and keep_yboundaries
-                        and region.connection_lower is None
-                        and da_inner.region.connection_lower is not None):
-                    # da_inner may have fewer points in the y-direction, because it has a
-                    # connection, not an actual boundary. Need to get the extra points
-                    # from its connection
-                    da_inner_lower = self.from_region(da_inner.region.connection_lower,
-                                                      with_guards=0)
-                    da_inner_lower = da_inner_lower.isel(
-                            **{xcoord: slice(-mxg, None), ycoord: slice(-myg_da, None)})
-                    save_region = da_inner.region
-                    da_inner = xr.concat((da_inner_lower, da_inner), ycoord,
-                                         join='exact')
-                    # xr.concat takes attributes from the first variable, but we need
-                    # da_inner's region
-                    da_inner.attrs['region'] = save_region
-                if (myg_da > 0 and keep_yboundaries
-                        and region.connection_upper is None
-                        and da_inner.region.connection_upper is not None):
-                    # da_inner may have fewer points in the y-direction, because it has a
-                    # connection, not an actual boundary. Need to get the extra points
-                    # from its connection
-                    da_inner_upper = self.from_region(da_inner.region.connection_upper,
-                                                      with_guards=0)
-                    da_inner_upper = da_inner_upper.isel(
-                            **{xcoord: slice(-mxg, None), ycoord: slice(myg_da)})
-                    da_inner = xr.concat((da_inner, da_inner_upper), ycoord,
-                                         join='exact')
-                    # xr.concat takes attributes from the first variable, so region is OK
-
-                if xcoord in da.coords:
-                    # Use local coordinates for neighbouring region, not communicated
-                    # ones
-                    slices = region.get_inner_guards_slices(mxg=mxg)
-                    new_xcoord = self.data[xcoord].isel(**{xcoord: slices[xcoord]})
-                    new_ycoord = self.data[ycoord].isel(**{ycoord: slices[ycoord]})
-                    da_inner = da_inner.assign_coords(
-                            **{xcoord: new_xcoord, ycoord: new_ycoord})
-
-                da = xr.concat((da_inner, da), xcoord, join='exact')
-                # xr.concat takes attributes from the first variable (for xarray>=0.15.0,
-                # keeps attrs that are the same in all objects for xarray<0.15.0), but da
-                # should not have a region yet
-                if (packaging.version.parse(xr.__version__)
-                        >= packaging.version.parse("0.15.0")):
-                    del da.attrs['region']
+                # get inner x-guard cells for da from the global array
+                da = _concat_inner_guards(da, self.data, mxg)
             if region.connection_outer is not None:
-                da_outer = self.from_region(region.connection_outer, with_guards=0)
-
-                if (myg_da > 0 and keep_yboundaries
-                        and region.connection_lower is not None
-                        and da_outer.region.connection_lower is None):
-                    # da_outer may have more points in the y-direction, because it has an
-                    # actual boundary, not a connection. Need to remove any extra points
-                    da_outer = da_outer.isel(**{ycoord: slice(myg_da, None)})
-                if (myg_da > 0 and keep_yboundaries
-                        and region.connection_upper is not None
-                        and da_outer.region.connection_upper is None):
-                    # da_outer may have more points in the y-direction, because it has an
-                    # actual boundary, not a connection. Need to remove any extra points
-                    da_outer = da_outer.isel(**{ycoord: slice(None, -myg_da)})
-
-                # select just the points we need to fill the guard cells of da
-                da_outer = da_outer.isel(**{xcoord: slice(mxg)})
-
-                if (myg_da > 0 and keep_yboundaries
-                        and region.connection_lower is None
-                        and da_outer.region.connection_lower is not None):
-                    # da_outer may have fewer points in the y-direction, because it has a
-                    # connection, not an actual boundary. Need to get the extra points
-                    # from its connection
-                    da_outer_lower = self.from_region(da_outer.region.connection_lower,
-                                                      with_guards=0)
-                    da_outer_lower = da_outer_lower.isel(
-                            **{xcoord: slice(-mxg, None), ycoord: slice(-myg_da, None)})
-                    save_region = da_outer.region
-                    da_outer = xr.concat((da_outer_lower, da_outer), ycoord,
-                                         join='exact')
-                    # xr.concat takes attributes from the first variable, but we need
-                    # da_outer's region
-                    da_outer.attrs['region'] = save_region
-                if (myg_da > 0 and keep_yboundaries
-                        and region.connection_upper is None
-                        and da_outer.region.connection_upper is not None):
-                    # da_outer may have fewer points in the y-direction, because it has a
-                    # connection, not an actual boundary. Need to get the extra points
-                    # from its connection
-                    da_outer_upper = self.from_region(da_outer.region.connection_upper,
-                                                      with_guards=0)
-                    da_outer_upper = da_outer_upper.isel(
-                            **{xcoord: slice(-mxg, None), ycoord: slice(myg_da)})
-                    da_outer = xr.concat((da_outer, da_outer_upper), ycoord,
-                                         join='exact')
-                    # xr.concat takes attributes from the first variable, so region is OK
-
-                if xcoord in da.coords:
-                    # Use local coordinates for neighbouring region, not communicated
-                    # ones
-                    slices = region.get_outer_guards_slices(mxg=mxg)
-                    new_xcoord = self.data[xcoord].isel(**{xcoord: slices[xcoord]})
-                    new_ycoord = self.data[ycoord].isel(**{ycoord: slices[ycoord]})
-                    da_outer = da_outer.assign_coords(
-                            **{xcoord: new_xcoord, ycoord: new_ycoord})
-
-                da = xr.concat((da, da_outer), xcoord, join='exact')
-                # xr.concat takes attributes from the first variable, so region is OK
+                # get outer x-guard cells for da from the global array
+                da = _concat_outer_guards(da, self.data, mxg)
 
         if myg > 0:
-            # get guard cells from y-neighbour regions
             if region.connection_lower is not None:
-                da_lower = self.from_region(region.connection_lower,
-                                            with_guards={xcoord: mxg, ycoord: 0})
-
-                # select just the points we need to fill the guard cells of da
-                da_lower = da_lower.isel(**{ycoord: slice(-myg, None)})
-
-                if ycoord in da.coords:
-                    # Use local coordinates for neighbouring region, not communicated
-                    # ones
-                    slices = region.get_lower_guards_slices(mxg=mxg, myg=myg)
-
-                    if slices[ycoord].start < 0:
-                        # For core-only or limiter topologies, the lower-y slice may be
-                        # out of the global array bounds
-                        raise ValueError('Trying to fill a slice which is not present '
-                                         + 'in the global array, so do not have '
-                                         + 'coordinate values for it. Try setting '
-                                         + 'keep_yboundaries=True when calling '
-                                         + 'open_boutdataset.')
-
-                    new_xcoord = self.data[xcoord].isel(**{xcoord: slices[xcoord]})
-                    new_ycoord = self.data[ycoord].isel(**{ycoord: slices[ycoord]})
-                    da_lower = da_lower.assign_coords(
-                            **{xcoord: new_xcoord, ycoord: new_ycoord})
-
-                da = xr.concat((da_lower, da), ycoord, join='exact')
-                # xr.concat takes attributes from the first variable (for xarray>=0.15.0,
-                # keeps attrs that are the same in all objects for xarray<0.15.0), but da
-                # should not have a region yet
-                if (packaging.version.parse(xr.__version__)
-                        >= packaging.version.parse("0.15.0")):
-                    del da.attrs['region']
+                # get lower y-guard cells from the global array
+                da = _concat_lower_guards(da, self.data, mxg, myg)
             if region.connection_upper is not None:
-                da_upper = self.from_region(region.connection_upper,
-                                            with_guards={xcoord: mxg, ycoord: 0})
-                # select just the points we need to fill the guard cells of da
-                da_upper = da_upper.isel(**{ycoord: slice(myg)})
-
-                if ycoord in da.coords:
-                    # Use local coordinates for neighbouring region, not communicated
-                    # ones
-                    slices = region.get_upper_guards_slices(mxg=mxg, myg=myg)
-
-                    if slices[ycoord].stop > self.data.sizes[ycoord]:
-                        # For core-only or limiter topologies, the upper-y slice may be
-                        # out of the global array bounds
-                        raise ValueError('Trying to fill a slice which is not present '
-                                         + 'in the global array, so do not have '
-                                         + 'coordinate values for it. Try setting '
-                                         + 'keep_yboundaries=True when calling '
-                                         + 'open_boutdataset.')
-
-                    new_xcoord = self.data[xcoord].isel(**{xcoord: slices[xcoord]})
-                    new_ycoord = self.data[ycoord].isel(**{ycoord: slices[ycoord]})
-                    da_upper = da_upper.assign_coords(
-                            **{xcoord: new_xcoord, ycoord: new_ycoord})
-
-                da = xr.concat((da, da_upper), ycoord, join='exact')
-                # xr.concat takes attributes from the first variable, so region is OK
-
-        da.attrs['region'] = region
+                # get upper y-guard cells from the global array
+                da = _concat_upper_guards(da, self.data, mxg, myg)
 
         return da
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -159,15 +159,9 @@ class BoutDataArrayAccessor:
             myg = self.data.metadata['MYG']
         else:
             try:
-                try:
-                    mxg = with_guards[xcoord]
-                except KeyError:
-                    mxg = self.data.metadata['MXG']
-                try:
-                    myg = with_guards[ycoord]
-                except KeyError:
-                    myg = self.data.metadata['MYG']
-            except TypeError:
+                mxg = with_guards.get(xcoord, self.data.metadata['MXG'])
+                myg = with_guards.get(ycoord, self.data.metadata['MYG'])
+            except AttributeError:
                 mxg = with_guards
                 myg = with_guards
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -90,7 +90,7 @@ class BoutDataArrayAccessor:
         for dim in phases.dims:
             extra_dims.remove(dim)
         phases = phases.expand_dims(extra_dims)
-        phases = phases.transpose(*fft_dims)
+        phases = phases.transpose(*fft_dims, transpose_coords=True)
 
         data_shifted_fft = data_fft * np.exp(phases.values)
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -144,8 +144,8 @@ class BoutDataArrayAccessor:
         region : str
             Region to get data for
         with_guards : int or dict of int, optional
-            Number of guard cells to include, by default use MXG and MYG from BOUT++. Pass
-            a dict to set different numbers for different coordinates.
+            Number of guard cells to include, by default use MXG and MYG from BOUT++.
+            Pass a dict to set different numbers for different coordinates.
         """
 
         region = self.data.regions[region]
@@ -207,7 +207,8 @@ class BoutDataArrayAccessor:
                     da_inner_lower = da_inner_lower.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(-myg_da, None)})
                     save_region = da_inner.region
-                    da_inner = xr.concat((da_inner_lower, da_inner), ycoord, join='exact')
+                    da_inner = xr.concat((da_inner_lower, da_inner), ycoord,
+                                         join='exact')
                     # xr.concat takes attributes from the first variable, but we need
                     # da_inner's region
                     da_inner.attrs['region'] = save_region
@@ -221,11 +222,13 @@ class BoutDataArrayAccessor:
                                        da_inner.region.connection_upper, with_guards=0)
                     da_inner_upper = da_inner_upper.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(myg_da)})
-                    da_inner = xr.concat((da_inner, da_inner_upper), ycoord, join='exact')
+                    da_inner = xr.concat((da_inner, da_inner_upper), ycoord,
+                                         join='exact')
                     # xr.concat takes attributes from the first variable, so region is OK
 
                 if xcoord in da.coords:
-                    # Use local coordinates for neighbouring region, not communicated ones
+                    # Use local coordinates for neighbouring region, not communicated
+                    # ones
                     xslice, yslice = region.getInnerGuardsSlices(mxg=mxg)
                     new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
                     new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
@@ -267,7 +270,8 @@ class BoutDataArrayAccessor:
                     da_outer_lower = da_outer_lower.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(-myg_da, None)})
                     save_region = da_outer.region
-                    da_outer = xr.concat((da_outer_lower, da_outer), ycoord, join='exact')
+                    da_outer = xr.concat((da_outer_lower, da_outer), ycoord,
+                                         join='exact')
                     # xr.concat takes attributes from the first variable, but we need
                     # da_outer's region
                     da_outer.attrs['region'] = save_region
@@ -281,11 +285,13 @@ class BoutDataArrayAccessor:
                                        da_outer.region.connection_upper, with_guards=0)
                     da_outer_upper = da_outer_upper.isel(
                             **{xcoord: slice(-mxg, None), ycoord: slice(myg_da)})
-                    da_outer = xr.concat((da_outer, da_outer_upper), ycoord, join='exact')
+                    da_outer = xr.concat((da_outer, da_outer_upper), ycoord,
+                                         join='exact')
                     # xr.concat takes attributes from the first variable, so region is OK
 
                 if xcoord in da.coords:
-                    # Use local coordinates for neighbouring region, not communicated ones
+                    # Use local coordinates for neighbouring region, not communicated
+                    # ones
                     xslice, yslice = region.getOuterGuardsSlices(mxg=mxg)
                     new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
                     new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
@@ -298,23 +304,25 @@ class BoutDataArrayAccessor:
         if myg > 0:
             # get guard cells from y-neighbour regions
             if region.connection_lower is not None:
-                da_lower = self.data.bout.fromRegion(region.connection_lower,
-                                                     with_guards={xcoord: mxg, ycoord:0})
+                da_lower = self.data.bout.fromRegion(
+                        region.connection_lower, with_guards={xcoord: mxg, ycoord: 0})
 
                 # select just the points we need to fill the guard cells of da
                 da_lower = da_lower.isel(**{ycoord: slice(-myg, None)})
 
                 if ycoord in da.coords:
-                    # Use local coordinates for neighbouring region, not communicated ones
+                    # Use local coordinates for neighbouring region, not communicated
+                    # ones
                     xslice, yslice = region.getLowerGuardsSlices(mxg=mxg, myg=myg)
 
                     if yslice.start < 0:
-                        # For core-only or limiter topologies, the lower-y slice may be out of
-                        # the global array bounds
+                        # For core-only or limiter topologies, the lower-y slice may be
+                        # out of the global array bounds
                         raise ValueError('Trying to fill a slice which is not present '
-                                + 'in the global array, so do not have coordinate '
-                                + 'values for it. Try setting keep_yboundaries=True '
-                                + 'when calling open_boutdataset.')
+                                         + 'in the global array, so do not have '
+                                         + 'coordinate values for it. Try setting '
+                                         + 'keep_yboundaries=True when calling '
+                                         + 'open_boutdataset.')
 
                     new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
                     new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})
@@ -326,22 +334,24 @@ class BoutDataArrayAccessor:
                 # have a region yet
                 del da.attrs['region']
             if region.connection_upper is not None:
-                da_upper = self.data.bout.fromRegion(region.connection_upper,
-                                                     with_guards={xcoord: mxg, ycoord: 0})
+                da_upper = self.data.bout.fromRegion(
+                        region.connection_upper, with_guards={xcoord: mxg, ycoord: 0})
                 # select just the points we need to fill the guard cells of da
                 da_upper = da_upper.isel(**{ycoord: slice(myg)})
 
                 if ycoord in da.coords:
-                    # Use local coordinates for neighbouring region, not communicated ones
+                    # Use local coordinates for neighbouring region, not communicated
+                    # ones
                     xslice, yslice = region.getUpperGuardsSlices(mxg=mxg, myg=myg)
 
                     if yslice.stop > self.data.sizes[ycoord]:
-                        # For core-only or limiter topologies, the upper-y slice may be out of
-                        # the global array bounds
+                        # For core-only or limiter topologies, the upper-y slice may be
+                        # out of the global array bounds
                         raise ValueError('Trying to fill a slice which is not present '
-                                + 'in the global array, so do not have coordinate '
-                                + 'values for it. Try setting keep_yboundaries=True '
-                                + 'when calling open_boutdataset.')
+                                         + 'in the global array, so do not have '
+                                         + 'coordinate values for it. Try setting '
+                                         + 'keep_yboundaries=True when calling '
+                                         + 'open_boutdataset.')
 
                     new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
                     new_ycoord = self.data[ycoord].isel(**{ycoord: yslice})

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -165,21 +165,18 @@ class BoutDataArrayAccessor:
         da = self.data.isel(region.get_slices())
         da.attrs['region'] = region
 
-        if mxg > 0:
-            if region.connection_inner is not None:
-                # get inner x-guard cells for da from the global array
-                da = _concat_inner_guards(da, self.data, mxg)
-            if region.connection_outer is not None:
-                # get outer x-guard cells for da from the global array
-                da = _concat_outer_guards(da, self.data, mxg)
-
-        if myg > 0:
-            if region.connection_lower is not None:
-                # get lower y-guard cells from the global array
-                da = _concat_lower_guards(da, self.data, mxg, myg)
-            if region.connection_upper is not None:
-                # get upper y-guard cells from the global array
-                da = _concat_upper_guards(da, self.data, mxg, myg)
+        if region.connection_inner is not None:
+            # get inner x-guard cells for da from the global array
+            da = _concat_inner_guards(da, self.data, mxg)
+        if region.connection_outer is not None:
+            # get outer x-guard cells for da from the global array
+            da = _concat_outer_guards(da, self.data, mxg)
+        if region.connection_lower is not None:
+            # get lower y-guard cells from the global array
+            da = _concat_lower_guards(da, self.data, mxg, myg)
+        if region.connection_upper is not None:
+            # get upper y-guard cells from the global array
+            da = _concat_upper_guards(da, self.data, mxg, myg)
 
         return da
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -165,16 +165,16 @@ class BoutDataArrayAccessor:
         da = self.data.isel(region.get_slices())
         da.attrs['region'] = region
 
-        if region.connection_inner is not None:
+        if region.connection_inner_x is not None:
             # get inner x-guard cells for da from the global array
             da = _concat_inner_guards(da, self.data, mxg)
-        if region.connection_outer is not None:
+        if region.connection_outer_x is not None:
             # get outer x-guard cells for da from the global array
             da = _concat_outer_guards(da, self.data, mxg)
-        if region.connection_lower is not None:
+        if region.connection_lower_y is not None:
             # get lower y-guard cells from the global array
             da = _concat_lower_guards(da, self.data, mxg, myg)
-        if region.connection_upper is not None:
+        if region.connection_upper_y is not None:
             # get upper y-guard cells from the global array
             da = _concat_upper_guards(da, self.data, mxg, myg)
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -165,7 +165,7 @@ class BoutDataArrayAccessor:
                 mxg = with_guards
                 myg = with_guards
 
-        xslice, yslice = region.getSlices()
+        xslice, yslice = region.get_slices()
         da = self.data.isel(**{xcoord: xslice, ycoord: yslice})
 
         if mxg > 0:

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -186,7 +186,7 @@ class BoutDataArrayAccessor:
                     # Note, at the moment this should do nothing, because all neigbours in the
                     # x-direction are contiguous in the global array anyway, but included to
                     # be future-proof
-                    xslice, yslice = region.getInnerGuardsSlices(mxg)
+                    xslice, yslice = region.getInnerGuardsSlices(mxg=mxg)
                     new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
                     da_inner = da_inner.assign_coords(**{xcoord: new_xcoord})
 
@@ -206,7 +206,7 @@ class BoutDataArrayAccessor:
                     # Note, at the moment this should do nothing, because all neigbours in the
                     # x-direction are contiguous in the global array anyway, but included to
                     # be future-proof
-                    xslice, yslice = region.getOuterGuardsSlices(mxg)
+                    xslice, yslice = region.getOuterGuardsSlices(mxg=mxg)
                     new_xcoord = self.data[xcoord].isel(**{xcoord: xslice})
                     da_outer = da_outer.assign_coords(**{xcoord: new_xcoord})
 
@@ -224,7 +224,7 @@ class BoutDataArrayAccessor:
 
                 if ycoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated ones
-                    xslice, yslice = region.getLowerGuardsSlices(myg)
+                    xslice, yslice = region.getLowerGuardsSlices(mxg=mxg, myg=myg)
 
                     if yslice.start < 0:
                         # For core-only or limiter topologies, the lower-y slice may be out of
@@ -249,7 +249,7 @@ class BoutDataArrayAccessor:
 
                 if ycoord in da.coords:
                     # Use local coordinates for neighbouring region, not communicated ones
-                    xslice, yslice = region.getUpperGuardsSlices(myg)
+                    xslice, yslice = region.getUpperGuardsSlices(mxg=mxg, myg=myg)
 
                     if yslice.stop > self.data.sizes[ycoord]:
                         # For core-only or limiter topologies, the upper-y slice may be out of

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -158,13 +158,14 @@ class BoutDatasetAccessor:
             except KeyError:
                 pass
 
-        # Do not need to save regions as these can be reconstructed from the metadata
-        del to_save.attrs['regions']
-        for var in chain(to_save.data_vars, to_save.coords):
-            try:
-                del to_save[var].attrs['regions']
-            except KeyError:
-                pass
+        if 'regions' in to_save.attrs:
+            # Do not need to save regions as these can be reconstructed from the metadata
+            del to_save.attrs['regions']
+            for var in chain(to_save.data_vars, to_save.coords):
+                try:
+                    del to_save[var].attrs['regions']
+                except KeyError:
+                    pass
 
         if separate_vars:
             # Save each major variable to a different netCDF file

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -148,6 +148,14 @@ class BoutDatasetAccessor:
             except KeyError:
                 pass
 
+        # Do not need to save regions as these can be reconstructed from the metadata
+        del to_save.attrs['regions']
+        for var in chain(to_save.data_vars, to_save.coords):
+            try:
+                del to_save[var].attrs['regions']
+            except KeyError:
+                pass
+
         if separate_vars:
             # Save each major variable to a different netCDF file
 

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -157,8 +157,8 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     # in disconnected regions, but there are no branch-cuts allowed in the x-direction in
     # BOUT++ (at least for the momement), so the y-coordinate has to be 1d and
     # single-valued. Therefore similarly dy has to be 1d and single-valued.]
-    # Need drop=True so that the result does not have an x-coordinate value which prevents
-    # it being added as a coordinate.
+    # Need drop=True so that the result does not have an x-coordinate value which
+    # prevents it being added as a coordinate.
     dy = ds['dy'].isel(x=0, drop=True)
 
     # calculate theta at the centre of each cell

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -230,6 +230,8 @@ def add_s_alpha_geometry_coords(ds, *, coordinates=None, grid=None):
                          "geometry='s-alpha'")
     ds['r'] = ds['hthe'].isel({coordinates['y']: 0}).squeeze(drop=True)
     ds['r'].attrs['units'] = 'm'
+    # remove x-index coordinate, don't need when we have 'r' as a radial coordinate
+    ds = ds.drop('x')
     ds = ds.set_coords('r')
     ds = ds.rename(x='r')
 

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -68,8 +68,6 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
     else:
         updated_ds = add_geometry_coords(ds)
 
-    updated_ds = _create_regions_toroidal(updated_ds)
-
     return updated_ds
 
 
@@ -196,6 +194,8 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
         ds = ds.set_coords('zShift')
     except KeyError:
         pass
+
+    ds = _create_regions_toroidal(ds)
 
     return ds
 

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -146,15 +146,21 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     ds = ds.rename(y=coordinates['y'])
 
     # Add 1D Orthogonal Toroidal coordinates
+    # Make index 'x' a coordinate, useful for handling global indexing
+    nx = ds.dims['x']
+    ds = ds.assign_coords(x=np.arange(nx))
     ny = ds.dims[coordinates['y']]
-    # dy should always be constant in x, so it is safe to slice to x=0
+    # dy should always be constant in x, so it is safe to slice to x=0.
     # [The y-coordinate has to be a 1d coordinate that labels x-z slices of the grid
     # (similarly x-coordinate is 1d coordinate that labels y-z slices and z-coordinate is
     # a 1d coordinate that labels x-y slices). A coordinate might have different values
     # in disconnected regions, but there are no branch-cuts allowed in the x-direction in
     # BOUT++ (at least for the momement), so the y-coordinate has to be 1d and
     # single-valued. Therefore similarly dy has to be 1d and single-valued.]
-    dy = ds['dy'].isel(x=0)
+    # Need drop=True so that the result does not have an x-coordinate value which prevents
+    # it being added as a coordinate.
+    dy = ds['dy'].isel(x=0, drop=True)
+
     # calculate theta at the centre of each cell
     theta = dy.cumsum(keep_attrs=True) - dy/2.
     ds = ds.assign_coords(**{coordinates['y']: theta})

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -122,12 +122,17 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     coordinates = _set_default_toroidal_coordinates(coordinates)
 
     # Check whether coordinates names conflict with variables in ds
-    bad_names = [name for name in coordinates.values() if name in ds]
+    bad_names = [name for name in coordinates.values() if name in ds.data_vars]
     if bad_names:
         raise ValueError("Coordinate names {} clash with variables in the dataset. "
                          "Register a different geometry to provide alternative names. "
                          "It may be useful to use the 'coordinates' argument to "
                          "add_toroidal_geometry_coords() for this.".format(bad_names))
+
+    if set(coordinates.values()).issubset(set(ds.coords).union(ds.dims)):
+        # Loading a Dataset which already had the coordinates created for it
+        ds = _create_regions_toroidal(ds)
+        return ds
 
     # Get extra geometry information from grid file if it's not in the dump files
     needed_variables = ['psixy', 'Rxy', 'Zxy']
@@ -217,6 +222,12 @@ def add_s_alpha_geometry_coords(ds, *, coordinates=None, grid=None):
 
     coordinates = _set_default_toroidal_coordinates(coordinates)
 
+    if set(coordinates.values()).issubset(set(ds.coords).union(ds.dims)):
+        # Loading a Dataset which already had the coordinates created for it
+        ds = _create_regions_toroidal(ds)
+        return ds
+
+    # Get extra geometry information from grid file if it's not in the dump files
     # Add 'hthe' from grid file, needed below for radial coordinate
     if 'hthe' not in ds:
         hthe_from_grid = True

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -231,6 +231,10 @@ def reload_boutdataset(
 
     ds = _add_options(ds, inputfilepath)
 
+    # If geometry was set, apply geometry again
+    if "geometry" in ds.attrs:
+        ds = geometries.apply_geometry(ds, ds.attrs["geometry"])
+
     if info == 'terse':
         print("Read in dataset from {}".format(str(Path(datapath))))
     elif info:

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -308,7 +308,7 @@ def _auto_open_mfboutdataset(datapath, chunks={}, info=True,
     ds = xr.open_mfdataset(paths_grid, concat_dim=concat_dims, combine='nested',
                            data_vars=_BOUT_TIME_DEPENDENT_META_VARS,
                            preprocess=_preprocess, engine=filetype,
-                           chunks=chunks, **kwargs)
+                           chunks=chunks, join='exact', **kwargs)
 
     # Remove any duplicate time values from concatenation
     _, unique_indices = unique(ds['t_array'], return_index=True)
@@ -621,5 +621,5 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2):
                     y=slice(nin + 2 * yboundaries, None, None))
                 grid = xr.concat((grid_lower, grid_upper), dim='y',
                                  data_vars='minimal',
-                                 compat='identical')
+                                 compat='identical', join='exact')
     return grid

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -100,16 +100,16 @@ def animate_poloidal(da, *, ax=None, cax=None, animate_over='t', separatrix=True
 
     ax.set_aspect(aspect)
 
-    regions = _decompose_regions(da)
+    da_regions = _decompose_regions(da)
 
     # Plot all regions on same axis
     blocks = []
-    for region in regions:
+    for da_region in da_regions:
         # Load values eagerly otherwise for some reason the plotting takes
         # 100's of times longer - for some reason animatplot does not deal
         # well with dask arrays!
-        blocks.append(amp.blocks.Pcolormesh(region.coords[x].values,
-                      region.coords[y].values, region.values, ax=ax, cmap=cmap,
+        blocks.append(amp.blocks.Pcolormesh(da_region.coords[x].values,
+                      da_region.coords[y].values, da_region.values, ax=ax, cmap=cmap,
                       **kwargs))
 
     ax.set_title(da.name)

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -104,7 +104,7 @@ def animate_poloidal(da, *, ax=None, cax=None, animate_over='t', separatrix=True
 
     # Plot all regions on same axis
     blocks = []
-    for da_region in da_regions:
+    for da_region in da_regions.values():
         # Load values eagerly otherwise for some reason the plotting takes
         # 100's of times longer - for some reason animatplot does not deal
         # well with dask arrays!
@@ -121,10 +121,10 @@ def animate_poloidal(da, *, ax=None, cax=None, animate_over='t', separatrix=True
          targets = False
 
     if separatrix:
-        plot_separatrices(da, ax)
+        plot_separatrices(da_regions, ax)
 
     if targets:
-        plot_targets(da, ax, hatching=add_limiter_hatching)
+        plot_targets(da_regions, ax, hatching=add_limiter_hatching)
 
     if animate:
         timeline = amp.Timeline(np.arange(da.sizes[animate_over]), fps=fps)

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -220,7 +220,7 @@ def animate_pcolormesh(data, animate_over='t', x=None, y=None, animate=True,
             raise ValueError("Dimension {} is not present in the data" .format(x))
         y = spatial_dims[0]
 
-    data = data.transpose(animate_over, y, x)
+    data = data.transpose(animate_over, y, x, transpose_coords=True)
 
     # Load values eagerly otherwise for some reason the plotting takes
     # 100's of times longer - for some reason animatplot does not deal
@@ -317,7 +317,7 @@ def animate_line(data, animate_over='t', animate=True,
     if (t_read is animate_over):
         pass
     else:
-        data = data.transpose(animate_over, t_read)
+        data = data.transpose(animate_over, t_read, transpose_coords=True)
 
     # Load values eagerly otherwise for some reason the plotting takes
     # 100's of times longer - for some reason animatplot does not deal

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -1,5 +1,3 @@
-import collections
-
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,7 +27,7 @@ def regions(da, ax=None, **kwargs):
     da_regions = _decompose_regions(da)
 
     colored_regions = [xr.full_like(da_region, fill_value=num / len(regions))
-                       for num, da_region in enumerate(da_regions)]
+                       for num, da_region in enumerate(da_regions.values())]
 
     return [region.plot.pcolormesh(x=x, y=y, vmin=0, vmax=1, cmap='tab20',
                                    infer_intervals=False, add_colorbar=False, ax=ax,
@@ -186,7 +184,8 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
     # Plot all regions on same axis
     add_labels = [True] + [False] * (len(da_regions) - 1)
     artists = [method(region, x=x, y=y, ax=ax, add_colorbar=False, add_labels=add_label,
-               cmap=cmap, **kwargs) for region, add_label in zip(da_regions, add_labels)]
+               cmap=cmap, **kwargs)
+               for region, add_label in zip(da_regions.values(), add_labels)]
 
     if method is xr.plot.contour:
         # using extend='neither' guarantees that the ends of the colorbar will be
@@ -214,8 +213,8 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
                     raise ValueError('Argument passed to gridlines must be bool, int or '
                                      'slice. Got a ' + type(value) + ', ' + str(value))
 
-        R_regions = [da_region['R'] for da_region in da_regions]
-        Z_regions = [da_region['Z'] for da_region in da_regions]
+        R_regions = [da_region['R'] for da_region in da_regions.values()]
+        Z_regions = [da_region['Z'] for da_region in da_regions.values()]
 
         for R, Z in zip(R_regions, Z_regions):
             if (not da.metadata['bout_xdim'] in R.dims
@@ -247,9 +246,9 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
         targets = False
 
     if separatrix:
-        plot_separatrices(da, ax)
+        plot_separatrices(da_regions, ax)
 
     if targets:
-        plot_targets(da, ax, hatching=add_limiter_hatching)
+        plot_targets(da_regions, ax, hatching=add_limiter_hatching)
 
     return artists

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -221,8 +221,8 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
                     and not da.metadata['bout_ydim'] in R.dims):
                 # Small regions around X-point do not have segments in x- or y-directions,
                 # so skip
-                ## Currently this region does not exist, but there is a small white gap at
-                ## the X-point, so we might add it back in future
+                # Currently this region does not exist, but there is a small white gap at
+                # the X-point, so we might add it back in future
                 continue
             if gridlines.get('x') is not None:
                 # transpose in case Dataset or DataArray has been transposed away from the usual

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -229,15 +229,17 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
                 # form
                 dim_order = (da.metadata['bout_xdim'], da.metadata['bout_ydim'])
                 yarg = {da.metadata['bout_ydim']: gridlines['x']}
-                plt.plot(R.isel(**yarg).transpose(*dim_order),
-                         Z.isel(**yarg).transpose(*dim_order), color='k', lw=0.1)
+                plt.plot(R.isel(**yarg).transpose(*dim_order, transpose_coords=True),
+                         Z.isel(**yarg).transpose(*dim_order, transpose_coords=True),
+                         color='k', lw=0.1)
             if gridlines.get('y') is not None:
                 xarg = {da.metadata['bout_xdim']: gridlines['y']}
                 # Need to plot transposed arrays to make gridlines that go in the
                 # y-direction
                 dim_order = (da.metadata['bout_ydim'], da.metadata['bout_xdim'])
-                plt.plot(R.isel(**xarg).transpose(*dim_order),
-                         Z.isel(**yarg).transpose(*dim_order), color='k', lw=0.1)
+                plt.plot(R.isel(**xarg).transpose(*dim_order, transpose_coords=True),
+                         Z.isel(**yarg).transpose(*dim_order, transpose_coords=True),
+                         color='k', lw=0.1)
 
     ax.set_title(da.name)
 

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -213,20 +213,17 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
                 if not isinstance(value, slice):
                     raise ValueError('Argument passed to gridlines must be bool, int or '
                                      'slice. Got a ' + type(value) + ', ' + str(value))
-        R_global = da['R']
-        R_global.attrs['metadata'] = da.metadata
 
-        Z_global = da['Z']
-        Z_global.attrs['metadata'] = da.metadata
-
-        R_regions = _decompose_regions(da['R'])
-        Z_regions = _decompose_regions(da['Z'])
+        R_regions = [da_region['R'] for da_region in da_regions]
+        Z_regions = [da_region['Z'] for da_region in da_regions]
 
         for R, Z in zip(R_regions, Z_regions):
             if (not da.metadata['bout_xdim'] in R.dims
                     and not da.metadata['bout_ydim'] in R.dims):
                 # Small regions around X-point do not have segments in x- or y-directions,
                 # so skip
+                ## Currently this region does not exist, but there is a small white gap at
+                ## the X-point, so we might add it back in future
                 continue
             if gridlines.get('x') is not None:
                 # transpose in case Dataset or DataArray has been transposed away from the usual

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -26,10 +26,10 @@ def regions(da, ax=None, **kwargs):
     if ax is None:
         fig, ax = plt.subplots()
 
-    regions = _decompose_regions(da)
+    da_regions = _decompose_regions(da)
 
-    colored_regions = [xr.full_like(region, fill_value=num / len(regions))
-                       for num, region in enumerate(regions)]
+    colored_regions = [xr.full_like(da_region, fill_value=num / len(regions))
+                       for num, da_region in enumerate(da_regions)]
 
     return [region.plot.pcolormesh(x=x, y=y, vmin=0, vmax=1, cmap='tab20',
                                    infer_intervals=False, add_colorbar=False, ax=ax,
@@ -181,12 +181,12 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
         if 'infer_intervals' not in kwargs:
             kwargs['infer_intervals'] = False
 
-    regions = _decompose_regions(da)
+    da_regions = _decompose_regions(da)
 
     # Plot all regions on same axis
-    add_labels = [True] + [False] * (len(regions) - 1)
+    add_labels = [True] + [False] * (len(da_regions) - 1)
     artists = [method(region, x=x, y=y, ax=ax, add_colorbar=False, add_labels=add_label,
-               cmap=cmap, **kwargs) for region, add_label in zip(regions, add_labels)]
+               cmap=cmap, **kwargs) for region, add_label in zip(da_regions, add_labels)]
 
     if method is xr.plot.contour:
         # using extend='neither' guarantees that the ends of the colorbar will be

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -87,7 +87,7 @@ def plot_separatrices(da, ax):
     ycoord = da0.metadata['bout_ydim']
 
     for da_region in da_regions.values():
-        inner = da_region.region.connection_inner
+        inner = da_region.region.connection_inner_x
         if inner is not None:
             da_inner = da_regions[inner]
             R = 0.5*(da_inner['R'].isel(**{xcoord: -1})
@@ -116,14 +116,14 @@ def plot_targets(da, ax, hatching=True):
         y_boundary_guards = 0
 
     for da_region in da_regions.values():
-        if da_region.region.connection_lower is None:
+        if da_region.region.connection_lower_y is None:
             # lower target exists
             R = da_region.coords['R'].isel(**{ycoord: y_boundary_guards})
             Z = da_region.coords['Z'].isel(**{ycoord: y_boundary_guards})
             [line] = ax.plot(R, Z, 'k-', linewidth=2)
             if hatching:
                 _add_hatching(line, ax)
-        if da_region.region.connection_upper is None:
+        if da_region.region.connection_upper_y is None:
             # upper target exists
             R = da_region.coords['R'].isel(**{ycoord: -y_boundary_guards - 1})
             Z = da_region.coords['Z'].isel(**{ycoord: -y_boundary_guards - 1})

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -61,7 +61,7 @@ def plot_separatrix(da, sep_pos, ax, radial_coord='x'):
 
 def _decompose_regions(da):
 
-    return {region: da.bout.fromRegion(region, with_guards=1) for region in da.regions}
+    return {region: da.bout.from_region(region, with_guards=1) for region in da.regions}
 
 
 def _is_core_only(da):

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -90,8 +90,10 @@ def plot_separatrices(da, ax):
         inner = da_region.region.connection_inner
         if inner is not None:
             da_inner = da_regions[inner]
-            R = 0.5*(da_inner['R'].isel(**{xcoord: -1}) + da_region['R'].isel(**{xcoord: 0}))
-            Z = 0.5*(da_inner['Z'].isel(**{xcoord: -1}) + da_region['Z'].isel(**{xcoord: 0}))
+            R = 0.5*(da_inner['R'].isel(**{xcoord: -1})
+                     + da_region['R'].isel(**{xcoord: 0}))
+            Z = 0.5*(da_inner['Z'].isel(**{xcoord: -1})
+                     + da_region['Z'].isel(**{xcoord: 0}))
             ax.plot(R, Z, 'k--')
 
 

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -10,38 +10,41 @@ class Region:
 
     Also stores the names of any neighbouring regions.
     """
-    def __init__(self, *, ds, name, xinner_ind, xouter_ind, ylower_ind, yupper_ind,
-                 connect_inner=None, connect_outer=None, connect_lower=None,
-                 connect_upper=None):
+    def __init__(self, *, name, ds=None, xinner_ind=None, xouter_ind=None,
+                 ylower_ind=None, yupper_ind=None, connect_inner=None, connect_outer=None,
+                 connect_lower=None, connect_upper=None):
         self.name = name
         self.xinner_ind = xinner_ind
         self.xouter_ind = xouter_ind
-        self.nx = xouter_ind - xinner_ind
+        if xouter_ind is not None and xinner_ind is not None:
+            self.nx = xouter_ind - xinner_ind
         self.ylower_ind = ylower_ind
         self.yupper_ind = yupper_ind
-        self.ny = yupper_ind - ylower_ind
+        if yupper_ind is not None and ylower_ind is not None:
+            self.ny = yupper_ind - ylower_ind
         self.connection_inner = connect_inner
         self.connection_outer = connect_outer
         self.connection_lower = connect_lower
         self.connection_upper = connect_upper
 
-        # calculate start and end coordinates
-        #####################################
-        xcoord = ds.metadata['bout_xdim']
-        ycoord = ds.metadata['bout_ydim']
+        if ds is not None:
+            # calculate start and end coordinates
+            #####################################
+            xcoord = ds.metadata['bout_xdim']
+            ycoord = ds.metadata['bout_ydim']
 
-        # dx is constant in any particular region in the y-direction, so convert to a 1d
-        # array
-        dx = ds['dx'].isel(**{ycoord: self.ylower_ind})
-        dx_cumsum = dx.cumsum()
-        self.xinner = dx_cumsum[xinner_ind] - dx[xinner_ind]/2.
-        self.xouter = dx_cumsum[xouter_ind - 1] + dx[xouter_ind - 1]/2.
+            # dx is constant in any particular region in the y-direction, so convert to a 1d
+            # array
+            dx = ds['dx'].isel(**{ycoord: self.ylower_ind})
+            dx_cumsum = dx.cumsum()
+            self.xinner = dx_cumsum[xinner_ind] - dx[xinner_ind]/2.
+            self.xouter = dx_cumsum[xouter_ind - 1] + dx[xouter_ind - 1]/2.
 
-        # dy is constant in the x-direction, so convert to a 1d array
-        dy = ds['dy'].isel(**{xcoord: self.xinner_ind})
-        dy_cumsum = dy.cumsum()
-        self.ylower = dy_cumsum[ylower_ind] - dy[ylower_ind]/2.
-        self.yupper = dy_cumsum[yupper_ind - 1] + dy[yupper_ind - 1]/2.
+            # dy is constant in the x-direction, so convert to a 1d array
+            dy = ds['dy'].isel(**{xcoord: self.xinner_ind})
+            dy_cumsum = dy.cumsum()
+            self.ylower = dy_cumsum[ylower_ind] - dy[ylower_ind]/2.
+            self.yupper = dy_cumsum[yupper_ind - 1] + dy[yupper_ind - 1]/2.
 
     def getSlices(self, mxg=0, myg=0):
         """
@@ -233,58 +236,58 @@ def _create_regions_toroidal(ds):
     regions = {}
     if topology == 'disconnected-double-null':
         regions['lower_inner_PFR'] = Region(
-                ds=ds, name='lower_inner_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=0, yupper_ind=jys11 + 1)
         regions['lower_inner_intersep'] = Region(
-                ds=ds, name='lower_inner_intersep', xinner_ind=ixs1, xouter_ind=ixs2,
+                name='lower_inner_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
                 ylower_ind=0, yupper_ind=jys11 + 1)
         regions['lower_inner_SOL'] = Region(
-                ds=ds, name='lower_inner_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='lower_inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=0, yupper_ind=jys11 + 1)
         regions['inner_core'] = Region(
-                ds=ds, name='inner_core', xinner_ind=0, xouter_ind=ixs1,
+                name='inner_core', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys11 + 1, yupper_ind=jys21 + 1)
         regions['inner_intersep'] = Region(
-                ds=ds, name='inner_intersep', xinner_ind=ixs1, xouter_ind=ixs2,
+                name='inner_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
                 ylower_ind=jys11 + 1, yupper_ind=jys21 + 1)
         regions['inner_SOL'] = Region(
-                ds=ds, name='inner_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=jys11 + 1, yupper_ind=jys21 + 1)
         regions['upper_inner_PFR'] = Region(
-                ds=ds, name='upper_inner_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='upper_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys21 + 1, yupper_ind=nyinner)
         regions['upper_inner_intersep'] = Region(
-                ds=ds, name='upper_inner_intersep', xinner_ind=ixs1, xouter_ind=ixs2,
+                name='upper_inner_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
                 ylower_ind=jys21 + 1, yupper_ind=nyinner)
         regions['upper_inner_SOL'] = Region(
-                ds=ds, name='upper_inner_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='upper_inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=jys21 + 1, yupper_ind=nyinner)
         regions['upper_outer_PFR'] = Region(
-                ds=ds, name='upper_outer_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='upper_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=nyinner, yupper_ind=jys12 + 1)
         regions['upper_outer_intersep'] = Region(
-                ds=ds, name='upper_outer_intersep', xinner_ind=ixs1, xouter_ind=ixs2,
+                name='upper_outer_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
                 ylower_ind=nyinner, yupper_ind=jys12 + 1)
         regions['upper_outer_SOL'] = Region(
-                ds=ds, name='upper_outer_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='upper_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=nyinner, yupper_ind=jys12 + 1)
         regions['outer_core'] = Region(
-                ds=ds, name='outer_core', xinner_ind=0, xouter_ind=ixs1,
+                name='outer_core', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys12 + 1, yupper_ind=jys22 + 1)
         regions['outer_intersep'] = Region(
-                ds=ds, name='outer_intersep', xinner_ind=ixs1, xouter_ind=ixs2,
+                name='outer_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
                 ylower_ind=jys12 + 1, yupper_ind=jys22 + 1)
         regions['outer_SOL'] = Region(
-                ds=ds, name='outer_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=jys12 + 1, yupper_ind=jys22 + 1)
         regions['lower_outer_PFR'] = Region(
-                ds=ds, name='lower_outer_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='lower_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys22 + 1, yupper_ind=ny)
         regions['lower_outer_intersep'] = Region(
-                ds=ds, name='lower_outer_intersep', xinner_ind=ixs1, xouter_ind=ixs2,
+                name='lower_outer_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
                 ylower_ind=jys22 + 1, yupper_ind=ny)
         regions['lower_outer_SOL'] = Region(
-                ds=ds, name='lower_outer_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='lower_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=jys22 + 1, yupper_ind=ny)
         _create_connection_x(regions, 'lower_inner_PFR', 'lower_inner_intersep')
         _create_connection_x(regions, 'lower_inner_intersep', 'lower_inner_SOL')
@@ -312,40 +315,40 @@ def _create_regions_toroidal(ds):
         _create_connection_y(regions, 'outer_SOL', 'lower_outer_SOL')
     elif topology == 'connected-double-null':
         regions['lower_inner_PFR'] = Region(
-                ds=ds, name='lower_inner_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=0, yupper_ind=jys11 + 1)
         regions['lower_inner_SOL'] = Region(
-                ds=ds, name='lower_inner_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='lower_inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=0, yupper_ind=jys11 + 1)
         regions['inner_core'] = Region(
-                ds=ds, name='inner_core', xinner_ind=0, xouter_ind=ixs1,
+                name='inner_core', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys11 + 1, yupper_ind=jys21 + 1)
         regions['inner_SOL'] = Region(
-                ds=ds, name='inner_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=jys11 + 1, yupper_ind=jys21 + 1)
         regions['upper_inner_PFR'] = Region(
-                ds=ds, name='upper_inner_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='upper_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys21 + 1, yupper_ind=nyinner)
         regions['upper_inner_SOL'] = Region(
-                ds=ds, name='upper_inner_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='upper_inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=jys21 + 1, yupper_ind=nyinner)
         regions['upper_outer_PFR'] = Region(
-                ds=ds, name='upper_outer_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='upper_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=nyinner, yupper_ind=jys12 + 1)
         regions['upper_outer_SOL'] = Region(
-                ds=ds, name='upper_outer_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='upper_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=nyinner, yupper_ind=jys12 + 1)
         regions['outer_core'] = Region(
-                ds=ds, name='outer_core', xinner_ind=0, xouter_ind=ixs1,
+                name='outer_core', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys12 + 1, yupper_ind=jys22 + 1)
         regions['outer_SOL'] = Region(
-                ds=ds, name='outer_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=jys12 + 1, yupper_ind=jys22 + 1)
         regions['lower_outer_PFR'] = Region(
-                ds=ds, name='lower_outer_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='lower_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys22 + 1, yupper_ind=ny)
         regions['lower_outer_SOL'] = Region(
-                ds=ds, name='lower_outer_SOL', xinner_ind=ixs2, xouter_ind=nx,
+                name='lower_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=jys22 + 1, yupper_ind=ny)
         _create_connection_x(regions, 'lower_inner_PFR', 'lower_inner_SOL')
         _create_connection_x(regions, 'inner_core', 'inner_SOL')
@@ -363,22 +366,22 @@ def _create_regions_toroidal(ds):
         _create_connection_y(regions, 'outer_SOL', 'lower_outer_SOL')
     elif topology == 'single-null':
         regions['inner_PFR'] = Region(
-                ds=ds, name='inner_PFR', xinner_ind=0, xouter_ind=ixs1, ylower_ind=0,
+                name='inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=0,
                 yupper_ind=jys11 + 1)
         regions['inner_SOL'] = Region(
-                ds=ds, name='inner_SOL', xinner_ind=ixs1, xouter_ind=nx, ylower_ind=0,
+                name='inner_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=0,
                 yupper_ind=jys11 + 1)
         regions['core'] = Region(
-                ds=ds, name='core', xinner_ind=0, xouter_ind=ixs1, ylower_ind=jys11 + 1,
+                name='core', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=jys11 + 1,
                 yupper_ind=jys22 + 1)
         regions['SOL'] = Region(
-                ds=ds, name='SOL', xinner_ind=ixs2, xouter_ind=nx, ylower_ind=jys11 + 1,
+                name='SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx, ylower_ind=jys11 + 1,
                 yupper_ind=jys22 + 1)
         regions['outer_PFR'] = Region(
-                ds=ds, name='lower_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='lower_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys22 + 1, yupper_ind=ny)
         regions['outer_SOL'] = Region(
-                ds=ds, name='lower_SOL', xinner_ind=ixs1, xouter_ind=nx,
+                name='lower_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
                 ylower_ind=jys22 + 1, yupper_ind=ny)
         _create_connection_x(regions, 'inner_PFR', 'inner_SOL')
         _create_connection_x(regions, 'core', 'SOL')
@@ -389,46 +392,46 @@ def _create_regions_toroidal(ds):
         _create_connection_y(regions, 'SOL', 'outer_SOL')
     elif topology == 'limiter':
         regions['core'] = Region(
-                ds=ds, name='core', xinner_ind=0, xouter_ind=ixs1, ylower_ind=0,
+                name='core', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=0,
                 yupper_ind=ny)
         regions['SOL'] = Region(
-                ds=ds, name='SOL', xinner_ind=ixs1, xouter_ind=nx, ylower_ind=0,
+                name='SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=0,
                 yupper_ind=ny)
         _create_connection_x(regions, 'core', 'SOL')
         _create_connection_y(regions, 'core', 'core')
     elif topology == 'core':
         regions['core'] = Region(
-                ds=ds, name='core', xinner_ind=0, xouter_ind=nx, ylower_ind=0,
+                name='core', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=0,
                 yupper_ind=ny)
         _create_connection_y(regions, 'core', 'core')
     elif topology == 'sol':
         regions['sol'] = Region(
-                ds=ds, name='sol', xinner_ind=0, xouter_ind=nx, ylower_ind=0,
+                name='sol', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=0,
                 yupper_ind=ny)
     elif topology == 'xpoint':
         regions['lower_inner_PFR'] = Region(
-                ds=ds, name='lower_inner_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=0, yupper_ind=jys11 + 1)
         regions['lower_inner_SOL'] = Region(
-                ds=ds, name='lower_inner_SOL', xinner_ind=ixs1, xouter_ind=nx,
+                name='lower_inner_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
                 ylower_ind=0, yupper_ind=jys11 + 1)
         regions['upper_inner_PFR'] = Region(
-                ds=ds, name='upper_inner_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='upper_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys11 + 1, yupper_ind=nyinner)
         regions['upper_inner_SOL'] = Region(
-                ds=ds, name='upper_inner_SOL', xinner_ind=ixs1, xouter_ind=nx,
+                name='upper_inner_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
                 ylower_ind=jys11 + 1, yupper_ind=nyinner)
         regions['upper_outer_PFR'] = Region(
-                ds=ds, name='upper_outer_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='upper_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=nyinner, yupper_ind=jys22 + 1)
         regions['upper_outer_SOL'] = Region(
-                ds=ds, name='upper_outer_SOL', xinner_ind=ixs1, xouter_ind=nx,
+                name='upper_outer_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
                 ylower_ind=nyinner, yupper_ind=jys22 + 1)
         regions['lower_outer_PFR'] = Region(
-                ds=ds, name='lower_outer_PFR', xinner_ind=0, xouter_ind=ixs1,
+                name='lower_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys22 + 1, yupper_ind=ny)
         regions['lower_outer_SOL'] = Region(
-                ds=ds, name='lower_outer_SOL', xinner_ind=ixs1, xouter_ind=nx,
+                name='lower_outer_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
                 ylower_ind=jys22 + 1, yupper_ind=ny)
         _create_connection_x(regions, 'lower_inner_PFR', 'lower_inner_SOL')
         _create_connection_x(regions, 'upper_inner_PFR', 'upper_inner_SOL')

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -446,7 +446,7 @@ def _create_regions_toroidal(ds):
                 name='core', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=jys11 + 1,
                 yupper_ind=jys22 + 1)
         regions['SOL'] = Region(
-                name='SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx, ylower_ind=jys11 + 1,
+                name='SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=jys11 + 1,
                 yupper_ind=jys22 + 1)
         regions['outer_PFR'] = Region(
                 name='lower_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -16,8 +16,10 @@ class Region:
         self.name = name
         self.xinner_ind = xinner_ind
         self.xouter_ind = xouter_ind
+        self.nx = xouter_ind - xinner_ind
         self.ylower_ind = ylower_ind
         self.yupper_ind = yupper_ind
+        self.ny = yupper_ind - ylower_ind
         self.connection_inner = connect_inner
         self.connection_outer = connect_outer
         self.connection_lower = connect_lower

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -56,18 +56,18 @@ class Region:
         if ds is not None:
             # calculate start and end coordinates
             #####################################
-            xcoord = ds.metadata['bout_xdim']
-            ycoord = ds.metadata['bout_ydim']
+            self.xcoord = ds.metadata['bout_xdim']
+            self.ycoord = ds.metadata['bout_ydim']
 
             # dx is constant in any particular region in the y-direction, so convert to a
             # 1d array
-            dx = ds['dx'].isel(**{ycoord: self.ylower_ind})
+            dx = ds['dx'].isel(**{self.ycoord: self.ylower_ind})
             dx_cumsum = dx.cumsum()
             self.xinner = dx_cumsum[xinner_ind] - dx[xinner_ind]/2.
             self.xouter = dx_cumsum[xouter_ind - 1] + dx[xouter_ind - 1]/2.
 
             # dy is constant in the x-direction, so convert to a 1d array
-            dy = ds['dy'].isel(**{xcoord: self.xinner_ind})
+            dy = ds['dy'].isel(**{self.xcoord: self.xinner_ind})
             dy_cumsum = dy.cumsum()
             self.ylower = dy_cumsum[ylower_ind] - dy[ylower_ind]/2.
             self.yupper = dy_cumsum[yupper_ind - 1] + dy[yupper_ind - 1]/2.
@@ -103,7 +103,7 @@ class Region:
         if self.connection_upper is not None:
             yu += myg
 
-        return slice(xi, xo), slice(yl, yu)
+        return {self.xcoord: slice(xi, xo), self.ycoord: slice(yl, yu)}
 
     def get_inner_guards_slices(self, *, mxg, myg=0):
         """
@@ -123,7 +123,8 @@ class Region:
         yupper = self.yupper_ind
         if self.connection_upper is not None:
             yupper += myg
-        return slice(self.xinner_ind - mxg, self.xinner_ind), slice(ylower, yupper)
+        return {self.xcoord: slice(self.xinner_ind - mxg, self.xinner_ind),
+                self.ycoord: slice(ylower, yupper)}
 
     def get_outer_guards_slices(self, *, mxg, myg=0):
         """
@@ -143,7 +144,8 @@ class Region:
         yupper = self.yupper_ind
         if self.connection_upper is not None:
             yupper += myg
-        return slice(self.xouter_ind, self.xouter_ind + mxg), slice(ylower, yupper)
+        return {self.xcoord: slice(self.xouter_ind, self.xouter_ind + mxg),
+                self.ycoord: slice(ylower, yupper)}
 
     def get_lower_guards_slices(self, *, myg, mxg=0):
         """
@@ -163,7 +165,8 @@ class Region:
         xouter = self.xouter_ind
         if self.connection_outer is not None:
             xouter += mxg
-        return slice(xinner, xouter), slice(self.ylower_ind - myg, self.ylower_ind)
+        return {self.xcoord: slice(xinner, xouter),
+                self.ycoord: slice(self.ylower_ind - myg, self.ylower_ind)}
 
     def get_upper_guards_slices(self, *, myg, mxg=0):
         """
@@ -183,7 +186,8 @@ class Region:
         xouter = self.xouter_ind
         if self.connection_outer is not None:
             xouter += mxg
-        return slice(xinner, xouter), slice(self.yupper_ind, self.yupper_ind + myg)
+        return {self.xcoord: slice(xinner, xouter),
+                self.ycoord: slice(self.yupper_ind, self.yupper_ind + myg)}
 
 
 def _in_range(val, lower, upper):

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -448,8 +448,8 @@ def _create_regions_toroidal(ds):
                 yupper_ind=ny - ybndry)
         _create_connection_y(regions, 'core', 'core')
     elif topology == 'sol':
-        regions['sol'] = Region(
-                name='sol', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=ybndry,
+        regions['SOL'] = Region(
+                name='SOL', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=ybndry,
                 yupper_ind=ny - ybndry)
     elif topology == 'xpoint':
         regions['lower_inner_PFR'] = Region(

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -191,6 +191,11 @@ class Region:
         return {self.xcoord: slice(xinner, xouter),
                 self.ycoord: slice(self.yupper_ind, self.yupper_ind + myg)}
 
+    def __eq__(self, other):
+        if not isinstance(other, Region):
+            return NotImplemented
+        return vars(self) == vars(other)
+
 
 def _in_range(val, lower, upper):
     if val < lower:

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -232,7 +232,7 @@ def _get_topology(ds):
             raise ValueError('Currently unsupported topology')
 
     if ixs1 == ixs2:
-        if jys21 < nyinner -1 and jys21 > nyinner:
+        if jys21 < nyinner -1 and jys12 > nyinner:
             return 'connected-double-null'
         else:
             raise ValueError('Currently unsupported topology')

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -531,6 +531,9 @@ def _concat_inner_guards(da, da_global, mxg):
     cells from the global array
     """
 
+    if mxg <= 0:
+        return da
+
     myg_da = da_global.metadata['MYG']
     keep_yboundaries = da_global.metadata['keep_yboundaries']
     xcoord = da_global.metadata['bout_xdim']
@@ -600,6 +603,9 @@ def _concat_outer_guards(da, da_global, mxg):
     cells from the global array
     """
 
+    if mxg <= 0:
+        return da
+
     myg_da = da_global.metadata['MYG']
     keep_yboundaries = da_global.metadata['keep_yboundaries']
     xcoord = da_global.metadata['bout_xdim']
@@ -668,6 +674,9 @@ def _concat_lower_guards(da, da_global, mxg, myg):
     cells from the global array
     """
 
+    if myg <= 0:
+        return da
+
     xcoord = da_global.metadata['bout_xdim']
     ycoord = da_global.metadata['bout_ydim']
 
@@ -709,6 +718,9 @@ def _concat_upper_guards(da, da_global, mxg, myg):
     Concatenate upper y-guard cells to da, which is in a single region, getting the guard
     cells from the global array
     """
+
+    if myg <= 0:
+        return da
 
     xcoord = da_global.metadata['bout_xdim']
     ycoord = da_global.metadata['bout_ydim']

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -75,7 +75,7 @@ class Region:
     def __repr__(self):
         result = "<xbout.region.Region>\n"
         for attr, val in vars(self).items():
-            result += "\t" + attr + "\t" + str(val) + "\n"
+            result += f"\t{attr}\t{val}\n"
         return result
 
     def get_slices(self, mxg=0, myg=0):

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -438,8 +438,8 @@ def _create_regions_toroidal(ds):
                 name='core', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=ybndry,
                 yupper_ind=ny - ybndry)
         regions['SOL'] = Region(
-                name='SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=ybndry,
-                yupper_ind=ny - ybndry)
+                name='SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=0,
+                yupper_ind=ny)
         _create_connection_x(regions, 'core', 'SOL')
         _create_connection_y(regions, 'core', 'core')
     elif topology == 'core':
@@ -449,8 +449,8 @@ def _create_regions_toroidal(ds):
         _create_connection_y(regions, 'core', 'core')
     elif topology == 'sol':
         regions['SOL'] = Region(
-                name='SOL', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=ybndry,
-                yupper_ind=ny - ybndry)
+                name='SOL', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=0,
+                yupper_ind=ny)
     elif topology == 'xpoint':
         regions['lower_inner_PFR'] = Region(
                 name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -78,7 +78,7 @@ class Region:
             result += "\t" + attr + "\t" + str(val) + "\n"
         return result
 
-    def getSlices(self, mxg=0, myg=0):
+    def get_slices(self, mxg=0, myg=0):
         """
         Return x- and y-dimension slices that select this region from the global
         DataArray.

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -105,7 +105,7 @@ class Region:
 
         return slice(xi, xo), slice(yl, yu)
 
-    def getInnerGuardsSlices(self, *, mxg, myg=0):
+    def get_inner_guards_slices(self, *, mxg, myg=0):
         """
         Return x- and y-dimension slices that select mxg guard cells on the inner-x side
         of this region from the global DataArray.
@@ -125,7 +125,7 @@ class Region:
             yupper += myg
         return slice(self.xinner_ind - mxg, self.xinner_ind), slice(ylower, yupper)
 
-    def getOuterGuardsSlices(self, *, mxg, myg=0):
+    def get_outer_guards_slices(self, *, mxg, myg=0):
         """
         Return x- and y-dimension slices that select mxg guard cells on the outer-x side
         of this region from the global DataArray.
@@ -145,7 +145,7 @@ class Region:
             yupper += myg
         return slice(self.xouter_ind, self.xouter_ind + mxg), slice(ylower, yupper)
 
-    def getLowerGuardsSlices(self, *, myg, mxg=0):
+    def get_lower_guards_slices(self, *, myg, mxg=0):
         """
         Return x- and y-dimension slices that select myg guard cells on the lower-y side
         of this region from the global DataArray.
@@ -165,7 +165,7 @@ class Region:
             xouter += mxg
         return slice(xinner, xouter), slice(self.ylower_ind - myg, self.ylower_ind)
 
-    def getUpperGuardsSlices(self, *, myg, mxg=0):
+    def get_upper_guards_slices(self, *, myg, mxg=0):
         """
         Return x- and y-dimension slices that select myg guard cells on the upper-y side
         of this region from the global DataArray.

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -13,8 +13,8 @@ class Region:
     Also stores the names of any neighbouring regions.
     """
     def __init__(self, *, name, ds=None, xinner_ind=None, xouter_ind=None,
-                 ylower_ind=None, yupper_ind=None, connect_inner=None, connect_outer=None,
-                 connect_lower=None, connect_upper=None):
+                 ylower_ind=None, yupper_ind=None, connect_inner=None,
+                 connect_outer=None, connect_lower=None, connect_upper=None):
         """
         Parameters
         ----------
@@ -59,8 +59,8 @@ class Region:
             xcoord = ds.metadata['bout_xdim']
             ycoord = ds.metadata['bout_ydim']
 
-            # dx is constant in any particular region in the y-direction, so convert to a 1d
-            # array
+            # dx is constant in any particular region in the y-direction, so convert to a
+            # 1d array
             dx = ds['dx'].isel(**{ycoord: self.ylower_ind})
             dx_cumsum = dx.cumsum()
             self.xinner = dx_cumsum[xinner_ind] - dx[xinner_ind]/2.
@@ -226,13 +226,13 @@ def _get_topology(ds):
         return 'single-null'
 
     if jys11 == jys21 and jys12 == jys22:
-        if jys11 < nyinner -1 and jys22 > nyinner:
+        if jys11 < nyinner - 1 and jys22 > nyinner:
             return 'xpoint'
         else:
             raise ValueError('Currently unsupported topology')
 
     if ixs1 == ixs2:
-        if jys21 < nyinner -1 and jys12 > nyinner:
+        if jys21 < nyinner - 1 and jys12 > nyinner:
             return 'connected-double-null'
         else:
             raise ValueError('Currently unsupported topology')

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -105,7 +105,7 @@ class Region:
 
         return slice(xi, xo), slice(yl, yu)
 
-    def getInnerGuardsSlices(self, mxg):
+    def getInnerGuardsSlices(self, *, mxg, myg=0):
         """
         Return x- and y-dimension slices that select mxg guard cells on the inner-x side
         of this region from the global DataArray.
@@ -114,11 +114,18 @@ class Region:
         ----------
         mxg : int
             Number of guard cells
+        myg : int, optional
+            Number of y-guard cells to include at the corners
         """
-        return slice(self.xinner_ind - mxg, self.xinner_ind), slice(self.ylower_ind,
-                self.yupper_ind)
+        ylower = self.ylower_ind
+        if self.connection_lower is not None:
+            ylower -= myg
+        yupper = self.yupper_ind
+        if self.connection_upper is not None:
+            yupper += myg
+        return slice(self.xinner_ind - mxg, self.xinner_ind), slice(ylower, yupper)
 
-    def getOuterGuardsSlices(self, mxg):
+    def getOuterGuardsSlices(self, *, mxg, myg=0):
         """
         Return x- and y-dimension slices that select mxg guard cells on the outer-x side
         of this region from the global DataArray.
@@ -127,11 +134,18 @@ class Region:
         ----------
         mxg : int
             Number of guard cells
+        myg : int, optional
+            Number of y-guard cells to include at the corners
         """
-        return slice(self.xouter_ind, self.xouter_ind + mxg), slice(self.ylower_ind,
-                self.yupper_ind)
+        ylower = self.ylower_ind
+        if self.connection_lower is not None:
+            ylower -= myg
+        yupper = self.yupper_ind
+        if self.connection_upper is not None:
+            yupper += myg
+        return slice(self.xouter_ind, self.xouter_ind + mxg), slice(ylower, yupper)
 
-    def getLowerGuardsSlices(self, myg):
+    def getLowerGuardsSlices(self, *, myg, mxg=0):
         """
         Return x- and y-dimension slices that select myg guard cells on the lower-y side
         of this region from the global DataArray.
@@ -140,11 +154,18 @@ class Region:
         ----------
         myg : int
             Number of guard cells
+        mxg : int, optional
+            Number of x-guard cells to include at the corners
         """
-        return slice(self.xinner_ind, self.xouter_ind), slice(self.ylower_ind - myg,
-                self.ylower_ind)
+        xinner = self.xinner_ind
+        if self.connection_inner is not None:
+            xinner -= mxg
+        xouter = self.xouter_ind
+        if self.connection_outer is not None:
+            xouter += mxg
+        return slice(xinner, xouter), slice(self.ylower_ind - myg, self.ylower_ind)
 
-    def getUpperGuardsSlices(self, myg):
+    def getUpperGuardsSlices(self, *, myg, mxg=0):
         """
         Return x- and y-dimension slices that select myg guard cells on the upper-y side
         of this region from the global DataArray.
@@ -153,9 +174,16 @@ class Region:
         ----------
         myg : int
             Number of guard cells
+        mxg : int, optional
+            Number of x-guard cells to include at the corners
         """
-        return slice(self.xinner_ind, self.xouter_ind), slice(self.yupper_ind,
-                self.yupper_ind + myg)
+        xinner = self.xinner_ind
+        if self.connection_inner is not None:
+            xinner -= mxg
+        xouter = self.xouter_ind
+        if self.connection_outer is not None:
+            xouter += mxg
+        return slice(xinner, xouter), slice(self.yupper_ind, self.yupper_ind + myg)
 
 
 def _in_range(val, lower, upper):

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -72,6 +72,12 @@ class Region:
             self.ylower = dy_cumsum[ylower_ind] - dy[ylower_ind]/2.
             self.yupper = dy_cumsum[yupper_ind - 1] + dy[yupper_ind - 1]/2.
 
+    def __repr__(self):
+        result = "<xbout.region.Region>\n"
+        for attr, val in vars(self).items():
+            result += "\t" + attr + "\t" + str(val) + "\n"
+        return result
+
     def getSlices(self, mxg=0, myg=0):
         """
         Return x- and y-dimension slices that select this region from the global

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -192,10 +192,16 @@ def _get_topology(ds):
         return 'single-null'
 
     if jys11 == jys21 and jys12 == jys22:
-        return 'xpoint'
+        if jys11 < nyinner -1 and jys22 > nyinner:
+            return 'xpoint'
+        else:
+            raise ValueError('Currently unsupported topology')
 
     if ixs1 == ixs2:
-        return 'connected-double-null'
+        if jys21 < nyinner -1 and jys21 > nyinner:
+            return 'connected-double-null'
+        else:
+            raise ValueError('Currently unsupported topology')
 
     return 'disconnected-double-null'
 

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -430,22 +430,22 @@ def _create_regions_toroidal(ds):
         _create_connection_y(regions, 'SOL', 'outer_SOL')
     elif topology == 'limiter':
         regions['core'] = Region(
-                name='core', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=0,
-                yupper_ind=ny)
+                name='core', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=ybndry,
+                yupper_ind=ny - ybndry)
         regions['SOL'] = Region(
-                name='SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=0,
-                yupper_ind=ny)
+                name='SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=ybndry,
+                yupper_ind=ny - ybndry)
         _create_connection_x(regions, 'core', 'SOL')
         _create_connection_y(regions, 'core', 'core')
     elif topology == 'core':
         regions['core'] = Region(
-                name='core', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=0,
-                yupper_ind=ny)
+                name='core', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=ybndry,
+                yupper_ind=ny - ybndry)
         _create_connection_y(regions, 'core', 'core')
     elif topology == 'sol':
         regions['sol'] = Region(
-                name='sol', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=0,
-                yupper_ind=ny)
+                name='sol', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=ybndry,
+                yupper_ind=ny - ybndry)
     elif topology == 'xpoint':
         regions['lower_inner_PFR'] = Region(
                 name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import numpy as np
 
 from .utils import _set_attrs_on_all_vars
@@ -13,6 +15,30 @@ class Region:
     def __init__(self, *, name, ds=None, xinner_ind=None, xouter_ind=None,
                  ylower_ind=None, yupper_ind=None, connect_inner=None, connect_outer=None,
                  connect_lower=None, connect_upper=None):
+        """
+        Parameters
+        ----------
+        name : str
+            Name of the region
+        ds : BoutDataset, optional
+            Dataset to get variables to calculate coordinates from
+        xinner_ind : int, optional
+            Global x-index of the inner points of this region
+        xouter_ind : int, optional
+            Global x-index of the points just beyond the outer edge of this region
+        ylower_ind : int, optional
+            Global y-index of the lower points of this region
+        yupper_ind : int, optional
+            Global y-index of the points just beyond the upper edge of this region
+        connect_inner : str, optional
+            The region inside this one in the x-direction
+        connect_outer : str, optional
+            The region outside this one in the x-direction
+        connect_lower : str, optional
+            The region below this one in the y-direction
+        connect_upper : str, optional
+            The region above this one in the y-direction
+        """
         self.name = name
         self.xinner_ind = xinner_ind
         self.xouter_ind = xouter_ind
@@ -233,7 +259,7 @@ def _create_regions_toroidal(ds):
     ny += 4*ybndry
 
     # Note, include guard cells in the created regions, fill them later
-    regions = {}
+    regions = OrderedDict()
     if topology == 'disconnected-double-null':
         regions['lower_inner_PFR'] = Region(
                 name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -245,6 +245,11 @@ def _create_regions_toroidal(ds):
     myg = ds.metadata['MYG']
     # keep_yboundaries is 1 if there are y-boundaries and 0 if there are not
     ybndry = ds.metadata['keep_yboundaries']*myg
+    if jys21 == jys12:
+        # No upper targets
+        ybndry_upper = 0
+    else:
+        ybndry_upper = ybndry
 
     # Make sure all sizes are sensible
     ixs1 = _in_range(ixs1, 0, nx)
@@ -265,10 +270,10 @@ def _create_regions_toroidal(ds):
         nx -= 2*mxg
     jys11 += ybndry
     jys21 += ybndry
-    nyinner += 2*ybndry
-    jys12 += 3*ybndry
-    jys22 += 3*ybndry
-    ny += 4*ybndry
+    nyinner += ybndry + ybndry_upper
+    jys12 += ybndry + 2*ybndry_upper
+    jys22 += ybndry + 2*ybndry_upper
+    ny += 2*ybndry + 2*ybndry_upper
 
     # Note, include guard cells in the created regions, fill them later
     regions = OrderedDict()

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -344,6 +344,8 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
     ds['MYSUB'] = lengths[2]
     ds['MZSUB'] = lengths[3]
 
+    MYSUB = lengths[2]
+
     if topology == 'core':
         ds['ixseps1'] = nx
         ds['ixseps2'] = nx

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -189,7 +189,7 @@ def bout_xyt_example_files(tmpdir_factory):
 
 def _bout_xyt_example_files(tmpdir_factory, prefix='BOUT.dmp', lengths=(6, 2, 4, 7),
                             nxpe=4, nype=2, nt=1, guards={}, syn_data_type='random',
-                            grid=None, squashed=False):
+                            grid=None, squashed=False, topology='core'):
     """
     Mocks up a set of BOUT-like netCDF files, and return the temporary test directory containing them.
 
@@ -203,13 +203,14 @@ def _bout_xyt_example_files(tmpdir_factory, prefix='BOUT.dmp', lengths=(6, 2, 4,
         # file had been created by combining a set of BOUT.dmp.*.nc files
         ds_list, file_list = create_bout_ds_list(prefix=prefix, lengths=lengths, nxpe=1,
                                                  nype=1, nt=nt, guards=guards,
+                                                 topology=topology,
                                                  syn_data_type=syn_data_type)
         ds_list[0]['nxpe'] = nxpe
         ds_list[0]['nype'] = nype
     else:
         ds_list, file_list = create_bout_ds_list(prefix=prefix, lengths=lengths,
                                                  nxpe=nxpe, nype=nype, nt=nt,
-                                                 guards=guards,
+                                                 guards=guards, topology=topology,
                                                  syn_data_type=syn_data_type)
 
     for ds, file_name in zip(ds_list, file_list):
@@ -218,7 +219,8 @@ def _bout_xyt_example_files(tmpdir_factory, prefix='BOUT.dmp', lengths=(6, 2, 4,
     if grid is not None:
         xsize = lengths[1]*nxpe
         ysize = lengths[2]*nype
-        grid_ds = create_bout_grid_ds(xsize=xsize, ysize=ysize, guards=guards)
+        grid_ds = create_bout_grid_ds(xsize=xsize, ysize=ysize, guards=guards,
+                                      topology=topology)
         grid_ds.to_netcdf(str(save_dir.join(grid + ".nc")))
 
     # Return a glob-like path to all files created, which has all file numbers replaced
@@ -236,7 +238,7 @@ def _bout_xyt_example_files(tmpdir_factory, prefix='BOUT.dmp', lengths=(6, 2, 4,
 
 
 def create_bout_ds_list(prefix, lengths=(6, 2, 4, 7), nxpe=4, nype=2, nt=1, guards={},
-                        syn_data_type='random'):
+                        topology='core', syn_data_type='random'):
     """
     Mocks up a set of BOUT-like datasets.
 
@@ -260,7 +262,7 @@ def create_bout_ds_list(prefix, lengths=(6, 2, 4, 7), nxpe=4, nype=2, nt=1, guar
             lower_bndry_cells = {dim: guards.get(dim) for dim in guards.keys()}
 
             ds = create_bout_ds(syn_data_type=syn_data_type, num=num, lengths=lengths, nxpe=nxpe, nype=nype,
-                                xproc=i, yproc=j, guards=guards)
+                                xproc=i, yproc=j, guards=guards, topology=topology)
             ds_list.append(ds)
 
     # Sort this in order of num to remove any BOUT-specific structure
@@ -271,7 +273,7 @@ def create_bout_ds_list(prefix, lengths=(6, 2, 4, 7), nxpe=4, nype=2, nt=1, guar
 
 
 def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, nype=1,
-                   xproc=0, yproc=0, guards={}):
+                   xproc=0, yproc=0, guards={}, topology='core'):
 
     # Set the shape of the data in this dataset
     t_length, x_length, y_length, z_length = lengths
@@ -341,13 +343,71 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
     ds['MXSUB'] = lengths[1]
     ds['MYSUB'] = lengths[2]
     ds['MZSUB'] = lengths[3]
-    ds['ixseps1'] = nx
-    ds['ixseps2'] = nx
-    ds['jyseps1_1'] = 0
-    ds['jyseps2_1'] = ny//2 - 1
-    ds['jyseps1_2'] = ny//2 - 1
-    ds['jyseps2_2'] = ny
-    ds['ny_inner'] = ny//2
+
+    if topology == 'core':
+        ds['ixseps1'] = nx
+        ds['ixseps2'] = nx
+        ds['jyseps1_1'] = 0
+        ds['jyseps2_1'] = ny//2 - 1
+        ds['jyseps1_2'] = ny//2 - 1
+        ds['jyseps2_2'] = ny
+        ds['ny_inner'] = ny//2
+    elif topology == 'sol':
+        ds['ixseps1'] = 0
+        ds['ixseps2'] = 0
+        ds['jyseps1_1'] = 0
+        ds['jyseps2_1'] = ny//2 - 1
+        ds['jyseps1_2'] = ny//2 - 1
+        ds['jyseps2_2'] = ny
+        ds['ny_inner'] = ny//2
+    elif topology == 'limiter':
+        ds['ixseps1'] = nx//2
+        ds['ixseps2'] = nx
+        ds['jyseps1_1'] = 0
+        ds['jyseps2_1'] = ny//2 - 1
+        ds['jyseps1_2'] = ny//2 - 1
+        ds['jyseps2_2'] = ny
+        ds['ny_inner'] = ny//2
+    elif topology == 'single-null':
+        if nype < 3:
+            raise ValueError('Not enough processors for single-null topology: '
+                             + 'nype=' + str(nype))
+        ds['ixseps1'] = nx//2
+        ds['ixseps2'] = nx
+        ds['jyseps1_1'] = MYSUB - 1
+        ds['jyseps2_1'] = ny//2 - 1
+        ds['jyseps1_2'] = ny//2 - 1
+        ds['jyseps2_2'] = ny - MYSUB - 1
+        ds['ny_inner'] = ny//2
+    elif topology == 'connected-double-null':
+        if nype < 6:
+            raise ValueError('Not enough processors for single-null topology: '
+                             + 'nype=' + str(nype))
+        ds['ixseps1'] = nx//2
+        ds['ixseps2'] = nx//2
+        ds['jyseps1_1'] = MYSUB - 1
+        ny_inner = 3*MYSUB
+        ds['ny_inner'] = ny_inner
+        ds['jyseps2_1'] = ny_inner - MYSUB - 1
+        ds['jyseps1_2'] = ny_inner + MYSUB - 1
+        ds['jyseps2_2'] = ny - MYSUB - 1
+    elif topology == 'disconnected-double-null':
+        if nype < 6:
+            raise ValueError('Not enough processors for single-null topology: '
+                             + 'nype=' + str(nype))
+        ds['ixseps1'] = nx//2
+        ds['ixseps2'] = nx//2 + 2*mxg
+        if ds['ixseps2'] >= nx:
+            raise ValueError('Not enough points in the x-direction. ixseps2='
+                             + str(ds['ixseps2']) + ' > nx=' + str(nx))
+        ds['jyseps1_1'] = MYSUB - 1
+        ny_inner = 3*MYSUB
+        ds['ny_inner'] = ny_inner
+        ds['jyseps2_1'] = ny_inner - MYSUB - 1
+        ds['jyseps1_2'] = ny_inner + MYSUB - 1
+        ds['jyseps2_2'] = ny - MYSUB - 1
+    else:
+        raise ValueError('Unrecognised topology=' + str(topology))
 
     one = DataArray(np.ones((x_length, y_length)), dims=['x', 'y'])
     zero = DataArray(np.zeros((x_length, y_length)), dims=['x', 'y'])
@@ -384,18 +444,33 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
     return ds
 
 
-def create_bout_grid_ds(xsize=2, ysize=4, guards={}):
+def create_bout_grid_ds(xsize=2, ysize=4, guards={}, topology='core'):
 
     # Set the shape of the data in this dataset
     mxg = guards.get('x', 0)
     myg = guards.get('y', 0)
     xsize += 2*mxg
     ysize += 2*myg
+
+    # jyseps* from grid file only ever used to check topology when loading the grid file,
+    # so do not need to be consistent with the main dataset
+    jyseps2_1 = ysize//2
+    jyseps1_2 = jyseps2_1
+
+    if 'double-null' in topology:
+        # Has upper target as well
+        ysize += 2*myg
+
+        # make different from jyseps2_1 so double-null toplogy is recognised
+        jyseps1_2 += 1
+
     shape = (xsize, ysize)
 
     data = DataArray(np.ones(shape), dims=['x', 'y'])
 
-    ds = Dataset({'psixy': data, 'Rxy': data, 'Zxy': data, 'hthe': data})
+    ds = Dataset({'psixy': data, 'Rxy': data, 'Zxy': data, 'hthe': data,
+                  'y_boundary_guards': myg, 'jyseps2_1': jyseps2_1,
+                  'jyseps1_2': jyseps1_2})
 
     return ds
 

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -370,6 +370,18 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
         ds['jyseps1_2'] = ny//2 - 1
         ds['jyseps2_2'] = ny
         ds['ny_inner'] = ny//2
+    elif topology == 'xpoint':
+        if nype < 4:
+            raise ValueError('Not enough processors for xpoint topology: '
+                             + 'nype=' + str(nype))
+        ds['ixseps1'] = nx//2
+        ds['ixseps2'] = nx//2
+        ds['jyseps1_1'] = MYSUB - 1
+        ny_inner = 2*MYSUB
+        ds['ny_inner'] = ny_inner
+        ds['jyseps2_1'] = MYSUB - 1
+        ds['jyseps1_2'] = ny - MYSUB - 1
+        ds['jyseps2_2'] = ny - MYSUB - 1
     elif topology == 'single-null':
         if nype < 3:
             raise ValueError('Not enough processors for single-null topology: '
@@ -459,7 +471,7 @@ def create_bout_grid_ds(xsize=2, ysize=4, guards={}, topology='core', ny_inner=0
     jyseps2_1 = ysize//2
     jyseps1_2 = jyseps2_1
 
-    if 'double-null' in topology:
+    if 'double-null' in topology or 'xpoint' in topology:
         # Has upper target as well
         ysize += 2*myg
 

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -398,7 +398,7 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
             raise ValueError('Not enough processors for disconnected-double-null '
                              + 'topology: nype=' + str(nype))
         ds['ixseps1'] = nx//2
-        ds['ixseps2'] = nx//2 + 2*mxg
+        ds['ixseps2'] = nx//2 + 4
         if ds['ixseps2'] >= nx:
             raise ValueError('Not enough points in the x-direction. ixseps2='
                              + str(ds['ixseps2']) + ' > nx=' + str(nx))

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -220,7 +220,7 @@ def _bout_xyt_example_files(tmpdir_factory, prefix='BOUT.dmp', lengths=(6, 2, 4,
         xsize = lengths[1]*nxpe
         ysize = lengths[2]*nype
         grid_ds = create_bout_grid_ds(xsize=xsize, ysize=ysize, guards=guards,
-                                      topology=topology)
+                                      topology=topology, ny_inner=3*lengths[2])
         grid_ds.to_netcdf(str(save_dir.join(grid + ".nc")))
 
     # Return a glob-like path to all files created, which has all file numbers replaced
@@ -446,7 +446,7 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
     return ds
 
 
-def create_bout_grid_ds(xsize=2, ysize=4, guards={}, topology='core'):
+def create_bout_grid_ds(xsize=2, ysize=4, guards={}, topology='core', ny_inner=0):
 
     # Set the shape of the data in this dataset
     mxg = guards.get('x', 0)
@@ -472,7 +472,7 @@ def create_bout_grid_ds(xsize=2, ysize=4, guards={}, topology='core'):
 
     ds = Dataset({'psixy': data, 'Rxy': data, 'Zxy': data, 'hthe': data,
                   'y_boundary_guards': myg, 'jyseps2_1': jyseps2_1,
-                  'jyseps1_2': jyseps1_2})
+                  'jyseps1_2': jyseps1_2, 'ny_inner': ny_inner, 'y_boundary_guards': myg})
 
     return ds
 

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -472,7 +472,8 @@ def create_bout_grid_ds(xsize=2, ysize=4, guards={}, topology='core', ny_inner=0
 
     ds = Dataset({'psixy': data, 'Rxy': data, 'Zxy': data, 'hthe': data,
                   'y_boundary_guards': myg, 'jyseps2_1': jyseps2_1,
-                  'jyseps1_2': jyseps1_2, 'ny_inner': ny_inner, 'y_boundary_guards': myg})
+                  'jyseps1_2': jyseps1_2, 'ny_inner': ny_inner,
+                  'y_boundary_guards': myg})
 
     return ds
 

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -344,9 +344,9 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
     ds['ixseps1'] = nx
     ds['ixseps2'] = nx
     ds['jyseps1_1'] = 0
-    ds['jyseps1_2'] = ny
     ds['jyseps2_1'] = ny//2 - 1
-    ds['jyseps2_2'] = ny//2 - 1
+    ds['jyseps1_2'] = ny//2 - 1
+    ds['jyseps2_2'] = ny
     ds['ny_inner'] = ny//2
 
     one = DataArray(np.ones((x_length, y_length)), dims=['x', 'y'])

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -383,7 +383,7 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
         ds['ny_inner'] = ny//2
     elif topology == 'connected-double-null':
         if nype < 6:
-            raise ValueError('Not enough processors for single-null topology: '
+            raise ValueError('Not enough processors for connected-double-null topology: '
                              + 'nype=' + str(nype))
         ds['ixseps1'] = nx//2
         ds['ixseps2'] = nx//2
@@ -395,8 +395,8 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
         ds['jyseps2_2'] = ny - MYSUB - 1
     elif topology == 'disconnected-double-null':
         if nype < 6:
-            raise ValueError('Not enough processors for single-null topology: '
-                             + 'nype=' + str(nype))
+            raise ValueError('Not enough processors for disconnected-double-null '
+                             + 'topology: nype=' + str(nype))
         ds['ixseps1'] = nx//2
         ds['ixseps2'] = nx//2 + 2*mxg
         if ds['ixseps2'] >= nx:

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -8,6 +8,7 @@ import xarray.testing as xrt
 from xbout.tests.test_load import bout_xyt_example_files
 from xbout import open_boutdataset
 
+
 class TestRegion:
 
     params_guards = "guards"
@@ -48,8 +49,9 @@ class TestRegion:
             ybndry = guards['y']
         else:
             ybndry = 0
-        xrt.assert_identical(n.isel(theta=slice(ybndry, -ybndry if ybndry!=0 else None)),
-                             n_core.isel(theta=slice(ybndry, -ybndry if ybndry!=0 else None)))
+        xrt.assert_identical(
+                n.isel(theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
+                n_core.isel(theta=slice(ybndry, -ybndry if ybndry != 0 else None)))
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
@@ -110,10 +112,11 @@ class TestRegion:
         # Corners may be different because core region 'communicates' in y
         del n_sol.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs, None)), n_sol.isel(x=slice(mxg, None)))
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, ixs),
-                                    theta=slice(ybndry, -ybndry if ybndry!=0 else None)),
-                             n_sol.isel(x=slice(mxg),
-                                 theta=slice(ybndry, -ybndry if ybndry!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs - mxg, ixs),
+                       theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
+                n_sol.isel(x=slice(mxg),
+                           theta=slice(ybndry, -ybndry if ybndry != 0 else None)))
 
         if guards['y'] > 0 and not keep_yboundaries:
             # expect exception for core region due to not having neighbour cells to get
@@ -125,10 +128,10 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_core.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(ybndry, -ybndry if ybndry!=0 else None)),
-                             n_core.isel(
-                                 theta=slice(ybndry, -ybndry if ybndry!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs + mxg),
+                       theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
+                n_core.isel(theta=slice(ybndry, -ybndry if ybndry != 0 else None)))
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
@@ -169,7 +172,7 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_inner_PFR.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys1 + 1)),
-                             n_inner_PFR.isel(theta=slice(-myg if myg!=0 else None)))
+                             n_inner_PFR.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -182,7 +185,7 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_inner_SOL.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs - mxg, None), theta=slice(jys1 + 1)),
-                             n_inner_SOL.isel(theta=slice(-myg if myg!=0 else None)))
+                             n_inner_SOL.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -196,7 +199,7 @@ class TestRegion:
         del n_core.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys1 + 1, jys2 + 1)),
-                             n_core.isel(theta=slice(myg, -myg if myg!=0 else None)))
+                             n_core.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -213,7 +216,7 @@ class TestRegion:
         del n_sol.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys1 + 1, jys2 + 1)),
-                             n_sol.isel(theta=slice(myg, -myg if myg!=0 else None)))
+                             n_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -294,7 +297,7 @@ class TestRegion:
         del n_lower_inner_PFR.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys11 + 1)),
                              n_lower_inner_PFR.isel(
-                                 theta=slice(-myg if myg!=0 else None)))
+                                 theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -308,7 +311,7 @@ class TestRegion:
         del n_lower_inner_SOL.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs - mxg, None), theta=slice(jys11 + 1)),
                              n_lower_inner_SOL.isel(
-                                 theta=slice(-myg if myg!=0 else None)))
+                                 theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -323,7 +326,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys11 + 1, jys21 + 1)),
                              n_inner_core.isel(
-                                 theta=slice(myg, -myg if myg!=0 else None)))
+                                 theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -338,9 +341,9 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_inner_sol.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys11 + 1, jys21 + 1)),
-                             n_inner_sol.isel(theta=slice(myg, -myg if myg!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs - mxg, None), theta=slice(jys11 + 1, jys21 + 1)),
+                n_inner_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -386,7 +389,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs + mxg),
                                     theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_PFR.isel(
-                                 theta=slice(-myg if myg!=0 else None)))
+                                 theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -401,7 +404,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_SOL.isel(
-                                 theta=slice(-myg if myg!=0 else None)))
+                                 theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -416,7 +419,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys12 + 1, jys22 + 1)),
                              n_outer_core.isel(
-                                 theta=slice(myg, -myg if myg!=0 else None)))
+                                 theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -431,9 +434,9 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_outer_sol.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys12 + 1, jys22 + 1)),
-                             n_outer_sol.isel(theta=slice(myg, -myg if myg!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs - mxg, None), theta=slice(jys12 + 1, jys22 + 1)),
+                n_outer_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -471,7 +474,6 @@ class TestRegion:
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
                              n_lower_outer_SOL.isel(theta=slice(myg)).values)
-
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
@@ -521,7 +523,7 @@ class TestRegion:
         del n_lower_inner_PFR.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs1 + mxg), theta=slice(jys11 + 1)),
                              n_lower_inner_PFR.isel(
-                                 theta=slice(-myg if myg!=0 else None)))
+                                 theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -536,7 +538,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                     theta=slice(jys11 + 1)),
                              n_lower_inner_intersep.isel(
-                                 theta=slice(-myg if myg!=0 else None)))
+                                 theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -550,7 +552,7 @@ class TestRegion:
         del n_lower_inner_SOL.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1)),
                              n_lower_inner_SOL.isel(
-                                 theta=slice(-myg if myg!=0 else None)))
+                                 theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -565,7 +567,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
                                     theta=slice(jys11 + 1, jys21 + 1)),
                              n_inner_core.isel(
-                                 theta=slice(myg, -myg if myg!=0 else None)))
+                                 theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -583,7 +585,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                     theta=slice(jys11 + 1, jys21 + 1)),
                              n_inner_intersep.isel(
-                                 theta=slice(myg, -myg if myg!=0 else None)))
+                                 theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -598,9 +600,9 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_inner_sol.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys11 + 1, jys21 + 1)),
-                             n_inner_sol.isel(theta=slice(myg, -myg if myg!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1, jys21 + 1)),
+                n_inner_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -660,7 +662,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
                                     theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_PFR.isel(
-                                 theta=slice(-myg if myg!=0 else None)))
+                                 theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -675,7 +677,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                     theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_intersep.isel(
-                                 theta=slice(-myg if myg!=0 else None)))
+                                 theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -690,7 +692,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
                                     theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_SOL.isel(
-                                 theta=slice(-myg if myg!=0 else None)))
+                                 theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -705,7 +707,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
                                     theta=slice(jys12 + 1, jys22 + 1)),
                              n_outer_core.isel(
-                                 theta=slice(myg, -myg if myg!=0 else None)))
+                                 theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -723,7 +725,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                     theta=slice(jys12 + 1, jys22 + 1)),
                              n_outer_intersep.isel(
-                                 theta=slice(myg, -myg if myg!=0 else None)))
+                                 theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -738,9 +740,9 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_outer_sol.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys12 + 1, jys22 + 1)),
-                             n_outer_sol.isel(theta=slice(myg, -myg if myg!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs2 - mxg, None), theta=slice(jys12 + 1, jys22 + 1)),
+                n_outer_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -849,9 +851,9 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_lower_inner_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards), theta=slice(jys11 + 1)),
-                             n_lower_inner_PFR.isel(
-                                 theta=slice(-yguards if yguards!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs1 + xguards), theta=slice(jys11 + 1)),
+                n_lower_inner_PFR.isel(theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -867,21 +869,22 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
                                     theta=slice(jys11 + 1)),
                              n_lower_inner_intersep.isel(
-                                 theta=slice(-yguards if yguards!=0 else None)))
+                                 theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
-                             n_lower_inner_intersep.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                           theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
+                    n_lower_inner_intersep.isel(theta=slice(-yguards, None)).values)
 
         n_lower_inner_SOL = n.bout.fromRegion('lower_inner_SOL', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_inner_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None), theta=slice(jys11 + 1)),
-                             n_lower_inner_SOL.isel(
-                                 theta=slice(-yguards if yguards!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs2 - xguards, None), theta=slice(jys11 + 1)),
+                n_lower_inner_SOL.isel(theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -893,10 +896,10 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_inner_core.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys11 + 1, jys21 + 1)),
-                             n_inner_core.isel(
-                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs1 + xguards), theta=slice(jys11 + 1, jys21 + 1)),
+                n_inner_core.isel(
+                    theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -911,10 +914,11 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_inner_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys11 + 1, jys21 + 1)),
-                             n_inner_intersep.isel(
-                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                       theta=slice(jys11 + 1, jys21 + 1)),
+                n_inner_intersep.isel(
+                    theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -929,10 +933,10 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_inner_sol.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys11 + 1, jys21 + 1)),
-                             n_inner_sol.isel(
-                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs2 - xguards, None), theta=slice(jys11 + 1, jys21 + 1)),
+                n_inner_sol.isel(
+                    theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -993,7 +997,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
                                     theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_PFR.isel(
-                                 theta=slice(-yguards if yguards!=0 else None)))
+                                 theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -1009,7 +1013,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
                                     theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_intersep.isel(
-                                 theta=slice(-yguards if yguards!=0 else None)))
+                                 theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -1025,7 +1029,7 @@ class TestRegion:
         xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
                                     theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_SOL.isel(
-                                 theta=slice(-yguards if yguards!=0 else None)))
+                                 theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -1037,10 +1041,10 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_outer_core.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys12 + 1, jys22 + 1)),
-                             n_outer_core.isel(
-                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs1 + xguards), theta=slice(jys12 + 1, jys22 + 1)),
+                n_outer_core.isel(
+                    theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -1055,10 +1059,11 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_outer_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys12 + 1, jys22 + 1)),
-                             n_outer_intersep.isel(
-                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                       theta=slice(jys12 + 1, jys22 + 1)),
+                n_outer_intersep.isel(
+                    theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values
@@ -1073,10 +1078,10 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_outer_sol.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys12 + 1, jys22 + 1)),
-                             n_outer_sol.isel(
-                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        xrt.assert_identical(
+                n.isel(x=slice(ixs2 - xguards, None), theta=slice(jys12 + 1, jys22 + 1)),
+                n_outer_sol.isel(
+                    theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by fromRegion
             # Coordinates are not equal, so only compare array values

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -2,6 +2,7 @@ import pytest
 
 from pathlib import Path
 
+import numpy.testing as npt
 import xarray.testing as xrt
 
 from xbout.tests.test_load import bout_xyt_example_files
@@ -47,8 +48,8 @@ class TestRegion:
             ybndry = guards['y']
         else:
             ybndry = 0
-        xrt.assert_identical(n.isel(theta=slice(ybndry, -ybndry)),
-                             n_core.isel(theta=slice(ybndry, -ybndry)))
+        xrt.assert_identical(n.isel(theta=slice(ybndry, -ybndry if ybndry!=0 else None)),
+                             n_core.isel(theta=slice(ybndry, -ybndry if ybndry!=0 else None)))
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
@@ -110,8 +111,9 @@ class TestRegion:
         del n_sol.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs, None)), n_sol.isel(x=slice(mxg, None)))
         xrt.assert_identical(n.isel(x=slice(ixs - mxg, ixs),
-                                    theta=slice(ybndry, -ybndry)),
-                             n_sol.isel(x=slice(mxg), theta=slice(ybndry, -ybndry)))
+                                    theta=slice(ybndry, -ybndry if ybndry!=0 else None)),
+                             n_sol.isel(x=slice(mxg),
+                                 theta=slice(ybndry, -ybndry if ybndry!=0 else None)))
 
         if guards['y'] > 0 and not keep_yboundaries:
             # expect exception for core region due to not having neighbour cells to get
@@ -123,5 +125,7 @@ class TestRegion:
 
         # Remove attributes that are expected to be different
         del n_core.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(ybndry, -ybndry)),
-                             n_core.isel(theta=slice(ybndry, -ybndry)))
+        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(ybndry, -ybndry if ybndry!=0 else None)),
+                             n_core.isel(
+                                 theta=slice(ybndry, -ybndry if ybndry!=0 else None)))

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -1,0 +1,51 @@
+import pytest
+
+from pathlib import Path
+
+import xarray.testing as xrt
+
+from xbout.tests.test_load import bout_xyt_example_files
+from xbout import open_boutdataset
+
+class TestRegion:
+
+    params_guards = "guards"
+    params_guards_values = [{'x': 0, 'y': 0}, {'x': 2, 'y': 0}, {'x': 0, 'y': 2},
+                            {'x': 2, 'y': 2}]
+    params_boundaries = "keep_xboundaries, keep_yboundaries"
+    params_boundaries_values = [(False, False), (True, False), (False, True),
+                                (True, True)]
+
+    @pytest.mark.parametrize(params_guards, params_guards_values)
+    @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
+    def test_region_core(self, tmpdir_factory, bout_xyt_example_files, guards,
+                         keep_xboundaries, keep_yboundaries):
+        # Note need to use more than (3*MXG,3*MYG) points per output file
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+                                      nype=4, nt=1, guards=guards, grid='grid',
+                                      topology='core')
+
+        ds = open_boutdataset(datapath=path,
+                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
+                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
+                              keep_yboundaries=keep_yboundaries)
+
+        n = ds['n']
+
+        if guards['y'] > 0 and not keep_yboundaries:
+            # expect exception for core topology due to not having neighbour cells to get
+            # coordinate values from
+            with pytest.raises(ValueError):
+                n_core = n.bout.fromRegion('core')
+            return
+        n_core = n.bout.fromRegion('core')
+
+        # Remove attributes that are expected to be different
+        del n_core.attrs['region']
+        # Select only non-boundary data
+        if keep_yboundaries:
+            ybndry = guards['y']
+        else:
+            ybndry = 0
+        xrt.assert_identical(n.isel(theta=slice(ybndry, -ybndry)),
+                             n_core.isel(theta=slice(ybndry, -ybndry)))

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -471,3 +471,324 @@ class TestRegion:
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
                              n_lower_outer_SOL.isel(theta=slice(myg)).values)
+
+
+    @pytest.mark.parametrize(params_guards, params_guards_values)
+    @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
+    def test_region_disconnecteddoublenull(self, tmpdir_factory, bout_xyt_example_files,
+                                           guards, keep_xboundaries, keep_yboundaries):
+        # Note using more than MXG x-direction points and MYG y-direction points per
+        # output file ensures tests for whether boundary cells are present do not fail
+        # when using minimal numbers of processors
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+                                      nype=6, nt=1, guards=guards, grid='grid',
+                                      topology='disconnected-double-null')
+
+        ds = open_boutdataset(datapath=path,
+                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
+                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
+                              keep_yboundaries=keep_yboundaries)
+
+        mxg = guards['x']
+        myg = guards['y']
+
+        if keep_xboundaries:
+            ixs1 = ds.metadata['ixseps1']
+        else:
+            ixs1 = ds.metadata['ixseps1'] - guards['x']
+
+        if keep_xboundaries:
+            ixs2 = ds.metadata['ixseps2']
+        else:
+            ixs2 = ds.metadata['ixseps2'] - guards['x']
+
+        if keep_yboundaries:
+            ybndry = guards['y']
+        else:
+            ybndry = 0
+        jys11 = ds.metadata['jyseps1_1'] + ybndry
+        jys21 = ds.metadata['jyseps2_1'] + ybndry
+        ny_inner = ds.metadata['ny_inner'] + 2*ybndry
+        jys12 = ds.metadata['jyseps1_2'] + 3*ybndry
+        jys22 = ds.metadata['jyseps2_2'] + 3*ybndry
+        ny = ds.metadata['ny'] + 4*ybndry
+
+        n = ds['n']
+
+        n_lower_inner_PFR = n.bout.fromRegion('lower_inner_PFR')
+
+        # Remove attributes that are expected to be different
+        del n_lower_inner_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg), theta=slice(jys11 + 1)),
+                             n_lower_inner_PFR.isel(
+                                 theta=slice(-myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                             n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
+
+        n_lower_inner_intersep = n.bout.fromRegion('lower_inner_intersep')
+
+        # Remove attributes that are expected to be different
+        del n_lower_inner_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys11 + 1)),
+                             n_lower_inner_intersep.isel(
+                                 theta=slice(-myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                             n_lower_inner_intersep.isel(theta=slice(-myg, None)).values)
+
+        n_lower_inner_SOL = n.bout.fromRegion('lower_inner_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_lower_inner_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1)),
+                             n_lower_inner_SOL.isel(
+                                 theta=slice(-myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                             n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
+
+        n_inner_core = n.bout.fromRegion('inner_core')
+
+        # Remove attributes that are expected to be different
+        del n_inner_core.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys11 + 1, jys21 + 1)),
+                             n_inner_core.isel(
+                                 theta=slice(myg, -myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                             n_inner_core.isel(theta=slice(myg)).values)
+            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                             n_inner_core.isel(theta=slice(-myg, None)).values)
+
+        n_inner_intersep = n.bout.fromRegion('inner_intersep')
+
+        # Remove attributes that are expected to be different
+        del n_inner_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys11 + 1, jys21 + 1)),
+                             n_inner_intersep.isel(
+                                 theta=slice(myg, -myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                             n_inner_intersep.isel(theta=slice(myg)).values)
+            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                             n_inner_intersep.isel(theta=slice(-myg, None)).values)
+
+        n_inner_sol = n.bout.fromRegion('inner_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_inner_sol.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys11 + 1, jys21 + 1)),
+                             n_inner_sol.isel(theta=slice(myg, -myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                             n_inner_sol.isel(theta=slice(myg)).values)
+            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                             n_inner_sol.isel(theta=slice(-myg, None)).values)
+
+        n_upper_inner_PFR = n.bout.fromRegion('upper_inner_PFR')
+
+        # Remove attributes that are expected to be different
+        del n_upper_inner_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys21 + 1, ny_inner)),
+                             n_upper_inner_PFR.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                             n_upper_inner_PFR.isel(theta=slice(myg)).values)
+
+        n_upper_inner_intersep = n.bout.fromRegion('upper_inner_intersep')
+
+        # Remove attributes that are expected to be different
+        del n_upper_inner_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys21 + 1, ny_inner)),
+                             n_upper_inner_intersep.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                             n_upper_inner_intersep.isel(theta=slice(myg)).values)
+
+        n_upper_inner_SOL = n.bout.fromRegion('upper_inner_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_upper_inner_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys21 + 1, ny_inner)),
+                             n_upper_inner_SOL.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                             n_upper_inner_SOL.isel(theta=slice(myg)).values)
+
+        n_upper_outer_PFR = n.bout.fromRegion('upper_outer_PFR')
+
+        # Remove attributes that are expected to be different
+        del n_upper_outer_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(ny_inner, jys12 + 1)),
+                             n_upper_outer_PFR.isel(
+                                 theta=slice(-myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                             n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
+
+        n_upper_outer_intersep = n.bout.fromRegion('upper_outer_intersep')
+
+        # Remove attributes that are expected to be different
+        del n_upper_outer_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(ny_inner, jys12 + 1)),
+                             n_upper_outer_intersep.isel(
+                                 theta=slice(-myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                             n_upper_outer_intersep.isel(theta=slice(-myg, None)).values)
+
+        n_upper_outer_SOL = n.bout.fromRegion('upper_outer_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_upper_outer_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(ny_inner, jys12 + 1)),
+                             n_upper_outer_SOL.isel(
+                                 theta=slice(-myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                             n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
+
+        n_outer_core = n.bout.fromRegion('outer_core')
+
+        # Remove attributes that are expected to be different
+        del n_outer_core.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys12 + 1, jys22 + 1)),
+                             n_outer_core.isel(
+                                 theta=slice(myg, -myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                             n_outer_core.isel(theta=slice(myg)).values)
+            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                             n_outer_core.isel(theta=slice(-myg, None)).values)
+
+        n_outer_intersep = n.bout.fromRegion('outer_intersep')
+
+        # Remove attributes that are expected to be different
+        del n_outer_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys12 + 1, jys22 + 1)),
+                             n_outer_intersep.isel(
+                                 theta=slice(myg, -myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                             n_outer_intersep.isel(theta=slice(myg)).values)
+            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                             n_outer_intersep.isel(theta=slice(-myg, None)).values)
+
+        n_outer_sol = n.bout.fromRegion('outer_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_outer_sol.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys12 + 1, jys22 + 1)),
+                             n_outer_sol.isel(theta=slice(myg, -myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                             n_outer_sol.isel(theta=slice(myg)).values)
+            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                             n_outer_sol.isel(theta=slice(-myg, None)).values)
+
+        n_lower_outer_PFR = n.bout.fromRegion('lower_outer_PFR')
+
+        # Remove attributes that are expected to be different
+        del n_lower_outer_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys22 + 1, None)),
+                             n_lower_outer_PFR.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
+                                    theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                             n_lower_outer_PFR.isel(theta=slice(myg)).values)
+
+        n_lower_outer_intersep = n.bout.fromRegion('lower_outer_intersep')
+
+        # Remove attributes that are expected to be different
+        del n_lower_outer_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys22 + 1, None)),
+                             n_lower_outer_intersep.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                    theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                             n_lower_outer_intersep.isel(theta=slice(myg)).values)
+
+        n_lower_outer_SOL = n.bout.fromRegion('lower_outer_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_lower_outer_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys22 + 1, None)),
+                             n_lower_outer_SOL.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
+                                    theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                             n_lower_outer_SOL.isel(theta=slice(myg)).values)

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -792,3 +792,340 @@ class TestRegion:
             npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
                              n_lower_outer_SOL.isel(theta=slice(myg)).values)
+
+    @pytest.mark.parametrize(params_guards, params_guards_values)
+    @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
+    @pytest.mark.parametrize('with_guards',
+                             [0, {'x': 1}, {'theta': 1}, {'x': 1, 'theta': 1}, 1])
+    def test_region_disconnecteddoublenull_get_one_guard(
+            self, tmpdir_factory, bout_xyt_example_files, guards, keep_xboundaries,
+            keep_yboundaries, with_guards):
+        # Note using more than MXG x-direction points and MYG y-direction points per
+        # output file ensures tests for whether boundary cells are present do not fail
+        # when using minimal numbers of processors
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+                                      nype=6, nt=1, guards=guards, grid='grid',
+                                      topology='disconnected-double-null')
+
+        ds = open_boutdataset(datapath=path,
+                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
+                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
+                              keep_yboundaries=keep_yboundaries)
+
+        mxg = guards['x']
+        myg = guards['y']
+
+        if keep_xboundaries:
+            ixs1 = ds.metadata['ixseps1']
+        else:
+            ixs1 = ds.metadata['ixseps1'] - guards['x']
+
+        if keep_xboundaries:
+            ixs2 = ds.metadata['ixseps2']
+        else:
+            ixs2 = ds.metadata['ixseps2'] - guards['x']
+
+        if keep_yboundaries:
+            ybndry = guards['y']
+        else:
+            ybndry = 0
+        jys11 = ds.metadata['jyseps1_1'] + ybndry
+        jys21 = ds.metadata['jyseps2_1'] + ybndry
+        ny_inner = ds.metadata['ny_inner'] + 2*ybndry
+        jys12 = ds.metadata['jyseps1_2'] + 3*ybndry
+        jys22 = ds.metadata['jyseps2_2'] + 3*ybndry
+        ny = ds.metadata['ny'] + 4*ybndry
+
+        if isinstance(with_guards, dict):
+            xguards = with_guards.get('x', mxg)
+            yguards = with_guards.get('theta', myg)
+        else:
+            xguards = with_guards
+            yguards = with_guards
+
+        n = ds['n']
+
+        n_lower_inner_PFR = n.bout.fromRegion('lower_inner_PFR', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_lower_inner_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards), theta=slice(jys11 + 1)),
+                             n_lower_inner_PFR.isel(
+                                 theta=slice(-yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
+                             n_lower_inner_PFR.isel(theta=slice(-yguards, None)).values)
+
+        n_lower_inner_intersep = n.bout.fromRegion('lower_inner_intersep',
+                                                   with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_lower_inner_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys11 + 1)),
+                             n_lower_inner_intersep.isel(
+                                 theta=slice(-yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
+                             n_lower_inner_intersep.isel(theta=slice(-yguards, None)).values)
+
+        n_lower_inner_SOL = n.bout.fromRegion('lower_inner_SOL', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_lower_inner_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None), theta=slice(jys11 + 1)),
+                             n_lower_inner_SOL.isel(
+                                 theta=slice(-yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
+                             n_lower_inner_SOL.isel(theta=slice(-yguards, None)).values)
+
+        n_inner_core = n.bout.fromRegion('inner_core', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_inner_core.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys11 + 1, jys21 + 1)),
+                             n_inner_core.isel(
+                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
+                             n_inner_core.isel(theta=slice(yguards)).values)
+            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
+                             n_inner_core.isel(theta=slice(-yguards, None)).values)
+
+        n_inner_intersep = n.bout.fromRegion('inner_intersep', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_inner_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys11 + 1, jys21 + 1)),
+                             n_inner_intersep.isel(
+                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
+                             n_inner_intersep.isel(theta=slice(yguards)).values)
+            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
+                             n_inner_intersep.isel(theta=slice(-yguards, None)).values)
+
+        n_inner_sol = n.bout.fromRegion('inner_SOL', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_inner_sol.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys11 + 1, jys21 + 1)),
+                             n_inner_sol.isel(
+                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
+                             n_inner_sol.isel(theta=slice(yguards)).values)
+            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
+                             n_inner_sol.isel(theta=slice(-yguards, None)).values)
+
+        n_upper_inner_PFR = n.bout.fromRegion('upper_inner_PFR', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_upper_inner_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys21 + 1, ny_inner)),
+                             n_upper_inner_PFR.isel(theta=slice(yguards, None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
+                             n_upper_inner_PFR.isel(theta=slice(yguards)).values)
+
+        n_upper_inner_intersep = n.bout.fromRegion('upper_inner_intersep',
+                                                   with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_upper_inner_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys21 + 1, ny_inner)),
+                             n_upper_inner_intersep.isel(theta=slice(yguards, None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
+                             n_upper_inner_intersep.isel(theta=slice(yguards)).values)
+
+        n_upper_inner_SOL = n.bout.fromRegion('upper_inner_SOL', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_upper_inner_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys21 + 1, ny_inner)),
+                             n_upper_inner_SOL.isel(theta=slice(yguards, None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
+                             n_upper_inner_SOL.isel(theta=slice(yguards)).values)
+
+        n_upper_outer_PFR = n.bout.fromRegion('upper_outer_PFR', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_upper_outer_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(ny_inner, jys12 + 1)),
+                             n_upper_outer_PFR.isel(
+                                 theta=slice(-yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
+                             n_upper_outer_PFR.isel(theta=slice(-yguards, None)).values)
+
+        n_upper_outer_intersep = n.bout.fromRegion('upper_outer_intersep',
+                                                   with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_upper_outer_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(ny_inner, jys12 + 1)),
+                             n_upper_outer_intersep.isel(
+                                 theta=slice(-yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
+                             n_upper_outer_intersep.isel(
+                                 theta=slice(-yguards, None)).values)
+
+        n_upper_outer_SOL = n.bout.fromRegion('upper_outer_SOL', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_upper_outer_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(ny_inner, jys12 + 1)),
+                             n_upper_outer_SOL.isel(
+                                 theta=slice(-yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
+                             n_upper_outer_SOL.isel(theta=slice(-yguards, None)).values)
+
+        n_outer_core = n.bout.fromRegion('outer_core', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_outer_core.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys12 + 1, jys22 + 1)),
+                             n_outer_core.isel(
+                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
+                             n_outer_core.isel(theta=slice(yguards)).values)
+            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
+                             n_outer_core.isel(theta=slice(-yguards, None)).values)
+
+        n_outer_intersep = n.bout.fromRegion('outer_intersep', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_outer_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys12 + 1, jys22 + 1)),
+                             n_outer_intersep.isel(
+                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
+                             n_outer_intersep.isel(theta=slice(yguards)).values)
+            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
+                             n_outer_intersep.isel(theta=slice(-yguards, None)).values)
+
+        n_outer_sol = n.bout.fromRegion('outer_SOL', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_outer_sol.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys12 + 1, jys22 + 1)),
+                             n_outer_sol.isel(
+                                 theta=slice(yguards, -yguards if yguards!=0 else None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
+                             n_outer_sol.isel(theta=slice(yguards)).values)
+            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
+                             n_outer_sol.isel(theta=slice(-yguards, None)).values)
+
+        n_lower_outer_PFR = n.bout.fromRegion('lower_outer_PFR', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_lower_outer_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys22 + 1, None)),
+                             n_lower_outer_PFR.isel(theta=slice(yguards, None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
+                                    theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
+                             n_lower_outer_PFR.isel(theta=slice(yguards)).values)
+
+        n_lower_outer_intersep = n.bout.fromRegion('lower_outer_intersep',
+                                                   with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_lower_outer_intersep.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys22 + 1, None)),
+                             n_lower_outer_intersep.isel(theta=slice(yguards, None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                    theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
+                             n_lower_outer_intersep.isel(theta=slice(yguards)).values)
+
+        n_lower_outer_SOL = n.bout.fromRegion('lower_outer_SOL', with_guards=with_guards)
+
+        # Remove attributes that are expected to be different
+        del n_lower_outer_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys22 + 1, None)),
+                             n_lower_outer_SOL.isel(theta=slice(yguards, None)))
+        if yguards > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
+                                    theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
+                             n_lower_outer_SOL.isel(theta=slice(yguards)).values)

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -23,7 +23,7 @@ class TestRegion:
     def test_region_core(self, tmpdir_factory, bout_xyt_example_files, guards,
                          keep_xboundaries, keep_yboundaries):
         # Note need to use more than (3*MXG,3*MYG) points per output file
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
                                       nype=4, nt=1, guards=guards, grid='grid',
                                       topology='core')
 
@@ -58,7 +58,7 @@ class TestRegion:
     def test_region_sol(self, tmpdir_factory, bout_xyt_example_files, guards,
                         keep_xboundaries, keep_yboundaries):
         # Note need to use more than (3*MXG,3*MYG) points per output file
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
                                       nype=4, nt=1, guards=guards, grid='grid',
                                       topology='sol')
 
@@ -82,7 +82,7 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
                                       nype=4, nt=1, guards=guards, grid='grid',
                                       topology='limiter')
 
@@ -140,7 +140,7 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
                                       nype=4, nt=1, guards=guards, grid='grid',
                                       topology='xpoint')
 
@@ -289,7 +289,7 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
                                       nype=4, nt=1, guards=guards, grid='grid',
                                       topology='single-null')
 
@@ -410,7 +410,7 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
                                       nype=6, nt=1, guards=guards, grid='grid',
                                       topology='connected-double-null')
 
@@ -631,7 +631,7 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
                                       nype=6, nt=1, guards=guards, grid='grid',
                                       topology='disconnected-double-null')
 
@@ -954,7 +954,7 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
                                       nype=6, nt=1, guards=guards, grid='grid',
                                       topology='disconnected-double-null')
 

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -38,9 +38,9 @@ class TestRegion:
             # expect exception for core topology due to not having neighbour cells to get
             # coordinate values from
             with pytest.raises(ValueError):
-                n_core = n.bout.fromRegion('core')
+                n_core = n.bout.from_region('core')
             return
-        n_core = n.bout.fromRegion('core')
+        n_core = n.bout.from_region('core')
 
         # Remove attributes that are expected to be different
         del n_core.attrs['region']
@@ -69,7 +69,7 @@ class TestRegion:
 
         n = ds['n']
 
-        n_sol = n.bout.fromRegion('SOL')
+        n_sol = n.bout.from_region('SOL')
 
         # Remove attributes that are expected to be different
         del n_sol.attrs['region']
@@ -106,7 +106,7 @@ class TestRegion:
 
         n = ds['n']
 
-        n_sol = n.bout.fromRegion('SOL')
+        n_sol = n.bout.from_region('SOL')
 
         # Remove attributes that are expected to be different
         # Corners may be different because core region 'communicates' in y
@@ -122,9 +122,9 @@ class TestRegion:
             # expect exception for core region due to not having neighbour cells to get
             # coordinate values from
             with pytest.raises(ValueError):
-                n_core = n.bout.fromRegion('core')
+                n_core = n.bout.from_region('core')
             return
-        n_core = n.bout.fromRegion('core')
+        n_core = n.bout.from_region('core')
 
         # Remove attributes that are expected to be different
         del n_core.attrs['region']
@@ -168,7 +168,7 @@ class TestRegion:
 
         n = ds['n']
 
-        n_lower_inner_PFR = n.bout.fromRegion('lower_inner_PFR')
+        n_lower_inner_PFR = n.bout.from_region('lower_inner_PFR')
 
         # Remove attributes that are expected to be different
         del n_lower_inner_PFR.attrs['region']
@@ -176,13 +176,13 @@ class TestRegion:
                              n_lower_inner_PFR.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
                              n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
 
-        n_lower_inner_SOL = n.bout.fromRegion('lower_inner_SOL')
+        n_lower_inner_SOL = n.bout.from_region('lower_inner_SOL')
 
         # Remove attributes that are expected to be different
         del n_lower_inner_SOL.attrs['region']
@@ -190,13 +190,13 @@ class TestRegion:
                              n_lower_inner_SOL.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
                              n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
 
-        n_upper_inner_PFR = n.bout.fromRegion('upper_inner_PFR')
+        n_upper_inner_PFR = n.bout.from_region('upper_inner_PFR')
 
         # Remove attributes that are expected to be different
         del n_upper_inner_PFR.attrs['region']
@@ -204,13 +204,13 @@ class TestRegion:
                                     theta=slice(jys1 + 1, ny_inner)),
                              n_upper_inner_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
                              n_upper_inner_PFR.isel(theta=slice(myg)).values)
 
-        n_upper_inner_SOL = n.bout.fromRegion('upper_inner_SOL')
+        n_upper_inner_SOL = n.bout.from_region('upper_inner_SOL')
 
         # Remove attributes that are expected to be different
         del n_upper_inner_SOL.attrs['region']
@@ -218,13 +218,13 @@ class TestRegion:
                                     theta=slice(jys1 + 1, ny_inner)),
                              n_upper_inner_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
                              n_upper_inner_SOL.isel(theta=slice(myg)).values)
 
-        n_upper_outer_PFR = n.bout.fromRegion('upper_outer_PFR')
+        n_upper_outer_PFR = n.bout.from_region('upper_outer_PFR')
 
         # Remove attributes that are expected to be different
         del n_upper_outer_PFR.attrs['region']
@@ -233,13 +233,13 @@ class TestRegion:
                              n_upper_outer_PFR.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
                              n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
 
-        n_upper_outer_SOL = n.bout.fromRegion('upper_outer_SOL')
+        n_upper_outer_SOL = n.bout.from_region('upper_outer_SOL')
 
         # Remove attributes that are expected to be different
         del n_upper_outer_SOL.attrs['region']
@@ -248,13 +248,13 @@ class TestRegion:
                              n_upper_outer_SOL.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
                              n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
 
-        n_lower_outer_PFR = n.bout.fromRegion('lower_outer_PFR')
+        n_lower_outer_PFR = n.bout.from_region('lower_outer_PFR')
 
         # Remove attributes that are expected to be different
         del n_lower_outer_PFR.attrs['region']
@@ -262,13 +262,13 @@ class TestRegion:
                                     theta=slice(jys2 + 1, None)),
                              n_lower_outer_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
                              n_lower_outer_PFR.isel(theta=slice(myg)).values)
 
-        n_lower_outer_SOL = n.bout.fromRegion('lower_outer_SOL')
+        n_lower_outer_SOL = n.bout.from_region('lower_outer_SOL')
 
         # Remove attributes that are expected to be different
         del n_lower_outer_SOL.attrs['region']
@@ -276,7 +276,7 @@ class TestRegion:
                                     theta=slice(jys2 + 1, None)),
                              n_lower_outer_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
@@ -316,33 +316,33 @@ class TestRegion:
 
         n = ds['n']
 
-        n_inner_PFR = n.bout.fromRegion('inner_PFR')
+        n_inner_PFR = n.bout.from_region('inner_PFR')
 
         # Remove attributes that are expected to be different
         del n_inner_PFR.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys1 + 1)),
                              n_inner_PFR.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
                              n_inner_PFR.isel(theta=slice(-myg, None)).values)
 
-        n_inner_SOL = n.bout.fromRegion('inner_SOL')
+        n_inner_SOL = n.bout.from_region('inner_SOL')
 
         # Remove attributes that are expected to be different
         del n_inner_SOL.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs - mxg, None), theta=slice(jys1 + 1)),
                              n_inner_SOL.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
                              n_inner_SOL.isel(theta=slice(-myg, None)).values)
 
-        n_core = n.bout.fromRegion('core')
+        n_core = n.bout.from_region('core')
 
         # Remove attributes that are expected to be different
         del n_core.attrs['region']
@@ -350,7 +350,7 @@ class TestRegion:
                                     theta=slice(jys1 + 1, jys2 + 1)),
                              n_core.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
@@ -359,7 +359,7 @@ class TestRegion:
                                     theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
                              n_core.isel(theta=slice(-myg, None)).values)
 
-        n_sol = n.bout.fromRegion('SOL')
+        n_sol = n.bout.from_region('SOL')
 
         # Remove attributes that are expected to be different
         del n_sol.attrs['region']
@@ -367,7 +367,7 @@ class TestRegion:
                                     theta=slice(jys1 + 1, jys2 + 1)),
                              n_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
@@ -376,20 +376,20 @@ class TestRegion:
                                     theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
                              n_sol.isel(theta=slice(-myg, None)).values)
 
-        n_outer_PFR = n.bout.fromRegion('outer_PFR')
+        n_outer_PFR = n.bout.from_region('outer_PFR')
 
         # Remove attributes that are expected to be different
         del n_outer_PFR.attrs['region']
         xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys2 + 1, None)),
                              n_outer_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
                              n_outer_PFR.isel(theta=slice(myg)).values)
 
-        n_outer_SOL = n.bout.fromRegion('outer_SOL')
+        n_outer_SOL = n.bout.from_region('outer_SOL')
 
         # Remove attributes that are expected to be different
         del n_outer_SOL.attrs['region']
@@ -397,7 +397,7 @@ class TestRegion:
                                     theta=slice(jys2 + 1, None)),
                              n_outer_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
@@ -440,7 +440,7 @@ class TestRegion:
 
         n = ds['n']
 
-        n_lower_inner_PFR = n.bout.fromRegion('lower_inner_PFR')
+        n_lower_inner_PFR = n.bout.from_region('lower_inner_PFR')
 
         # Remove attributes that are expected to be different
         del n_lower_inner_PFR.attrs['region']
@@ -448,13 +448,13 @@ class TestRegion:
                              n_lower_inner_PFR.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
                              n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
 
-        n_lower_inner_SOL = n.bout.fromRegion('lower_inner_SOL')
+        n_lower_inner_SOL = n.bout.from_region('lower_inner_SOL')
 
         # Remove attributes that are expected to be different
         del n_lower_inner_SOL.attrs['region']
@@ -462,13 +462,13 @@ class TestRegion:
                              n_lower_inner_SOL.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
                              n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
 
-        n_inner_core = n.bout.fromRegion('inner_core')
+        n_inner_core = n.bout.from_region('inner_core')
 
         # Remove attributes that are expected to be different
         del n_inner_core.attrs['region']
@@ -477,7 +477,7 @@ class TestRegion:
                              n_inner_core.isel(
                                  theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
@@ -486,7 +486,7 @@ class TestRegion:
                                     theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
                              n_inner_core.isel(theta=slice(-myg, None)).values)
 
-        n_inner_sol = n.bout.fromRegion('inner_SOL')
+        n_inner_sol = n.bout.from_region('inner_SOL')
 
         # Remove attributes that are expected to be different
         del n_inner_sol.attrs['region']
@@ -494,7 +494,7 @@ class TestRegion:
                 n.isel(x=slice(ixs - mxg, None), theta=slice(jys11 + 1, jys21 + 1)),
                 n_inner_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
@@ -503,7 +503,7 @@ class TestRegion:
                                     theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
                              n_inner_sol.isel(theta=slice(-myg, None)).values)
 
-        n_upper_inner_PFR = n.bout.fromRegion('upper_inner_PFR')
+        n_upper_inner_PFR = n.bout.from_region('upper_inner_PFR')
 
         # Remove attributes that are expected to be different
         del n_upper_inner_PFR.attrs['region']
@@ -511,13 +511,13 @@ class TestRegion:
                                     theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
                              n_upper_inner_PFR.isel(theta=slice(myg)).values)
 
-        n_upper_inner_SOL = n.bout.fromRegion('upper_inner_SOL')
+        n_upper_inner_SOL = n.bout.from_region('upper_inner_SOL')
 
         # Remove attributes that are expected to be different
         del n_upper_inner_SOL.attrs['region']
@@ -525,13 +525,13 @@ class TestRegion:
                                     theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
                              n_upper_inner_SOL.isel(theta=slice(myg)).values)
 
-        n_upper_outer_PFR = n.bout.fromRegion('upper_outer_PFR')
+        n_upper_outer_PFR = n.bout.from_region('upper_outer_PFR')
 
         # Remove attributes that are expected to be different
         del n_upper_outer_PFR.attrs['region']
@@ -540,13 +540,13 @@ class TestRegion:
                              n_upper_outer_PFR.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
                              n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
 
-        n_upper_outer_SOL = n.bout.fromRegion('upper_outer_SOL')
+        n_upper_outer_SOL = n.bout.from_region('upper_outer_SOL')
 
         # Remove attributes that are expected to be different
         del n_upper_outer_SOL.attrs['region']
@@ -555,13 +555,13 @@ class TestRegion:
                              n_upper_outer_SOL.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
                              n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
 
-        n_outer_core = n.bout.fromRegion('outer_core')
+        n_outer_core = n.bout.from_region('outer_core')
 
         # Remove attributes that are expected to be different
         del n_outer_core.attrs['region']
@@ -570,7 +570,7 @@ class TestRegion:
                              n_outer_core.isel(
                                  theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
@@ -579,7 +579,7 @@ class TestRegion:
                                     theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
                              n_outer_core.isel(theta=slice(-myg, None)).values)
 
-        n_outer_sol = n.bout.fromRegion('outer_SOL')
+        n_outer_sol = n.bout.from_region('outer_SOL')
 
         # Remove attributes that are expected to be different
         del n_outer_sol.attrs['region']
@@ -587,7 +587,7 @@ class TestRegion:
                 n.isel(x=slice(ixs - mxg, None), theta=slice(jys12 + 1, jys22 + 1)),
                 n_outer_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
@@ -596,7 +596,7 @@ class TestRegion:
                                     theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
                              n_outer_sol.isel(theta=slice(-myg, None)).values)
 
-        n_lower_outer_PFR = n.bout.fromRegion('lower_outer_PFR')
+        n_lower_outer_PFR = n.bout.from_region('lower_outer_PFR')
 
         # Remove attributes that are expected to be different
         del n_lower_outer_PFR.attrs['region']
@@ -604,13 +604,13 @@ class TestRegion:
                                     theta=slice(jys22 + 1, None)),
                              n_lower_outer_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs + mxg),
                                     theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
                              n_lower_outer_PFR.isel(theta=slice(myg)).values)
 
-        n_lower_outer_SOL = n.bout.fromRegion('lower_outer_SOL')
+        n_lower_outer_SOL = n.bout.from_region('lower_outer_SOL')
 
         # Remove attributes that are expected to be different
         del n_lower_outer_SOL.attrs['region']
@@ -618,7 +618,7 @@ class TestRegion:
                                     theta=slice(jys22 + 1, None)),
                              n_lower_outer_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
@@ -666,7 +666,7 @@ class TestRegion:
 
         n = ds['n']
 
-        n_lower_inner_PFR = n.bout.fromRegion('lower_inner_PFR')
+        n_lower_inner_PFR = n.bout.from_region('lower_inner_PFR')
 
         # Remove attributes that are expected to be different
         del n_lower_inner_PFR.attrs['region']
@@ -674,13 +674,13 @@ class TestRegion:
                              n_lower_inner_PFR.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
                                     theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
                              n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
 
-        n_lower_inner_intersep = n.bout.fromRegion('lower_inner_intersep')
+        n_lower_inner_intersep = n.bout.from_region('lower_inner_intersep')
 
         # Remove attributes that are expected to be different
         del n_lower_inner_intersep.attrs['region']
@@ -689,13 +689,13 @@ class TestRegion:
                              n_lower_inner_intersep.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                     theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
                              n_lower_inner_intersep.isel(theta=slice(-myg, None)).values)
 
-        n_lower_inner_SOL = n.bout.fromRegion('lower_inner_SOL')
+        n_lower_inner_SOL = n.bout.from_region('lower_inner_SOL')
 
         # Remove attributes that are expected to be different
         del n_lower_inner_SOL.attrs['region']
@@ -703,13 +703,13 @@ class TestRegion:
                              n_lower_inner_SOL.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
                                     theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
                              n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
 
-        n_inner_core = n.bout.fromRegion('inner_core')
+        n_inner_core = n.bout.from_region('inner_core')
 
         # Remove attributes that are expected to be different
         del n_inner_core.attrs['region']
@@ -718,7 +718,7 @@ class TestRegion:
                              n_inner_core.isel(
                                  theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
@@ -727,7 +727,7 @@ class TestRegion:
                                     theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
                              n_inner_core.isel(theta=slice(-myg, None)).values)
 
-        n_inner_intersep = n.bout.fromRegion('inner_intersep')
+        n_inner_intersep = n.bout.from_region('inner_intersep')
 
         # Remove attributes that are expected to be different
         del n_inner_intersep.attrs['region']
@@ -736,7 +736,7 @@ class TestRegion:
                              n_inner_intersep.isel(
                                  theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                     theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
@@ -745,7 +745,7 @@ class TestRegion:
                                     theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
                              n_inner_intersep.isel(theta=slice(-myg, None)).values)
 
-        n_inner_sol = n.bout.fromRegion('inner_SOL')
+        n_inner_sol = n.bout.from_region('inner_SOL')
 
         # Remove attributes that are expected to be different
         del n_inner_sol.attrs['region']
@@ -753,7 +753,7 @@ class TestRegion:
                 n.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1, jys21 + 1)),
                 n_inner_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
                                     theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
@@ -762,7 +762,7 @@ class TestRegion:
                                     theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
                              n_inner_sol.isel(theta=slice(-myg, None)).values)
 
-        n_upper_inner_PFR = n.bout.fromRegion('upper_inner_PFR')
+        n_upper_inner_PFR = n.bout.from_region('upper_inner_PFR')
 
         # Remove attributes that are expected to be different
         del n_upper_inner_PFR.attrs['region']
@@ -770,13 +770,13 @@ class TestRegion:
                                     theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
                                     theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
                              n_upper_inner_PFR.isel(theta=slice(myg)).values)
 
-        n_upper_inner_intersep = n.bout.fromRegion('upper_inner_intersep')
+        n_upper_inner_intersep = n.bout.from_region('upper_inner_intersep')
 
         # Remove attributes that are expected to be different
         del n_upper_inner_intersep.attrs['region']
@@ -784,13 +784,13 @@ class TestRegion:
                                     theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_intersep.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                     theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
                              n_upper_inner_intersep.isel(theta=slice(myg)).values)
 
-        n_upper_inner_SOL = n.bout.fromRegion('upper_inner_SOL')
+        n_upper_inner_SOL = n.bout.from_region('upper_inner_SOL')
 
         # Remove attributes that are expected to be different
         del n_upper_inner_SOL.attrs['region']
@@ -798,13 +798,13 @@ class TestRegion:
                                     theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
                                     theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
                              n_upper_inner_SOL.isel(theta=slice(myg)).values)
 
-        n_upper_outer_PFR = n.bout.fromRegion('upper_outer_PFR')
+        n_upper_outer_PFR = n.bout.from_region('upper_outer_PFR')
 
         # Remove attributes that are expected to be different
         del n_upper_outer_PFR.attrs['region']
@@ -813,13 +813,13 @@ class TestRegion:
                              n_upper_outer_PFR.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
                                     theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
                              n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
 
-        n_upper_outer_intersep = n.bout.fromRegion('upper_outer_intersep')
+        n_upper_outer_intersep = n.bout.from_region('upper_outer_intersep')
 
         # Remove attributes that are expected to be different
         del n_upper_outer_intersep.attrs['region']
@@ -828,13 +828,13 @@ class TestRegion:
                              n_upper_outer_intersep.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                     theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
                              n_upper_outer_intersep.isel(theta=slice(-myg, None)).values)
 
-        n_upper_outer_SOL = n.bout.fromRegion('upper_outer_SOL')
+        n_upper_outer_SOL = n.bout.from_region('upper_outer_SOL')
 
         # Remove attributes that are expected to be different
         del n_upper_outer_SOL.attrs['region']
@@ -843,13 +843,13 @@ class TestRegion:
                              n_upper_outer_SOL.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
                                     theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
                              n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
 
-        n_outer_core = n.bout.fromRegion('outer_core')
+        n_outer_core = n.bout.from_region('outer_core')
 
         # Remove attributes that are expected to be different
         del n_outer_core.attrs['region']
@@ -858,7 +858,7 @@ class TestRegion:
                              n_outer_core.isel(
                                  theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
                                     theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
@@ -867,7 +867,7 @@ class TestRegion:
                                     theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
                              n_outer_core.isel(theta=slice(-myg, None)).values)
 
-        n_outer_intersep = n.bout.fromRegion('outer_intersep')
+        n_outer_intersep = n.bout.from_region('outer_intersep')
 
         # Remove attributes that are expected to be different
         del n_outer_intersep.attrs['region']
@@ -876,7 +876,7 @@ class TestRegion:
                              n_outer_intersep.isel(
                                  theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                     theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
@@ -885,7 +885,7 @@ class TestRegion:
                                     theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
                              n_outer_intersep.isel(theta=slice(-myg, None)).values)
 
-        n_outer_sol = n.bout.fromRegion('outer_SOL')
+        n_outer_sol = n.bout.from_region('outer_SOL')
 
         # Remove attributes that are expected to be different
         del n_outer_sol.attrs['region']
@@ -893,7 +893,7 @@ class TestRegion:
                 n.isel(x=slice(ixs2 - mxg, None), theta=slice(jys12 + 1, jys22 + 1)),
                 n_outer_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
                                     theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
@@ -902,7 +902,7 @@ class TestRegion:
                                     theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
                              n_outer_sol.isel(theta=slice(-myg, None)).values)
 
-        n_lower_outer_PFR = n.bout.fromRegion('lower_outer_PFR')
+        n_lower_outer_PFR = n.bout.from_region('lower_outer_PFR')
 
         # Remove attributes that are expected to be different
         del n_lower_outer_PFR.attrs['region']
@@ -910,13 +910,13 @@ class TestRegion:
                                     theta=slice(jys22 + 1, None)),
                              n_lower_outer_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
                                     theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
                              n_lower_outer_PFR.isel(theta=slice(myg)).values)
 
-        n_lower_outer_intersep = n.bout.fromRegion('lower_outer_intersep')
+        n_lower_outer_intersep = n.bout.from_region('lower_outer_intersep')
 
         # Remove attributes that are expected to be different
         del n_lower_outer_intersep.attrs['region']
@@ -924,13 +924,13 @@ class TestRegion:
                                     theta=slice(jys22 + 1, None)),
                              n_lower_outer_intersep.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
                              n_lower_outer_intersep.isel(theta=slice(myg)).values)
 
-        n_lower_outer_SOL = n.bout.fromRegion('lower_outer_SOL')
+        n_lower_outer_SOL = n.bout.from_region('lower_outer_SOL')
 
         # Remove attributes that are expected to be different
         del n_lower_outer_SOL.attrs['region']
@@ -938,7 +938,7 @@ class TestRegion:
                                     theta=slice(jys22 + 1, None)),
                              n_lower_outer_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
@@ -996,7 +996,7 @@ class TestRegion:
 
         n = ds['n']
 
-        n_lower_inner_PFR = n.bout.fromRegion('lower_inner_PFR', with_guards=with_guards)
+        n_lower_inner_PFR = n.bout.from_region('lower_inner_PFR', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_inner_PFR.attrs['region']
@@ -1004,13 +1004,13 @@ class TestRegion:
                 n.isel(x=slice(ixs1 + xguards), theta=slice(jys11 + 1)),
                 n_lower_inner_PFR.isel(theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
                                     theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
                              n_lower_inner_PFR.isel(theta=slice(-yguards, None)).values)
 
-        n_lower_inner_intersep = n.bout.fromRegion('lower_inner_intersep',
+        n_lower_inner_intersep = n.bout.from_region('lower_inner_intersep',
                                                    with_guards=with_guards)
 
         # Remove attributes that are expected to be different
@@ -1020,14 +1020,14 @@ class TestRegion:
                              n_lower_inner_intersep.isel(
                                  theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                     n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
                            theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
                     n_lower_inner_intersep.isel(theta=slice(-yguards, None)).values)
 
-        n_lower_inner_SOL = n.bout.fromRegion('lower_inner_SOL', with_guards=with_guards)
+        n_lower_inner_SOL = n.bout.from_region('lower_inner_SOL', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_inner_SOL.attrs['region']
@@ -1035,13 +1035,13 @@ class TestRegion:
                 n.isel(x=slice(ixs2 - xguards, None), theta=slice(jys11 + 1)),
                 n_lower_inner_SOL.isel(theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
                                     theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
                              n_lower_inner_SOL.isel(theta=slice(-yguards, None)).values)
 
-        n_inner_core = n.bout.fromRegion('inner_core', with_guards=with_guards)
+        n_inner_core = n.bout.from_region('inner_core', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_inner_core.attrs['region']
@@ -1050,7 +1050,7 @@ class TestRegion:
                 n_inner_core.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
                                     theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
@@ -1059,7 +1059,7 @@ class TestRegion:
                                     theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
                              n_inner_core.isel(theta=slice(-yguards, None)).values)
 
-        n_inner_intersep = n.bout.fromRegion('inner_intersep', with_guards=with_guards)
+        n_inner_intersep = n.bout.from_region('inner_intersep', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_inner_intersep.attrs['region']
@@ -1069,7 +1069,7 @@ class TestRegion:
                 n_inner_intersep.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
                                     theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
@@ -1078,7 +1078,7 @@ class TestRegion:
                                     theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
                              n_inner_intersep.isel(theta=slice(-yguards, None)).values)
 
-        n_inner_sol = n.bout.fromRegion('inner_SOL', with_guards=with_guards)
+        n_inner_sol = n.bout.from_region('inner_SOL', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_inner_sol.attrs['region']
@@ -1087,7 +1087,7 @@ class TestRegion:
                 n_inner_sol.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
                                     theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
@@ -1096,7 +1096,7 @@ class TestRegion:
                                     theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
                              n_inner_sol.isel(theta=slice(-yguards, None)).values)
 
-        n_upper_inner_PFR = n.bout.fromRegion('upper_inner_PFR', with_guards=with_guards)
+        n_upper_inner_PFR = n.bout.from_region('upper_inner_PFR', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_upper_inner_PFR.attrs['region']
@@ -1104,13 +1104,13 @@ class TestRegion:
                                     theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_PFR.isel(theta=slice(yguards, None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
                                     theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
                              n_upper_inner_PFR.isel(theta=slice(yguards)).values)
 
-        n_upper_inner_intersep = n.bout.fromRegion('upper_inner_intersep',
+        n_upper_inner_intersep = n.bout.from_region('upper_inner_intersep',
                                                    with_guards=with_guards)
 
         # Remove attributes that are expected to be different
@@ -1119,13 +1119,13 @@ class TestRegion:
                                     theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_intersep.isel(theta=slice(yguards, None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
                                     theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
                              n_upper_inner_intersep.isel(theta=slice(yguards)).values)
 
-        n_upper_inner_SOL = n.bout.fromRegion('upper_inner_SOL', with_guards=with_guards)
+        n_upper_inner_SOL = n.bout.from_region('upper_inner_SOL', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_upper_inner_SOL.attrs['region']
@@ -1133,13 +1133,13 @@ class TestRegion:
                                     theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_SOL.isel(theta=slice(yguards, None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
                                     theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
                              n_upper_inner_SOL.isel(theta=slice(yguards)).values)
 
-        n_upper_outer_PFR = n.bout.fromRegion('upper_outer_PFR', with_guards=with_guards)
+        n_upper_outer_PFR = n.bout.from_region('upper_outer_PFR', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_upper_outer_PFR.attrs['region']
@@ -1148,13 +1148,13 @@ class TestRegion:
                              n_upper_outer_PFR.isel(
                                  theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
                                     theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
                              n_upper_outer_PFR.isel(theta=slice(-yguards, None)).values)
 
-        n_upper_outer_intersep = n.bout.fromRegion('upper_outer_intersep',
+        n_upper_outer_intersep = n.bout.from_region('upper_outer_intersep',
                                                    with_guards=with_guards)
 
         # Remove attributes that are expected to be different
@@ -1164,14 +1164,14 @@ class TestRegion:
                              n_upper_outer_intersep.isel(
                                  theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
                                     theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
                              n_upper_outer_intersep.isel(
                                  theta=slice(-yguards, None)).values)
 
-        n_upper_outer_SOL = n.bout.fromRegion('upper_outer_SOL', with_guards=with_guards)
+        n_upper_outer_SOL = n.bout.from_region('upper_outer_SOL', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_upper_outer_SOL.attrs['region']
@@ -1180,13 +1180,13 @@ class TestRegion:
                              n_upper_outer_SOL.isel(
                                  theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
                                     theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
                              n_upper_outer_SOL.isel(theta=slice(-yguards, None)).values)
 
-        n_outer_core = n.bout.fromRegion('outer_core', with_guards=with_guards)
+        n_outer_core = n.bout.from_region('outer_core', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_outer_core.attrs['region']
@@ -1195,7 +1195,7 @@ class TestRegion:
                 n_outer_core.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
                                     theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
@@ -1204,7 +1204,7 @@ class TestRegion:
                                     theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
                              n_outer_core.isel(theta=slice(-yguards, None)).values)
 
-        n_outer_intersep = n.bout.fromRegion('outer_intersep', with_guards=with_guards)
+        n_outer_intersep = n.bout.from_region('outer_intersep', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_outer_intersep.attrs['region']
@@ -1214,7 +1214,7 @@ class TestRegion:
                 n_outer_intersep.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
                                     theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
@@ -1223,7 +1223,7 @@ class TestRegion:
                                     theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
                              n_outer_intersep.isel(theta=slice(-yguards, None)).values)
 
-        n_outer_sol = n.bout.fromRegion('outer_SOL', with_guards=with_guards)
+        n_outer_sol = n.bout.from_region('outer_SOL', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_outer_sol.attrs['region']
@@ -1232,7 +1232,7 @@ class TestRegion:
                 n_outer_sol.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
                                     theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
@@ -1241,7 +1241,7 @@ class TestRegion:
                                     theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
                              n_outer_sol.isel(theta=slice(-yguards, None)).values)
 
-        n_lower_outer_PFR = n.bout.fromRegion('lower_outer_PFR', with_guards=with_guards)
+        n_lower_outer_PFR = n.bout.from_region('lower_outer_PFR', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_outer_PFR.attrs['region']
@@ -1249,13 +1249,13 @@ class TestRegion:
                                     theta=slice(jys22 + 1, None)),
                              n_lower_outer_PFR.isel(theta=slice(yguards, None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
                                     theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
                              n_lower_outer_PFR.isel(theta=slice(yguards)).values)
 
-        n_lower_outer_intersep = n.bout.fromRegion('lower_outer_intersep',
+        n_lower_outer_intersep = n.bout.from_region('lower_outer_intersep',
                                                    with_guards=with_guards)
 
         # Remove attributes that are expected to be different
@@ -1264,13 +1264,13 @@ class TestRegion:
                                     theta=slice(jys22 + 1, None)),
                              n_lower_outer_intersep.isel(theta=slice(yguards, None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
                                     theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
                              n_lower_outer_intersep.isel(theta=slice(yguards)).values)
 
-        n_lower_outer_SOL = n.bout.fromRegion('lower_outer_SOL', with_guards=with_guards)
+        n_lower_outer_SOL = n.bout.from_region('lower_outer_SOL', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_outer_SOL.attrs['region']
@@ -1278,7 +1278,7 @@ class TestRegion:
                                     theta=slice(jys22 + 1, None)),
                              n_lower_outer_SOL.isel(theta=slice(yguards, None)))
         if yguards > 0:
-            # check y-guards, which were 'communicated' by fromRegion
+            # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
                                     theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -66,7 +66,6 @@ class TestRegion:
 
         n = ds['n']
 
-        print(n.regions)
         n_sol = n.bout.fromRegion('SOL')
 
         # Remove attributes that are expected to be different

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -129,3 +129,124 @@ class TestRegion:
                                     theta=slice(ybndry, -ybndry if ybndry!=0 else None)),
                              n_core.isel(
                                  theta=slice(ybndry, -ybndry if ybndry!=0 else None)))
+
+    @pytest.mark.parametrize(params_guards, params_guards_values)
+    @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
+    def test_region_singlenull(self, tmpdir_factory, bout_xyt_example_files, guards,
+                               keep_xboundaries, keep_yboundaries):
+        # Note using more than MXG x-direction points and MYG y-direction points per
+        # output file ensures tests for whether boundary cells are present do not fail
+        # when using minimal numbers of processors
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+                                      nype=4, nt=1, guards=guards, grid='grid',
+                                      topology='single-null')
+
+        ds = open_boutdataset(datapath=path,
+                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
+                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
+                              keep_yboundaries=keep_yboundaries)
+
+        mxg = guards['x']
+        myg = guards['y']
+
+        if keep_xboundaries:
+            ixs = ds.metadata['ixseps1']
+        else:
+            ixs = ds.metadata['ixseps1'] - guards['x']
+
+        if keep_yboundaries:
+            ybndry = guards['y']
+        else:
+            ybndry = 0
+        jys1 = ds.metadata['jyseps1_1'] + ybndry
+        jys2 = ds.metadata['jyseps2_2'] + ybndry
+        ny = ds.metadata['ny'] + 2*ybndry
+
+        n = ds['n']
+
+        n_inner_PFR = n.bout.fromRegion('inner_PFR')
+
+        # Remove attributes that are expected to be different
+        del n_inner_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys1 + 1)),
+                             n_inner_PFR.isel(theta=slice(-myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
+                             n_inner_PFR.isel(theta=slice(-myg, None)).values)
+
+        n_inner_SOL = n.bout.fromRegion('inner_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_inner_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None), theta=slice(jys1 + 1)),
+                             n_inner_SOL.isel(theta=slice(-myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
+                             n_inner_SOL.isel(theta=slice(-myg, None)).values)
+
+        n_core = n.bout.fromRegion('core')
+
+        # Remove attributes that are expected to be different
+        del n_core.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys1 + 1, jys2 + 1)),
+                             n_core.isel(theta=slice(myg, -myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
+                             n_core.isel(theta=slice(myg)).values)
+            npt.assert_equal(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
+                             n_core.isel(theta=slice(-myg, None)).values)
+
+        n_sol = n.bout.fromRegion('SOL')
+
+        # Remove attributes that are expected to be different
+        del n_sol.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys1 + 1, jys2 + 1)),
+                             n_sol.isel(theta=slice(myg, -myg if myg!=0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
+                             n_sol.isel(theta=slice(myg)).values)
+            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
+                             n_sol.isel(theta=slice(-myg, None)).values)
+
+        n_outer_PFR = n.bout.fromRegion('outer_PFR')
+
+        # Remove attributes that are expected to be different
+        del n_outer_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys2 + 1, None)),
+                             n_outer_PFR.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
+                             n_outer_PFR.isel(theta=slice(myg)).values)
+
+        n_outer_SOL = n.bout.fromRegion('outer_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_outer_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys2 + 1, None)),
+                             n_outer_SOL.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
+                             n_outer_SOL.isel(theta=slice(myg)).values)

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -135,6 +135,155 @@ class TestRegion:
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
+    def test_region_xpoint(self, tmpdir_factory, bout_xyt_example_files, guards,
+                           keep_xboundaries, keep_yboundaries):
+        # Note using more than MXG x-direction points and MYG y-direction points per
+        # output file ensures tests for whether boundary cells are present do not fail
+        # when using minimal numbers of processors
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+                                      nype=4, nt=1, guards=guards, grid='grid',
+                                      topology='xpoint')
+
+        ds = open_boutdataset(datapath=path,
+                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
+                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
+                              keep_yboundaries=keep_yboundaries)
+
+        mxg = guards['x']
+        myg = guards['y']
+
+        if keep_xboundaries:
+            ixs = ds.metadata['ixseps1']
+        else:
+            ixs = ds.metadata['ixseps1'] - guards['x']
+
+        if keep_yboundaries:
+            ybndry = guards['y']
+        else:
+            ybndry = 0
+        jys1 = ds.metadata['jyseps1_1'] + ybndry
+        ny_inner = ds.metadata['ny_inner'] + 2*ybndry
+        jys2 = ds.metadata['jyseps2_2'] + 3*ybndry
+        ny = ds.metadata['ny'] + 4*ybndry
+
+        n = ds['n']
+
+        n_lower_inner_PFR = n.bout.fromRegion('lower_inner_PFR')
+
+        # Remove attributes that are expected to be different
+        del n_lower_inner_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys1 + 1)),
+                             n_lower_inner_PFR.isel(
+                                 theta=slice(-myg if myg != 0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
+                             n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
+
+        n_lower_inner_SOL = n.bout.fromRegion('lower_inner_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_lower_inner_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None), theta=slice(jys1 + 1)),
+                             n_lower_inner_SOL.isel(
+                                 theta=slice(-myg if myg != 0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
+                             n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
+
+        n_upper_inner_PFR = n.bout.fromRegion('upper_inner_PFR')
+
+        # Remove attributes that are expected to be different
+        del n_upper_inner_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys1 + 1, ny_inner)),
+                             n_upper_inner_PFR.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
+                             n_upper_inner_PFR.isel(theta=slice(myg)).values)
+
+        n_upper_inner_SOL = n.bout.fromRegion('upper_inner_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_upper_inner_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys1 + 1, ny_inner)),
+                             n_upper_inner_SOL.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
+                             n_upper_inner_SOL.isel(theta=slice(myg)).values)
+
+        n_upper_outer_PFR = n.bout.fromRegion('upper_outer_PFR')
+
+        # Remove attributes that are expected to be different
+        del n_upper_outer_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(ny_inner, jys2 + 1)),
+                             n_upper_outer_PFR.isel(
+                                 theta=slice(-myg if myg != 0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
+                             n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
+
+        n_upper_outer_SOL = n.bout.fromRegion('upper_outer_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_upper_outer_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(ny_inner, jys2 + 1)),
+                             n_upper_outer_SOL.isel(
+                                 theta=slice(-myg if myg != 0 else None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
+                             n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
+
+        n_lower_outer_PFR = n.bout.fromRegion('lower_outer_PFR')
+
+        # Remove attributes that are expected to be different
+        del n_lower_outer_PFR.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys2 + 1, None)),
+                             n_lower_outer_PFR.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs + mxg),
+                                    theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
+                             n_lower_outer_PFR.isel(theta=slice(myg)).values)
+
+        n_lower_outer_SOL = n.bout.fromRegion('lower_outer_SOL')
+
+        # Remove attributes that are expected to be different
+        del n_lower_outer_SOL.attrs['region']
+        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys2 + 1, None)),
+                             n_lower_outer_SOL.isel(theta=slice(myg, None)))
+        if myg > 0:
+            # check y-guards, which were 'communicated' by fromRegion
+            # Coordinates are not equal, so only compare array values
+            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
+                                    theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
+                             n_lower_outer_SOL.isel(theta=slice(myg)).values)
+
+    @pytest.mark.parametrize(params_guards, params_guards_values)
+    @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
     def test_region_singlenull(self, tmpdir_factory, bout_xyt_example_files, guards,
                                keep_xboundaries, keep_yboundaries):
         # Note using more than MXG x-direction points and MYG y-direction points per


### PR DESCRIPTION
It will be useful to operate on or plot variables in a region, within which the grid is contiguous. This PR provides a `Region` class to define regions (indices of their boundaries, connections to neighbouring regions). It also adds a method `BoutDataArray.fromRegion()` to get a variable in a region, including guard cells correctly filled from the connections of the region (not the adjacent points in the global array).

Includes #106, because it uses the `join` argument to `xr.concat`.

This is a fairly big PR, but only 835 of the lines added are 'code', the rest are for the tests.