### PR TITLE
Parallel interpolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
 env:
   - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
-  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3.
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
 install:
   - pip install --upgrade ${PIP_PACKAGES}
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
 env:
   - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
-  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==1.0.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3.
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3.
 install:
   - pip install --upgrade ${PIP_PACKAGES}
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
 env:
   - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
-  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.13.0 dask==1.0.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3.
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==1.0.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3.
 install:
   - pip install --upgrade ${PIP_PACKAGES}
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
   - pip install -r requirements.txt
   - pip install -e .
 script:
-  - pytest -v --cov
+  - pytest -v --long --cov
 after_success:
   - codecov

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,11 @@
 import pytest
 
+
 # Add command line option '--long' for pytest, to be used to enable long tests
 def pytest_addoption(parser):
     parser.addoption("--long", action="store_true", default=False,
                      help="enable tests marked as 'long'")
+
 
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--long"):

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+# Add command line option '--long' for pytest, to be used to enable long tests
+def pytest_addoption(parser):
+    parser.addoption("--long", action="store_true", default=False,
+                     help="enable tests marked as 'long'")
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--long"):
+        # --long not given in cli: skip long tests
+        print("\n    skipping long tests, pass '--long' to enable")
+        skip_long = pytest.mark.skip(reason="need --long option to run")
+        for item in items:
+            if "long" in item.keywords:
+                item.add_marker(skip_long)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 filterwarnings =
     ignore:No geometry type found, no coordinates will be added:UserWarning
     ignore:deallocating CachingFileManager.*, but file is not already closed. This may indicate a bug\.:RuntimeWarning
+
+markers =
+    long: long test, or one of many permutations (disabled by default)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-xarray >= 0.13.0
+xarray >= 0.16.0
 dask[array] >= 1.0.0
 natsort >= 5.5.0
 matplotlib >= 3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 xarray >= 0.16.0
-dask[array] >= 1.0.0
+dask[array] >= 2.10.0
 natsort >= 5.5.0
 matplotlib >= 3.1.1
 animatplot >= 0.4.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         'xarray>=0.16.0',
-        'dask[array]>=1.0.0',
+        'dask[array]>=2.10.0',
         'natsort>=5.5.0',
         'matplotlib>=3.1.1',
         'animatplot>=0.4.1',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     license="Apache",
     python_requires='>=3.6',
     install_requires=[
-        'xarray>=v0.13.0',
+        'xarray>=0.16.0',
         'dask[array]>=1.0.0',
         'natsort>=5.5.0',
         'matplotlib>=3.1.1',

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -59,6 +59,7 @@ class BoutDataArrayAccessor:
         def dropIfExists(ds, name):
             if name in ds.attrs:
                 del ds.attrs[name]
+
         dropIfExists(ds, 'direction_y')
         dropIfExists(ds, 'direction_z')
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -311,6 +311,11 @@ class BoutDataArrayAccessor:
                              region.yupper + (ybndry_upper - 0.5)*dy,
                              ny_fine + ybndry_lower + ybndry_upper)
 
+        # This prevents da.interp() from being very slow, but don't know why.
+        # Slow-down was introduced in d062fa9e75c02fbfdd46e5d1104b9b12f034448f when
+        # _add_attrs_to_var(updated_ds, ycoord) was added in geometries.py
+        da = da.compute()
+
         da = da.interp({ycoord: y_fine.data}, assume_sorted=True, method=method,
                        kwargs={'fill_value': 'extrapolate'})
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -519,6 +519,12 @@ class BoutDataArrayAccessor:
         result = xr.combine_by_coords(parts)
         result.attrs = parts[0].attrs
 
+        # result has all regions, so should not have a region attribute
+        if 'region' in result.attrs:
+            del result.attrs['region']
+        if 'region' in result[self.data.name].attrs:
+            del result[self.data.name].attrs['region']
+
         return result
 
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -278,11 +278,11 @@ class BoutDataArrayAccessor:
         dy = (region.yupper - region.ylower)/ny_fine
 
         myg = da.metadata['MYG']
-        if da.metadata['keep_yboundaries'] and region.connection_lower is None:
+        if da.metadata['keep_yboundaries'] and region.connection_lower_y is None:
             ybndry_lower = myg
         else:
             ybndry_lower = 0
-        if da.metadata['keep_yboundaries'] and region.connection_upper is None:
+        if da.metadata['keep_yboundaries'] and region.connection_upper_y is None:
             ybndry_upper = myg
         else:
             ybndry_upper = 0

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -482,7 +482,7 @@ class BoutDataArrayAccessor:
         return da
 
 
-    def highParallelRes(self, **kwargs):
+    def highParallelRes(self, return_dataset=False, **kwargs):
         """
         Interpolate in the parallel direction to get a higher resolution version of the
         variable.
@@ -500,10 +500,14 @@ class BoutDataArrayAccessor:
             The interpolation method to use. Options from xarray.DataArray.interp(),
             currently: linear, nearest, zero, slinear, quadratic, cubic. Default is
             'cubic'.
+        return_dataset : bool, optional
+            If this is set to True, return a Dataset containing this variable as a member
+            (by default returns a DataArray)
 
         Returns
         -------
-        A new Dataset containing a high-resolution version of the variable.
+        A new DataArray containing a high-resolution version of the variable. (If
+        return_dataset=True, instead returns a Dataset containing the DataArray.)
         """
 
         # xr.combine_by_coords does not keep attrs at the moment. See
@@ -527,7 +531,11 @@ class BoutDataArrayAccessor:
         if 'region' in result[self.data.name].attrs:
             del result[self.data.name].attrs['region']
 
-        return result
+        if return_dataset:
+            return result
+        else:
+            # Extract the DataArray to return
+            return result[self.data.name]
 
 
     def animate2D(self, animate_over='t', x=None, y=None, animate=True, fps=10,

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -141,6 +141,16 @@ class BoutDataArrayAccessor:
         result["direction_y"] = "Standard"
         return result
 
+    @property
+    def regions(self):
+        if "regions" not in self.data.attrs:
+            raise ValueError(
+                "Called a method requiring regions, but these have not been created. "
+                "Please set the 'geometry' option when calling open_boutdataset() to "
+                "create regions."
+            )
+        return self.data.attrs["regions"]
+
     def from_region(self, name, with_guards=None):
         """
         Get a logically-rectangular section of data from a certain region.

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -394,8 +394,10 @@ class BoutDataArrayAccessor:
             BoutDataset.setupParallelInterp(), or 10 if that has not been called.
         toroidal_points : int or sequence of int, optional
             If int, number of toroidal points to output, applies a stride to toroidal
-            direction to save memory usage. If sequence of int, the indexes of toroidal
-            points for the output.
+            direction to save memory usage. It is not always possible to get a particular
+            number of output points with a constant stride, so the number of outputs will
+            be only less than or equal to toroidal_points. If sequence of int, the indexes
+            of toroidal points for the output.
         method : str, optional
             The interpolation method to use. Options from xarray.DataArray.interp(),
             currently: linear, nearest, zero, slinear, quadratic, cubic. Default is
@@ -472,7 +474,7 @@ class BoutDataArrayAccessor:
         if toroidal_points is not None and zcoord in da.sizes:
             if isinstance(toroidal_points, int):
                 nz = len(da[zcoord])
-                zstride = nz//toroidal_points
+                zstride = (nz + toroidal_points - 1)//toroidal_points
                 da = da.isel(**{zcoord: slice(None, None, zstride)})
             else:
                 da = da.isel(**{zcoord: toroidal_points})

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -227,7 +227,7 @@ class BoutDataArrayAccessor:
             except KeyError:
                 n = 8
 
-        da = da.bout.fromRegion(region.name, with_guards={xcoord: 0, ycoord: 2})
+        da = da.bout.from_region(region.name, with_guards={xcoord: 0, ycoord: 2})
         da = da.chunk({ycoord: None})
 
         ny_fine = n*region.ny

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -387,8 +387,8 @@ class BoutDataArrayAccessor:
             If int, number of toroidal points to output, applies a stride to toroidal
             direction to save memory usage. It is not always possible to get a particular
             number of output points with a constant stride, so the number of outputs will
-            be only less than or equal to toroidal_points. If sequence of int, the indexes
-            of toroidal points for the output.
+            be only less than or equal to toroidal_points. If sequence of int, the
+            indexes of toroidal points for the output.
         method : str, optional
             The interpolation method to use. Options from xarray.DataArray.interp(),
             currently: linear, nearest, zero, slinear, quadratic, cubic. Default is
@@ -439,12 +439,12 @@ class BoutDataArrayAccessor:
 
         da = _update_metadata_increased_resolution(da, n)
 
-        # Add dy to da as a coordinate. This will only be temporary, once we have combined
-        # the regions together, we will demote dy to a regular variable
+        # Add dy to da as a coordinate. This will only be temporary, once we have
+        # combined the regions together, we will demote dy to a regular variable
         dy_array = xr.DataArray(np.full([da.sizes[xcoord], da.sizes[ycoord]], dy),
                                 dims=[xcoord, ycoord])
-        # need a view of da with only x- and y-dimensions, unfortunately no neat way to do
-        # this with isel
+        # need a view of da with only x- and y-dimensions, unfortunately no neat way to
+        # do this with isel
         da_2d = da
         if tcoord in da.sizes:
             da_2d = da_2d.isel(**{tcoord: 0}, drop=True)
@@ -471,7 +471,6 @@ class BoutDataArrayAccessor:
                 da = da.isel(**{zcoord: toroidal_points})
 
         return da
-
 
     def highParallelRes(self, return_dataset=False, **kwargs):
         """
@@ -501,20 +500,20 @@ class BoutDataArrayAccessor:
         return_dataset=True, instead returns a Dataset containing the DataArray.)
         """
 
-        # xr.combine_by_coords does not keep attrs at the moment. See
-        # https://github.com/pydata/xarray/issues/3865
-        # For now just copy the attrs from the first region. Can remove this workaround
-        # when the xarray issue is fixed. Should be able to use just:
-        #return xr.combine_by_coords(
-        #        [self.highParallelResRegion(region, **kwargs).bout.to_dataset()
-        #            for region in self.data.regions]
-        #        )
-
         parts = [self.highParallelResRegion(region, **kwargs).bout.to_dataset()
-                    for region in self.data.regions]
+                 for region in self.data.regions]
 
         result = xr.combine_by_coords(parts)
         result.attrs = parts[0].attrs
+        # xr.combine_by_coords does not keep attrs at the moment. See
+        # https://github.com/pydata/xarray/issues/3865
+        # For now just copy the attrs from the first region. Can remove this workaround
+        # when the xarray issue is fixed. Should be able to use instead of the above
+        # just:
+        # result = xr.combine_by_coords(
+        #         [self.highParallelResRegion(region, **kwargs).bout.to_dataset()
+        #             for region in self.data.regions]
+        #         )
 
         # result has all regions, so should not have a region attribute
         if 'region' in result.attrs:

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -125,7 +125,7 @@ class BoutDataArrayAccessor:
         if self.data.direction_y != "Standard":
             raise ValueError("Cannot shift a " + self.direction_y + " type field to "
                              + "field-aligned coordinates")
-        if not (
+        if hasattr(self.data, "cell_location") and not (
             self.data.cell_location == "CELL_CENTRE"
             or self.data.cell_location == "CELL_ZLOW"
         ):
@@ -145,7 +145,7 @@ class BoutDataArrayAccessor:
         if self.data.direction_y != "Aligned":
             raise ValueError("Cannot shift a " + self.direction_y + " type field to "
                              + "field-aligned coordinates")
-        if not (
+        if hasattr(self.data, "cell_location") and not (
             self.data.cell_location == "CELL_CENTRE"
             or self.data.cell_location == "CELL_ZLOW"
         ):

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -125,6 +125,14 @@ class BoutDataArrayAccessor:
         if self.data.direction_y != "Standard":
             raise ValueError("Cannot shift a " + self.direction_y + " type field to "
                              + "field-aligned coordinates")
+        if not (
+            self.data.cell_location == "CELL_CENTRE"
+            or self.data.cell_location == "CELL_ZLOW"
+        ):
+            raise ValueError(
+                f"toFieldAligned does not support staggered grids yet, but "
+                f"location is {self.data.cell_location}."
+            )
         result = self._shiftZ(self.data['zShift'])
         result["direction_y"] = "Aligned"
         return result
@@ -137,6 +145,14 @@ class BoutDataArrayAccessor:
         if self.data.direction_y != "Aligned":
             raise ValueError("Cannot shift a " + self.direction_y + " type field to "
                              + "field-aligned coordinates")
+        if not (
+            self.data.cell_location == "CELL_CENTRE"
+            or self.data.cell_location == "CELL_ZLOW"
+        ):
+            raise ValueError(
+                f"fromFieldAligned does not support staggered grids yet, but "
+                f"location is {self.data.cell_location}."
+            )
         result = self._shiftZ(-self.data['zShift'])
         result["direction_y"] = "Standard"
         return result

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -311,10 +311,13 @@ class BoutDataArrayAccessor:
                              region.yupper + (ybndry_upper - 0.5)*dy,
                              ny_fine + ybndry_lower + ybndry_upper)
 
-        # This prevents da.interp() from being very slow, but don't know why.
+        # This prevents da.interp() from being very slow.
+        # Apparently large attrs (i.e. regions) on a coordinate which is passed as an
+        # argument to dask.array.map_blocks() slow things down, maybe because coordinates
+        # are numpy arrays, not dask arrays?
         # Slow-down was introduced in d062fa9e75c02fbfdd46e5d1104b9b12f034448f when
         # _add_attrs_to_var(updated_ds, ycoord) was added in geometries.py
-        da = da.compute()
+        da[ycoord].attrs = {}
 
         da = da.interp({ycoord: y_fine.data}, assume_sorted=True, method=method,
                        kwargs={'fill_value': 'extrapolate'})

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -187,6 +187,25 @@ class BoutDataArrayAccessor:
 
         return da
 
+    @property
+    def fine_interpolation_factor(self):
+        """
+        The default factor to increase resolution when doing parallel interpolation
+        """
+        return self.data.metadata['fine_interpolation_factor']
+
+    @fine_interpolation_factor.setter
+    def fine_interpolation_factor(self, n):
+        """
+        Set the default factor to increase resolution when doing parallel interpolation.
+
+        Parameters
+        -----------
+        n : int
+            Factor to increase parallel resolution by
+        """
+        self.data.metadata['fine_interpolation_factor'] = n
+
     def interpolate_parallel(self, region=None, *, n=None, toroidal_points=None,
                              method='cubic', return_dataset=False):
         """
@@ -266,10 +285,7 @@ class BoutDataArrayAccessor:
             aligned_input = True
 
         if n is None:
-            try:
-                n = self.data.metadata['fine_interpolation_factor']
-            except KeyError:
-                n = 8
+            n = self.fine_interpolation_factor
 
         da = da.bout.from_region(region.name, with_guards={xcoord: 0, ycoord: 2})
         da = da.chunk({ycoord: None})

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -62,6 +62,7 @@ class BoutDataArrayAccessor:
 
         dropIfExists(ds, 'direction_y')
         dropIfExists(ds, 'direction_z')
+        dropIfExists(ds, 'cell_location')
 
         return ds
 

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -123,23 +123,25 @@ class BoutDatasetAccessor:
         Dataset is a valid BoutDataset, although containing only the specified variables.
         """
         if isinstance(variables, str):
-            ds = self.data[variables].bout.highParallelRes(return_dataset=True, **kwargs)
+            ds = self.data[variables].bout.interpolate_parallel(return_dataset=True,
+                                                                **kwargs)
         else:
             # Need to start with a Dataset with attrs as merge() drops the attrs of the
             # passed-in argument.
-            ds = self.data[variables[0]].bout.highParallelRes(return_dataset=True,
-                                                              **kwargs)
+            ds = self.data[variables[0]].bout.interpolate_parallel(return_dataset=True,
+                                                                   **kwargs)
             for var in variables[1:]:
-                ds = ds.merge(self.data[var].bout.highParallelRes(return_dataset=True,
-                                                                  **kwargs))
+                ds = ds.merge(
+                        self.data[var].bout.interpolate_parallel(return_dataset=True,
+                                                                 **kwargs)
+                     )
 
         # Add extra variables needed to make this a valid Dataset
-        ds['dx'] = self.data['dx'].bout.highParallelRes(return_dataset=True,
-                                                        **kwargs)['dx']
+        ds['dx'] = self.data['dx'].bout.interpolate_parallel(**kwargs)
 
         # dy needs to be compatible with the new poloidal coordinate
-        # dy was created as a coordinate in BoutDataArray.highParallelResRegion, here
-        # just need to demote back to a regular variable.
+        # dy was created as a coordinate in BoutDataArray.interpolate_parallel, here just
+        # need to demote back to a regular variable.
         ds = ds.reset_coords('dy')
 
         # Apply geometry

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -80,6 +80,16 @@ class BoutDatasetAccessor:
             return self.data[aligned_name]
 
     @property
+    def regions(self):
+        if "regions" not in self.data.attrs:
+            raise ValueError(
+                "Called a method requiring regions, but these have not been created. "
+                "Please set the 'geometry' option when calling open_boutdataset() to "
+                "create regions."
+            )
+        return self.data.attrs["regions"]
+
+    @property
     def fine_interpolation_factor(self):
         """
         The default factor to increase resolution when doing parallel interpolation

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -138,16 +138,16 @@ class BoutDatasetAccessor:
                                                         **kwargs)['dx']
 
         # dy needs to be compatible with the new poloidal coordinate
-        # dy was created as a coordinate in BoutDataArray.highParallelResRegion, here just
-        # need to demote back to a regular variable.
+        # dy was created as a coordinate in BoutDataArray.highParallelResRegion, here
+        # just need to demote back to a regular variable.
         ds = ds.reset_coords('dy')
 
         # Apply geometry
         try:
             ds = apply_geometry(ds, ds.geometry)
         except AttributeError as e:
-            # if no geometry was originally applied, then ds has no geometry attribute and
-            # we can continue without applying geometry here
+            # if no geometry was originally applied, then ds has no geometry attribute
+            # and we can continue without applying geometry here
             if str(e) != "'Dataset' object has no attribute 'geometry'":
                 raise
 

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -79,7 +79,15 @@ class BoutDatasetAccessor:
                 self.data[aligned_name] = self.data[name].bout.toFieldAligned()
             return self.data[aligned_name]
 
-    def set_parallel_interpolation_factor(self, n):
+    @property
+    def fine_interpolation_factor(self):
+        """
+        The default factor to increase resolution when doing parallel interpolation
+        """
+        return self.data.metadata['fine_interpolation_factor']
+
+    @fine_interpolation_factor.setter
+    def fine_interpolation_factor(self, n):
         """
         Set the default factor to increase resolution when doing parallel interpolation.
 
@@ -88,13 +96,10 @@ class BoutDatasetAccessor:
         n : int
             Factor to increase parallel resolution by
         """
-
         ds = self.data
         ds.metadata['fine_interpolation_factor'] = n
         for da in ds.values():
             da.metadata['fine_interpolation_factor'] = n
-
-        return ds
 
     def interpolate_parallel(self, variables, **kwargs):
         """

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -135,11 +135,11 @@ class BoutDatasetAccessor:
 
         if variables is ...:
             variables = [v for v in self.data]
-            if 'dy' in variables:
-                # dy is treated specially, as it is converted to a coordinate, and then
-                # converted back again below, so must not call
-                # interpolate_parallel('dy').
-                variables.remove('dy')
+        if 'dy' in variables:
+            # dy is treated specially, as it is converted to a coordinate, and then
+            # converted back again below, so must not call
+            # interpolate_parallel('dy').
+            variables.remove('dy')
 
         if isinstance(variables, str):
             ds = self.data[variables].bout.interpolate_parallel(return_dataset=True,

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -188,7 +188,7 @@ class BoutDatasetAccessor:
                         da.bout.interpolate_parallel(return_dataset=True, **kwargs)
                      )
             elif ycoord not in da.dims:
-                ds = ds.merge(da)
+                ds[var] = da
             # Can't interpolate a variable that depends on y but not x, so just skip
 
         # dy needs to be compatible with the new poloidal coordinate

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -98,7 +98,7 @@ class BoutDatasetAccessor:
         """
         ds = self.data
         ds.metadata['fine_interpolation_factor'] = n
-        for da in ds.data_vars:
+        for da in ds.data_vars.values():
             da.metadata['fine_interpolation_factor'] = n
 
     def interpolate_parallel(self, variables, **kwargs):

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -123,16 +123,19 @@ class BoutDatasetAccessor:
         Dataset is a valid BoutDataset, although containing only the specified variables.
         """
         if isinstance(variables, str):
-            ds = self.data[variables].bout.highParallelRes(**kwargs)
+            ds = self.data[variables].bout.highParallelRes(return_dataset=True, **kwargs)
         else:
             # Need to start with a Dataset with attrs as merge() drops the attrs of the
             # passed-in argument.
-            ds = self.data[variables[0]].bout.highParallelRes(**kwargs)
+            ds = self.data[variables[0]].bout.highParallelRes(return_dataset=True,
+                                                              **kwargs)
             for var in variables[1:]:
-                ds = ds.merge(self.data[var].bout.highParallelRes(**kwargs))
+                ds = ds.merge(self.data[var].bout.highParallelRes(return_dataset=True,
+                                                                  **kwargs))
 
         # Add extra variables needed to make this a valid Dataset
-        ds['dx'] = self.data['dx'].bout.highParallelRes(**kwargs)['dx']
+        ds['dx'] = self.data['dx'].bout.highParallelRes(return_dataset=True,
+                                                        **kwargs)['dx']
 
         # dy needs to be compatible with the new poloidal coordinate
         # dy was created as a coordinate in BoutDataArray.highParallelResRegion, here just

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -168,7 +168,8 @@ class BoutDatasetAccessor:
         first_var = find_with_dims(None, self.data.dims)
         first_var = find_with_dims(first_var, set(self.data.dims) - set(tcoord))
         first_var = find_with_dims(first_var, set(self.data.dims) - set(zcoord))
-        first_var = find_with_dims(first_var, set(self.data.dims) - set([tcoord, zcoord]))
+        first_var = find_with_dims(first_var, set(self.data.dims)
+                                   - set([tcoord, zcoord]))
         if first_var is None:
             raise ValueError(
                 f"Could not find variable to interpolate with both "

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -107,8 +107,9 @@ class BoutDatasetAccessor:
 
         Parameters
         ----------
-        variables : str or sequence of str
-            The names of the variables to interpolate
+        variables : str or sequence of str or ...
+            The names of the variables to interpolate. If 'variables=...' is passed
+            explicitly, then interpolate all variables in the Dataset.
         n : int, optional
             The factor to increase the resolution by. Defaults to the value set by
             BoutDataset.setupParallelInterp(), or 10 if that has not been called.
@@ -126,6 +127,15 @@ class BoutDatasetAccessor:
         A new Dataset containing a high-resolution versions of the variables. The new
         Dataset is a valid BoutDataset, although containing only the specified variables.
         """
+
+        if variables is ...:
+            variables = [v for v in self.data]
+            if 'dy' in variables:
+                # dy is treated specially, as it is converted to a coordinate, and then
+                # converted back again below, so must not call
+                # interpolate_parallel('dy').
+                variables.remove('dy')
+
         if isinstance(variables, str):
             ds = self.data[variables].bout.interpolate_parallel(return_dataset=True,
                                                                 **kwargs)

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -79,7 +79,7 @@ class BoutDatasetAccessor:
                 self.data[aligned_name] = self.data[name].bout.toFieldAligned()
             return self.data[aligned_name]
 
-    def resetParallelInterpFactor(self, n):
+    def set_parallel_interpolation_factor(self, n):
         """
         Set the default factor to increase resolution when doing parallel interpolation.
 

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -129,7 +129,7 @@ class BoutDatasetAccessor:
             # passed-in argument.
             ds = self.data[variables[0]].bout.highParallelRes(**kwargs)
             for var in variables[1:]:
-                ds.merge(self.data[var].bout.highParallelRes(**kwargs))
+                ds = ds.merge(self.data[var].bout.highParallelRes(**kwargs))
 
         # Add extra variables needed to make this a valid Dataset
         ds['dx'] = self.data['dx'].bout.highParallelRes(**kwargs)['dx']

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -98,7 +98,7 @@ class BoutDatasetAccessor:
         """
         ds = self.data
         ds.metadata['fine_interpolation_factor'] = n
-        for da in ds.values():
+        for da in ds.data_vars:
             da.metadata['fine_interpolation_factor'] = n
 
     def interpolate_parallel(self, variables, **kwargs):

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -96,10 +96,14 @@ class BoutDatasetAccessor:
 
         return ds
 
-    def getHighParallelResVars(self, variables, **kwargs):
+    def interpolate_parallel(self, variables, **kwargs):
         """
-        Interpolate in the parallel direction to get a higher resolution version of one
-        or more variables.
+        Interpolate in the parallel direction to get a higher resolution version of a
+        subset of variables.
+
+        Note that the high-resolution variables are all loaded into memory, so most
+        likely it is necessary to select only a small number. The toroidal_points
+        argument can also be used to reduce the memory demand.
 
         Parameters
         ----------

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -145,13 +145,10 @@ class BoutDatasetAccessor:
         ds = ds.reset_coords('dy')
 
         # Apply geometry
-        try:
+        if hasattr(ds, 'geometry'):
             ds = apply_geometry(ds, ds.geometry)
-        except AttributeError as e:
-            # if no geometry was originally applied, then ds has no geometry attribute
-            # and we can continue without applying geometry here
-            if str(e) != "'Dataset' object has no attribute 'geometry'":
-                raise
+        # if no geometry was originally applied, then ds has no geometry attribute and we
+        # can continue without applying geometry here
 
         return ds
 

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -138,6 +138,8 @@ class BoutDatasetAccessor:
 
         if isinstance(variables, str):
             variables = [variables]
+        if isinstance(variables, tuple):
+            variables = list(variables)
 
         if 'dy' in variables:
             # dy is treated specially, as it is converted to a coordinate, and then

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -276,7 +276,10 @@ class BoutDatasetAccessor:
                 pass
 
         # Do not need to save regions as these can be reconstructed from the metadata
-        del to_save.attrs['regions']
+        try:
+            del to_save.attrs['regions']
+        except KeyError:
+            pass
         for var in chain(to_save.data_vars, to_save.coords):
             try:
                 del to_save[var].attrs['regions']

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -72,8 +72,8 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
     # ######################
     # Note the global coordinates used here are defined so that they are zero at
     # the boundaries of the grid (where the grid includes all boundary cells), not
-    # necessarily the physical boundaries, because constant offsets do not matter, as long
-    # as these bounds are consistent with the global coordinates defined in
+    # necessarily the physical boundaries, because constant offsets do not matter, as
+    # long as these bounds are consistent with the global coordinates defined in
     # Region.__init__() (we will only use these coordinates for interpolation) and it is
     # simplest to calculate them with cumsum().
     xcoord = updated_ds.metadata.get('bout_xdim', 'x')
@@ -83,8 +83,8 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
         # Make index 'x' a coordinate, useful for handling global indexing
         # Note we have to use the index value, not the value calculated from 'dx' because
         # 'dx' may not be consistent between different regions (e.g. core and PFR).
-        # For some geometries xcoord may have already been created by add_geometry_coords,
-        # in which case we do not need this.
+        # For some geometries xcoord may have already been created by
+        # add_geometry_coords, in which case we do not need this.
         nx = updated_ds.dims[xcoord]
         updated_ds = updated_ds.assign_coords(**{xcoord: np.arange(nx)})
     ny = updated_ds.dims[ycoord]
@@ -115,7 +115,7 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
                  + str(2.*np.pi*updated_ds.metadata['ZMAX'] - z0)
                  + '): using value from dz')
         z = xr.DataArray(np.linspace(start=z0, stop=z1, num=nz, endpoint=False),
-                           dims=zcoord)
+                         dims=zcoord)
         updated_ds = updated_ds.assign_coords(**{zcoord: z})
 
     return updated_ds
@@ -171,8 +171,8 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
 
     coordinates = _set_default_toroidal_coordinates(coordinates)
 
-    # If the coordinates already exist, we are re-applying the geometry and do not need to
-    # add them again.
+    # If the coordinates already exist, we are re-applying the geometry and do not need
+    # to add them again.
     # Ignore coordinates['z'] because ds might be Field2D-type without a z-dimension, and
     # if the other coordinates all match for a Field3D-type ds, we must actually be
     # re-applying the geometry.
@@ -181,21 +181,22 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
                    for c in coordinates.values()]):
 
         # Check whether coordinates names conflict with variables in ds
-        bad_names = [name for name in coordinates.values() if name in ds and name not in
-                ds.coords]
+        bad_names = [name for name in coordinates.values()
+                     if name in ds and name not in ds.coords]
         if bad_names:
             raise ValueError("Coordinate names {} clash with variables in the dataset. "
-                             "Register a different geometry to provide alternative names. "
-                             "It may be useful to use the 'coordinates' argument to "
-                             "add_toroidal_geometry_coords() for this.".format(bad_names))
+                             "Register a different geometry to provide alternative "
+                             "names. It may be useful to use the 'coordinates' argument "
+                             "to add_toroidal_geometry_coords() for this."
+                             .format(bad_names))
 
         # Get extra geometry information from grid file if it's not in the dump files
         needed_variables = ['psixy', 'Rxy', 'Zxy']
         for v in needed_variables:
             if v not in ds:
                 if grid is None:
-                    raise ValueError("Grid file is required to provide %s. Pass the grid "
-                                     "file name as the 'gridfilepath' argument to "
+                    raise ValueError("Grid file is required to provide %s. Pass the "
+                                     "grid file name as the 'gridfilepath' argument to "
                                      "open_boutdataset().")
                 ds[v] = grid[v]
 

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -76,9 +76,16 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
     # long as these bounds are consistent with the global coordinates defined in
     # Region.__init__() (we will only use these coordinates for interpolation) and it is
     # simplest to calculate them with cumsum().
+    tcoord = updated_ds.metadata.get('bout_tdim', 't')
     xcoord = updated_ds.metadata.get('bout_xdim', 'x')
     ycoord = updated_ds.metadata.get('bout_ydim', 'y')
     zcoord = updated_ds.metadata.get('bout_zdim', 'z')
+
+    if (tcoord not in ds.coords) and (tcoord in ds.dims):
+        # Create the time coordinate from t_array
+        updated_ds = updated_ds.rename({'t_array': tcoord})
+        updated_ds = updated_ds.set_coords(tcoord)
+
     if xcoord not in ds.coords:
         # Make index 'x' a coordinate, useful for handling global indexing
         # Note we have to use the index value, not the value calculated from 'dx' because

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -86,7 +86,7 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
         updated_ds = updated_ds.rename({'t_array': tcoord})
         updated_ds = updated_ds.set_coords(tcoord)
 
-    if xcoord not in ds.coords:
+    if xcoord not in updated_ds.coords:
         # Make index 'x' a coordinate, useful for handling global indexing
         # Note we have to use the index value, not the value calculated from 'dx' because
         # 'dx' may not be consistent between different regions (e.g. core and PFR).

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -201,9 +201,9 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
         for v in needed_variables:
             if v not in ds:
                 if grid is None:
-                    raise ValueError("Grid file is required to provide %s. Pass the "
-                                     "grid file name as the 'gridfilepath' argument to "
-                                     "open_boutdataset().")
+                    raise ValueError(f"Grid file is required to provide {v}. Pass the "
+                                     f"grid file name as the 'gridfilepath' argument to "
+                                     f"open_boutdataset().")
                 ds[v] = grid[v]
 
         # Rename 't' if user requested it

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -110,10 +110,9 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
         z1 = z0 + nz*updated_ds.metadata['dz']
         if not np.isclose(z1, 2.*np.pi*updated_ds.metadata['ZMAX'],
                           rtol=1.e-15, atol=0.):
-            warn('Size of toroidal domain as calculated from nz*dz (' + str(z1 - z0)
-                 + ' is not the same as 2pi*(ZMAX - ZMIN) ('
-                 + str(2.*np.pi*updated_ds.metadata['ZMAX'] - z0)
-                 + '): using value from dz')
+            warn(f"Size of toroidal domain as calculated from nz*dz ({str(z1 - z0)}"
+                 f" is not the same as 2pi*(ZMAX - ZMIN) ("
+                 f"{2.*np.pi*updated_ds.metadata['ZMAX'] - z0}): using value from dz")
         z = xr.DataArray(np.linspace(start=z0, stop=z1, num=nz, endpoint=False),
                          dims=zcoord)
         updated_ds = updated_ds.assign_coords(**{zcoord: z})

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -240,6 +240,18 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
         ds = ds.set_coords('zShift')
     except KeyError:
         pass
+    try:
+        ds = ds.set_coords('zShift_CELL_XLOW')
+    except KeyError:
+        pass
+    try:
+        ds = ds.set_coords('zShift_CELL_YLOW')
+    except KeyError:
+        pass
+    try:
+        ds = ds.set_coords('zShift_CELL_ZLOW')
+    except KeyError:
+        pass
 
     ds = _create_regions_toroidal(ds)
 

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -292,8 +292,6 @@ def add_s_alpha_geometry_coords(ds, *, coordinates=None, grid=None):
                          "geometry='s-alpha'")
     ds['r'] = ds['hthe'].isel({ycoord: 0}).squeeze(drop=True)
     ds['r'].attrs['units'] = 'm'
-    # remove x-index coordinate, don't need when we have 'r' as a radial coordinate
-    ds = ds.drop('x')
     ds = ds.set_coords('r')
     ds = ds.rename(x='r')
     ds.metadata['bout_xdim'] = 'r'

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -210,27 +210,6 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     # Change names of dimensions to Orthogonal Toroidal ones
     ds = ds.rename(y=coordinates['y'])
 
-    # Add 1D Orthogonal Toroidal coordinates
-    # Make index 'x' a coordinate, useful for handling global indexing
-    nx = ds.dims['x']
-    ds = ds.assign_coords(x=np.arange(nx))
-    _add_attrs_to_var(ds, 'x')
-    ny = ds.dims[coordinates['y']]
-    # dy should always be constant in x, so it is safe to slice to x=0.
-    # [The y-coordinate has to be a 1d coordinate that labels x-z slices of the grid
-    # (similarly x-coordinate is 1d coordinate that labels y-z slices and z-coordinate is
-    # a 1d coordinate that labels x-y slices). A coordinate might have different values
-    # in disconnected regions, but there are no branch-cuts allowed in the x-direction in
-    # BOUT++ (at least for the momement), so the y-coordinate has to be 1d and
-    # single-valued. Therefore similarly dy has to be 1d and single-valued.]
-    # Need drop=True so that the result does not have an x-coordinate value which
-    # prevents it being added as a coordinate.
-    dy = ds['dy'].isel(x=0, drop=True)
-
-    # calculate theta at the centre of each cell
-    theta = dy.cumsum(keep_attrs=True) - dy/2.
-    ds = ds.assign_coords(**{coordinates['y']: theta})
-
     # TODO automatically make this coordinate 1D in simplified cases?
     ds = ds.rename(psixy=coordinates['x'])
     ds = ds.set_coords(coordinates['x'])
@@ -245,16 +224,6 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     # If full data (not just grid file) then toroidal dim will be present
     if 'z' in ds.dims:
         ds = ds.rename(z=coordinates['z'])
-        nz = ds.dims[coordinates['z']]
-        phi0 = 2*np.pi*ds.metadata['ZMIN']
-        phi1 = phi0 + nz*ds.metadata['dz']
-        if not np.isclose(phi1, 2.*np.pi*ds.metadata['ZMAX'], rtol=1.e-15, atol=0.):
-            warn(f"Size of toroidal domain as calculated from nz*dz ({phi1 - phi0}) is "
-                 f"not the same as 2pi*(ZMAX - ZMIN) "
-                 f"({2.*np.pi*ds.metadata['ZMAX'] - phi0}): using value from dz")
-        phi = xr.DataArray(np.linspace(start=phi0, stop=phi1, num=nz, endpoint=False),
-                           dims=coordinates['z'])
-        ds = ds.assign_coords(**{coordinates['z']: phi})
 
         # Record which dimension 'z' was renamed to.
         ds.metadata['bout_zdim'] = coordinates['z']

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -238,19 +238,19 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     # Add zShift as a coordinate, so that it gets interpolated along with a variable
     try:
         ds = ds.set_coords('zShift')
-    except KeyError:
+    except ValueError:
         pass
     try:
         ds = ds.set_coords('zShift_CELL_XLOW')
-    except KeyError:
+    except ValueError:
         pass
     try:
         ds = ds.set_coords('zShift_CELL_YLOW')
-    except KeyError:
+    except ValueError:
         pass
     try:
         ds = ds.set_coords('zShift_CELL_ZLOW')
-    except KeyError:
+    except ValueError:
         pass
 
     ds = _create_regions_toroidal(ds)

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -168,6 +168,10 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
     if run_name:
         ds.name = run_name
 
+    # Set some default settings that are only used in post-processing by xBOUT, not by
+    # BOUT++
+    ds.bout.fine_interpolation_factor = 8
+
     if info is 'terse':
         print("Read in dataset from {}".format(str(Path(datapath))))
     elif info:

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -121,10 +121,10 @@ def animate_poloidal(da, *, ax=None, cax=None, animate_over='t', separatrix=True
          targets = False
 
     if separatrix:
-        plot_separatrices(da_regions, ax)
+        plot_separatrices(da_regions, ax, x=x, y=y)
 
     if targets:
-        plot_targets(da_regions, ax, hatching=add_limiter_hatching)
+        plot_targets(da_regions, ax, x=x, y=y, hatching=add_limiter_hatching)
 
     if animate:
         timeline = amp.Timeline(np.arange(da.sizes[animate_over]), fps=fps)

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -213,12 +213,20 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
                     raise ValueError('Argument passed to gridlines must be bool, int or '
                                      'slice. Got a ' + type(value) + ', ' + str(value))
 
-        R_regions = [da_region['R'] for da_region in da_regions.values()]
-        Z_regions = [da_region['Z'] for da_region in da_regions.values()]
+        x_regions = [da_region[x] for da_region in da_regions.values()]
+        y_regions = [da_region[y] for da_region in da_regions.values()]
 
-        for R, Z in zip(R_regions, Z_regions):
-            if (not da.metadata['bout_xdim'] in R.dims
-                    and not da.metadata['bout_ydim'] in R.dims):
+        for x, y in zip(x_regions, y_regions):
+            if (
+                (
+                    not da.metadata['bout_xdim'] in x.dims
+                    and not da.metadata['bout_ydim'] in x.dims
+                )
+                or (
+                    not da.metadata['bout_xdim'] in y.dims
+                    and not da.metadata['bout_ydim'] in y.dims
+                )
+            ):
                 # Small regions around X-point do not have segments in x- or y-directions,
                 # so skip
                 # Currently this region does not exist, but there is a small white gap at
@@ -229,16 +237,16 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
                 # form
                 dim_order = (da.metadata['bout_xdim'], da.metadata['bout_ydim'])
                 yarg = {da.metadata['bout_ydim']: gridlines['x']}
-                plt.plot(R.isel(**yarg).transpose(*dim_order, transpose_coords=True),
-                         Z.isel(**yarg).transpose(*dim_order, transpose_coords=True),
+                plt.plot(x.isel(**yarg).transpose(*dim_order, transpose_coords=True),
+                         y.isel(**yarg).transpose(*dim_order, transpose_coords=True),
                          color='k', lw=0.1)
             if gridlines.get('y') is not None:
                 xarg = {da.metadata['bout_xdim']: gridlines['y']}
                 # Need to plot transposed arrays to make gridlines that go in the
                 # y-direction
                 dim_order = (da.metadata['bout_ydim'], da.metadata['bout_xdim'])
-                plt.plot(R.isel(**xarg).transpose(*dim_order, transpose_coords=True),
-                         Z.isel(**yarg).transpose(*dim_order, transpose_coords=True),
+                plt.plot(x.isel(**xarg).transpose(*dim_order, transpose_coords=True),
+                         y.isel(**yarg).transpose(*dim_order, transpose_coords=True),
                          color='k', lw=0.1)
 
     ax.set_title(da.name)
@@ -248,9 +256,9 @@ def plot2d_wrapper(da, method, *, ax=None, separatrix=True, targets=True,
         targets = False
 
     if separatrix:
-        plot_separatrices(da_regions, ax)
+        plot_separatrices(da_regions, ax, x=x, y=y)
 
     if targets:
-        plot_targets(da_regions, ax, hatching=add_limiter_hatching)
+        plot_targets(da_regions, ax, x=x, y=y, hatching=add_limiter_hatching)
 
     return artists

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -73,7 +73,7 @@ def _is_core_only(da):
     return (ix1 >= nx and ix2 >= nx)
 
 
-def plot_separatrices(da, ax):
+def plot_separatrices(da, ax, *, x='R', y='Z'):
     """Plot separatrices"""
 
     if not isinstance(da, dict):
@@ -90,14 +90,14 @@ def plot_separatrices(da, ax):
         inner = da_region.region.connection_inner_x
         if inner is not None:
             da_inner = da_regions[inner]
-            R = 0.5*(da_inner['R'].isel(**{xcoord: -1})
-                     + da_region['R'].isel(**{xcoord: 0}))
-            Z = 0.5*(da_inner['Z'].isel(**{xcoord: -1})
-                     + da_region['Z'].isel(**{xcoord: 0}))
-            ax.plot(R, Z, 'k--')
+            x_sep = 0.5*(da_inner[x].isel(**{xcoord: -1})
+                         + da_region[x].isel(**{xcoord: 0}))
+            y_sep = 0.5*(da_inner[y].isel(**{xcoord: -1})
+                         + da_region[y].isel(**{xcoord: 0}))
+            ax.plot(x_sep, y_sep, 'k--')
 
 
-def plot_targets(da, ax, hatching=True):
+def plot_targets(da, ax, *, x='R', y='Z', hatching=True):
     """Plot divertor and limiter target plates"""
 
     if not isinstance(da, dict):
@@ -118,16 +118,16 @@ def plot_targets(da, ax, hatching=True):
     for da_region in da_regions.values():
         if da_region.region.connection_lower_y is None:
             # lower target exists
-            R = da_region.coords['R'].isel(**{ycoord: y_boundary_guards})
-            Z = da_region.coords['Z'].isel(**{ycoord: y_boundary_guards})
-            [line] = ax.plot(R, Z, 'k-', linewidth=2)
+            x_target = da_region.coords[x].isel(**{ycoord: y_boundary_guards})
+            y_target = da_region.coords[y].isel(**{ycoord: y_boundary_guards})
+            [line] = ax.plot(x_target, y_target, 'k-', linewidth=2)
             if hatching:
                 _add_hatching(line, ax)
         if da_region.region.connection_upper_y is None:
             # upper target exists
-            R = da_region.coords['R'].isel(**{ycoord: -y_boundary_guards - 1})
-            Z = da_region.coords['Z'].isel(**{ycoord: -y_boundary_guards - 1})
-            [line] = ax.plot(R, Z, 'k-', linewidth=2)
+            x_target = da_region.coords[x].isel(**{ycoord: -y_boundary_guards - 1})
+            y_target = da_region.coords[y].isel(**{ycoord: -y_boundary_guards - 1})
+            [line] = ax.plot(x_target, y_target, 'k-', linewidth=2)
             if hatching:
                 _add_hatching(line, ax, reversed=True)
 

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -102,6 +102,7 @@ class Region:
             # particular regions, so do not need to be consistent between different
             # regions (e.g. core and PFR), so we are not forced to use just the index
             # value here.
+            dx = ds['dx']
             dx_cumsum = dx.cumsum()
             self.xinner = dx_cumsum[xinner_ind] - dx[xinner_ind]
             self.xouter = dx_cumsum[xouter_ind - 1] + dx[xouter_ind - 1]

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from .utils import _set_attrs_on_all_vars
 
 
@@ -319,7 +317,7 @@ topologies = {}
 
 def topology_disconnected_double_null(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner,
                                       jys12, jys22, ny, ybndry):
-    regions = OrderedDict()
+    regions = {}
     regions['lower_inner_PFR'] = Region(
             name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=0, yupper_ind=jys11 + 1, connect_outer='lower_inner_intersep',
@@ -408,7 +406,7 @@ topologies['disconnected-double-null'] = topology_disconnected_double_null
 
 def topology_connected_double_null(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12,
                                    jys22, ny, ybndry):
-    regions = OrderedDict()
+    regions = {}
     regions['lower_inner_PFR'] = Region(
             name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=0, yupper_ind=jys11 + 1, connect_outer='lower_inner_SOL',
@@ -465,7 +463,7 @@ topologies['connected-double-null'] = topology_connected_double_null
 
 def topology_single_null(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, jys22,
                          ny, ybndry):
-    regions = OrderedDict()
+    regions = {}
     regions['inner_PFR'] = Region(
             name='inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=0,
             yupper_ind=jys11 + 1, connect_outer='inner_SOL',
@@ -497,7 +495,7 @@ topologies['single-null'] = topology_single_null
 
 def topology_limiter(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, jys22, ny,
                      ybndry):
-    regions = OrderedDict()
+    regions = {}
     regions['core'] = Region(
             name='core', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=ybndry,
             yupper_ind=ny - ybndry, connect_outer='SOL', connect_lower='core',
@@ -513,7 +511,7 @@ topologies['limiter'] = topology_limiter
 
 def topology_core(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, jys22, ny,
                   ybndry):
-    regions = OrderedDict()
+    regions = {}
     regions['core'] = Region(
             name='core', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=ybndry,
             yupper_ind=ny - ybndry, connect_lower='core', connect_upper='core')
@@ -525,7 +523,7 @@ topologies['core'] = topology_core
 
 def topology_sol(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, jys22, ny,
                  ybndry):
-    regions = OrderedDict()
+    regions = {}
     regions['SOL'] = Region(
             name='SOL', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=0,
             yupper_ind=ny)
@@ -537,7 +535,7 @@ topologies['sol'] = topology_sol
 
 def topology_xpoint(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, jys22, ny,
                     ybndry):
-    regions = OrderedDict()
+    regions = {}
     regions['lower_inner_PFR'] = Region(
             name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=0, yupper_ind=jys11 + 1, connect_outer='lower_inner_SOL',

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -71,14 +71,12 @@ class Region:
                 ybndry = ds.metadata['MYG']
                 if self.connection_lower is None:
                     self.ny -= ybndry
-                    print('check ny 2', self.ny, self.connection_lower, connect_lower)
 
                     # used to calculate y-coordinate of lower side (self.ylower)
                     ylower_ind += ybndry
 
                 if self.connection_upper is None:
                     self.ny -= ybndry
-                    print('check ny 3', self.ny, self.connection_upper, connect_upper)
 
                     # used to calculate y-coordinate of upper side (self.yupper)
                     yupper_ind -= ybndry

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -92,11 +92,11 @@ class Region:
             ycoord = ds.metadata['bout_ydim']
 
             # Note the global coordinates used here are defined so that they are zero at
-            # the boundaries of the grid (where the grid includes all boundary cells), not
-            # necessarily the physical boundaries because constant offsets do not matter,
-            # as long as these bounds are consistent with the global coordinates defined
-            # in apply_geometry (we will only use these coordinates for interpolation) and
-            # it is simplest to calculate them with cumsum().
+            # the boundaries of the grid (where the grid includes all boundary cells),
+            # not necessarily the physical boundaries because constant offsets do not
+            # matter, as long as these bounds are consistent with the global coordinates
+            # defined in apply_geometry (we will only use these coordinates for
+            # interpolation) and it is simplest to calculate them with cumsum().
 
             # dx is constant in any particular region in the y-direction, so convert to a
             # 1d array
@@ -114,7 +114,7 @@ class Region:
             dy = ds['dy'].isel(**{xcoord: self.xinner_ind})
             dy_cumsum = dy.cumsum()
             self.ylower = dy_cumsum[ylower_ind] - dy[ylower_ind]
-            self.yupper = dy_cumsum[yupper_ind- 1]
+            self.yupper = dy_cumsum[yupper_ind - 1]
 
     def __repr__(self):
         result = "<xbout.region.Region>\n"
@@ -405,8 +405,9 @@ def _create_regions_toroidal(ds):
                 connect_outer='upper_inner_intersep', connect_lower='upper_outer_PFR')
         regions['upper_inner_intersep'] = Region(
                 name='upper_inner_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
-                ylower_ind=jys21 + 1, yupper_ind=nyinner, connect_inner='upper_inner_PFR',
-                connect_outer='upper_inner_SOL', connect_lower='upper_outer_intersep')
+                ylower_ind=jys21 + 1, yupper_ind=nyinner,
+                connect_inner='upper_inner_PFR', connect_outer='upper_inner_SOL',
+                connect_lower='upper_outer_intersep')
         regions['upper_inner_SOL'] = Region(
                 name='upper_inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=jys21 + 1, yupper_ind=nyinner,
@@ -417,8 +418,9 @@ def _create_regions_toroidal(ds):
                 connect_outer='upper_outer_intersep', connect_upper='upper_inner_PFR')
         regions['upper_outer_intersep'] = Region(
                 name='upper_outer_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
-                ylower_ind=nyinner, yupper_ind=jys12 + 1, connect_inner='upper_outer_PFR',
-                connect_outer='upper_outer_SOL', connect_upper='upper_inner_intersep')
+                ylower_ind=nyinner, yupper_ind=jys12 + 1,
+                connect_inner='upper_outer_PFR', connect_outer='upper_outer_SOL',
+                connect_upper='upper_inner_intersep')
         regions['upper_outer_SOL'] = Region(
                 name='upper_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
                 ylower_ind=nyinner, yupper_ind=jys12 + 1,
@@ -440,16 +442,16 @@ def _create_regions_toroidal(ds):
                 connect_upper='lower_outer_SOL')
         regions['lower_outer_PFR'] = Region(
                 name='lower_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-                ylower_ind=jys22 + 1, yupper_ind=ny, connect_outer='lower_outer_intersep',
-                connect_lower='lower_inner_PFR')
+                ylower_ind=jys22 + 1, yupper_ind=ny,
+                connect_outer='lower_outer_intersep', connect_lower='lower_inner_PFR')
         regions['lower_outer_intersep'] = Region(
                 name='lower_outer_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
                 ylower_ind=jys22 + 1, yupper_ind=ny, connect_inner='lower_outer_PFR',
                 connect_outer='lower_outer_SOL', connect_lower='outer_intersep')
         regions['lower_outer_SOL'] = Region(
                 name='lower_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
-                ylower_ind=jys22 + 1, yupper_ind=ny, connect_inner='lower_outer_intersep',
-                connect_lower='outer_SOL')
+                ylower_ind=jys22 + 1, yupper_ind=ny,
+                connect_inner='lower_outer_intersep', connect_lower='outer_SOL')
         _check_connections(regions)
     elif topology == 'connected-double-null':
         regions['lower_inner_PFR'] = Region(
@@ -470,20 +472,20 @@ def _create_regions_toroidal(ds):
                 connect_lower='lower_inner_SOL', connect_upper='upper_inner_SOL')
         regions['upper_inner_PFR'] = Region(
                 name='upper_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-                ylower_ind=jys21 + 1, yupper_ind=nyinner, connect_outer='upper_inner_SOL',
-                connect_lower='upper_outer_PFR')
+                ylower_ind=jys21 + 1, yupper_ind=nyinner,
+                connect_outer='upper_inner_SOL', connect_lower='upper_outer_PFR')
         regions['upper_inner_SOL'] = Region(
                 name='upper_inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
-                ylower_ind=jys21 + 1, yupper_ind=nyinner, connect_inner='upper_inner_PFR',
-                connect_lower='inner_SOL')
+                ylower_ind=jys21 + 1, yupper_ind=nyinner,
+                connect_inner='upper_inner_PFR', connect_lower='inner_SOL')
         regions['upper_outer_PFR'] = Region(
                 name='upper_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-                ylower_ind=nyinner, yupper_ind=jys12 + 1, connect_outer='upper_outer_SOL',
-                connect_upper='upper_inner_PFR')
+                ylower_ind=nyinner, yupper_ind=jys12 + 1,
+                connect_outer='upper_outer_SOL', connect_upper='upper_inner_PFR')
         regions['upper_outer_SOL'] = Region(
                 name='upper_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
-                ylower_ind=nyinner, yupper_ind=jys12 + 1, connect_inner='upper_outer_PFR',
-                connect_upper='outer_SOL')
+                ylower_ind=nyinner, yupper_ind=jys12 + 1,
+                connect_inner='upper_outer_PFR', connect_upper='outer_SOL')
         regions['outer_core'] = Region(
                 name='outer_core', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys12 + 1, yupper_ind=jys22 + 1, connect_outer='outer_SOL',
@@ -504,7 +506,8 @@ def _create_regions_toroidal(ds):
     elif topology == 'single-null':
         regions['inner_PFR'] = Region(
                 name='inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=0,
-                yupper_ind=jys11 + 1, connect_outer='inner_SOL', connect_upper='outer_PFR')
+                yupper_ind=jys11 + 1, connect_outer='inner_SOL',
+                connect_upper='outer_PFR')
         regions['inner_SOL'] = Region(
                 name='inner_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=0,
                 yupper_ind=jys11 + 1, connect_inner='inner_PFR', connect_upper='SOL')
@@ -555,20 +558,20 @@ def _create_regions_toroidal(ds):
                 connect_upper='upper_inner_SOL')
         regions['upper_inner_PFR'] = Region(
                 name='upper_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-                ylower_ind=jys11 + 1, yupper_ind=nyinner, connect_outer='upper_inner_SOL',
-                connect_lower='upper_outer_PFR')
+                ylower_ind=jys11 + 1, yupper_ind=nyinner,
+                connect_outer='upper_inner_SOL', connect_lower='upper_outer_PFR')
         regions['upper_inner_SOL'] = Region(
                 name='upper_inner_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
-                ylower_ind=jys11 + 1, yupper_ind=nyinner, connect_inner='upper_inner_PFR',
-                connect_lower='lower_inner_SOL')
+                ylower_ind=jys11 + 1, yupper_ind=nyinner,
+                connect_inner='upper_inner_PFR', connect_lower='lower_inner_SOL')
         regions['upper_outer_PFR'] = Region(
                 name='upper_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-                ylower_ind=nyinner, yupper_ind=jys22 + 1, connect_outer='upper_outer_SOL',
-                connect_upper='upper_inner_PFR')
+                ylower_ind=nyinner, yupper_ind=jys22 + 1,
+                connect_outer='upper_outer_SOL', connect_upper='upper_inner_PFR')
         regions['upper_outer_SOL'] = Region(
                 name='upper_outer_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
-                ylower_ind=nyinner, yupper_ind=jys22 + 1, connect_inner='upper_outer_PFR',
-                connect_upper='lower_outer_SOL')
+                ylower_ind=nyinner, yupper_ind=jys22 + 1,
+                connect_inner='upper_outer_PFR', connect_upper='lower_outer_SOL')
         regions['lower_outer_PFR'] = Region(
                 name='lower_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
                 ylower_ind=jys22 + 1, yupper_ind=ny, connect_outer='lower_outer_SOL',

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -285,31 +285,31 @@ def _check_connections(regions):
         if region.connection_inner is not None:
             if regions[region.connection_inner].connection_outer != region.name:
                 raise ValueError(
-                        'Inner connection of ' + region.name + ' is '
-                        + region.connection_inner + ', but outer connection of '
-                        + region.connection_inner + ' is '
-                        + regions[region.connection_inner].connection_outer)
+                        f'Inner connection of {region.name} is '
+                        f'{region.connection_inner}, but outer connection of '
+                        f'{region.connection_inner} is '
+                        f'{regions[region.connection_inner].connection_outer}')
         if region.connection_outer is not None:
             if regions[region.connection_outer].connection_inner != region.name:
                 raise ValueError(
-                        'Inner connection of ' + region.name + ' is '
-                        + region.connection_outer + ', but inner connection of '
-                        + region.connection_outer + ' is '
-                        + regions[region.connection_outer].connection_inner)
+                        f'Inner connection of {region.name} is '
+                        f'{region.connection_outer}, but inner connection of '
+                        f'{region.connection_outer} is '
+                        f'{regions[region.connection_outer].connection_inner}')
         if region.connection_lower is not None:
             if regions[region.connection_lower].connection_upper != region.name:
                 raise ValueError(
-                        'Inner connection of ' + region.name + ' is '
-                        + region.connection_lower + ', but upper connection of '
-                        + region.connection_lower + ' is '
-                        + regions[region.connection_lower].connection_upper)
+                        f'Inner connection of {region.name} is '
+                        f'{region.connection_lower}, but upper connection of '
+                        f'{region.connection_lower} is '
+                        f'{regions[region.connection_lower].connection_upper}')
         if region.connection_upper is not None:
             if regions[region.connection_upper].connection_lower != region.name:
                 raise ValueError(
-                        'Inner connection of ' + region.name + ' is '
-                        + region.connection_upper + ', but lower connection of '
-                        + region.connection_upper + ' is '
-                        + regions[region.connection_upper].connection_lower)
+                        f'Inner connection of {region.name} is '
+                        f'{region.connection_upper}, but lower connection of '
+                        f'{region.connection_upper} is '
+                        f'{regions[region.connection_upper].connection_lower}')
 
 
 topologies = {}
@@ -628,7 +628,7 @@ def _create_regions_toroidal(ds):
                                        jys21=jys21, ny_inner=ny_inner, jys12=jys12,
                                        jys22=jys22, ny=ny, ybndry=ybndry)
     except KeyError:
-        raise NotImplementedError("Topology '" + topology + "' is not implemented")
+        raise NotImplementedError(f"Topology '{topology}' is not implemented")
 
     _check_connections(regions)
 

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -101,7 +101,7 @@ class Region:
             # particular regions, so do not need to be consistent between different
             # regions (e.g. core and PFR), so we are not forced to use just the index
             # value here.
-            dx = ds['dx']
+            dx = ds['dx'].isel({self.ycoord: ylower_ind})
             dx_cumsum = dx.cumsum()
             self.xinner = dx_cumsum[xinner_ind] - dx[xinner_ind]
             self.xouter = dx_cumsum[xouter_ind - 1] + dx[xouter_ind - 1]

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -56,13 +56,13 @@ class Region:
             # self.xinner, self.xouter, self.ylower, self.yupper
             if ds.metadata['keep_xboundaries']:
                 xbndry = ds.metadata['MXG']
-                if self.connection_inner is None:
+                if self.connection_inner_x is None:
                     self.nx -= xbndry
 
                     # used to calculate x-coordinate of inner side (self.xinner)
                     xinner_ind += xbndry
 
-                if self.connection_outer is None:
+                if self.connection_outer_x is None:
                     self.nx -= xbndry
 
                     # used to calculate x-coordinate of outer side (self.xouter)
@@ -70,13 +70,13 @@ class Region:
 
             if ds.metadata['keep_yboundaries']:
                 ybndry = ds.metadata['MYG']
-                if self.connection_lower is None:
+                if self.connection_lower_y is None:
                     self.ny -= ybndry
 
                     # used to calculate y-coordinate of lower side (self.ylower)
                     ylower_ind += ybndry
 
-                if self.connection_upper is None:
+                if self.connection_upper_y is None:
                     self.ny -= ybndry
 
                     # used to calculate y-coordinate of upper side (self.yupper)
@@ -286,34 +286,34 @@ def _get_topology(ds):
 
 def _check_connections(regions):
     for region in regions.values():
-        if region.connection_inner is not None:
-            if regions[region.connection_inner].connection_outer != region.name:
+        if region.connection_inner_x is not None:
+            if regions[region.connection_inner_x].connection_outer_x != region.name:
                 raise ValueError(
-                        f'Inner connection of {region.name} is '
-                        f'{region.connection_inner}, but outer connection of '
-                        f'{region.connection_inner} is '
-                        f'{regions[region.connection_inner].connection_outer}')
-        if region.connection_outer is not None:
-            if regions[region.connection_outer].connection_inner != region.name:
+                        f'Inner-x connection of {region.name} is '
+                        f'{region.connection_inner_x}, but outer-x connection of '
+                        f'{region.connection_inner_x} is '
+                        f'{regions[region.connection_inner_x].connection_outer_x}')
+        if region.connection_outer_x is not None:
+            if regions[region.connection_outer_x].connection_inner_x != region.name:
                 raise ValueError(
-                        f'Inner connection of {region.name} is '
-                        f'{region.connection_outer}, but inner connection of '
-                        f'{region.connection_outer} is '
-                        f'{regions[region.connection_outer].connection_inner}')
-        if region.connection_lower is not None:
-            if regions[region.connection_lower].connection_upper != region.name:
+                        f'Inner-x connection of {region.name} is '
+                        f'{region.connection_outer_x}, but inner-x connection of '
+                        f'{region.connection_outer_x} is '
+                        f'{regions[region.connection_outer_x].connection_inner_x}')
+        if region.connection_lower_y is not None:
+            if regions[region.connection_lower_y].connection_upper_y != region.name:
                 raise ValueError(
-                        f'Inner connection of {region.name} is '
-                        f'{region.connection_lower}, but upper connection of '
-                        f'{region.connection_lower} is '
-                        f'{regions[region.connection_lower].connection_upper}')
-        if region.connection_upper is not None:
-            if regions[region.connection_upper].connection_lower != region.name:
+                        f'Lower-y connection of {region.name} is '
+                        f'{region.connection_lower_y}, but upper-y connection of '
+                        f'{region.connection_lower_y} is '
+                        f'{regions[region.connection_lower_y].connection_upper_y}')
+        if region.connection_upper_y is not None:
+            if regions[region.connection_upper_y].connection_lower_y != region.name:
                 raise ValueError(
-                        f'Inner connection of {region.name} is '
-                        f'{region.connection_upper}, but lower connection of '
-                        f'{region.connection_upper} is '
-                        f'{regions[region.connection_upper].connection_lower}')
+                        f'Upper-y connection of {region.name} is '
+                        f'{region.connection_upper_y}, but lower-y connection of '
+                        f'{region.connection_upper_y} is '
+                        f'{regions[region.connection_upper_y].connection_lower_y}')
 
 
 topologies = {}
@@ -324,84 +324,88 @@ def topology_disconnected_double_null(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_in
     regions = {}
     regions['lower_inner_PFR'] = Region(
             name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-            ylower_ind=0, yupper_ind=jys11 + 1, connect_outer='lower_inner_intersep',
-            connect_upper='lower_outer_PFR')
+            ylower_ind=0, yupper_ind=jys11 + 1,
+            connection_outer_x='lower_inner_intersep',
+            connection_upper_y='lower_outer_PFR')
     regions['lower_inner_intersep'] = Region(
             name='lower_inner_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
-            ylower_ind=0, yupper_ind=jys11 + 1, connect_inner='lower_inner_PFR',
-            connect_outer='lower_inner_SOL', connect_upper='inner_intersep')
+            ylower_ind=0, yupper_ind=jys11 + 1, connection_inner_x='lower_inner_PFR',
+            connection_outer_x='lower_inner_SOL', connection_upper_y='inner_intersep')
     regions['lower_inner_SOL'] = Region(
             name='lower_inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
-            ylower_ind=0, yupper_ind=jys11 + 1, connect_inner='lower_inner_intersep',
-            connect_upper='inner_SOL')
+            ylower_ind=0, yupper_ind=jys11 + 1,
+            connection_inner_x='lower_inner_intersep', connection_upper_y='inner_SOL')
     regions['inner_core'] = Region(
             name='inner_core', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=jys11 + 1, yupper_ind=jys21 + 1,
-            connect_outer='inner_intersep', connect_lower='outer_core',
-            connect_upper='outer_core')
+            connection_outer_x='inner_intersep', connection_lower_y='outer_core',
+            connection_upper_y='outer_core')
     regions['inner_intersep'] = Region(
             name='inner_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
-            ylower_ind=jys11 + 1, yupper_ind=jys21 + 1, connect_inner='inner_core',
-            connect_outer='inner_SOL', connect_lower='lower_inner_intersep',
-            connect_upper='outer_intersep')
+            ylower_ind=jys11 + 1, yupper_ind=jys21 + 1, connection_inner_x='inner_core',
+            connection_outer_x='inner_SOL', connection_lower_y='lower_inner_intersep',
+            connection_upper_y='outer_intersep')
     regions['inner_SOL'] = Region(
             name='inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
             ylower_ind=jys11 + 1, yupper_ind=jys21 + 1,
-            connect_inner='inner_intersep', connect_lower='lower_inner_SOL',
-            connect_upper='upper_inner_SOL')
+            connection_inner_x='inner_intersep', connection_lower_y='lower_inner_SOL',
+            connection_upper_y='upper_inner_SOL')
     regions['upper_inner_PFR'] = Region(
             name='upper_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=jys21 + 1, yupper_ind=ny_inner,
-            connect_outer='upper_inner_intersep', connect_lower='upper_outer_PFR')
+            connection_outer_x='upper_inner_intersep',
+            connection_lower_y='upper_outer_PFR')
     regions['upper_inner_intersep'] = Region(
             name='upper_inner_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
             ylower_ind=jys21 + 1, yupper_ind=ny_inner,
-            connect_inner='upper_inner_PFR', connect_outer='upper_inner_SOL',
-            connect_lower='upper_outer_intersep')
+            connection_inner_x='upper_inner_PFR', connection_outer_x='upper_inner_SOL',
+            connection_lower_y='upper_outer_intersep')
     regions['upper_inner_SOL'] = Region(
             name='upper_inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
             ylower_ind=jys21 + 1, yupper_ind=ny_inner,
-            connect_inner='upper_inner_intersep', connect_lower='inner_SOL')
+            connection_inner_x='upper_inner_intersep', connection_lower_y='inner_SOL')
     regions['upper_outer_PFR'] = Region(
             name='upper_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=ny_inner, yupper_ind=jys12 + 1,
-            connect_outer='upper_outer_intersep', connect_upper='upper_inner_PFR')
+            connection_outer_x='upper_outer_intersep',
+            connection_upper_y='upper_inner_PFR')
     regions['upper_outer_intersep'] = Region(
             name='upper_outer_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
             ylower_ind=ny_inner, yupper_ind=jys12 + 1,
-            connect_inner='upper_outer_PFR', connect_outer='upper_outer_SOL',
-            connect_upper='upper_inner_intersep')
+            connection_inner_x='upper_outer_PFR', connection_outer_x='upper_outer_SOL',
+            connection_upper_y='upper_inner_intersep')
     regions['upper_outer_SOL'] = Region(
             name='upper_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
             ylower_ind=ny_inner, yupper_ind=jys12 + 1,
-            connect_inner='upper_outer_intersep', connect_upper='outer_SOL')
+            connection_inner_x='upper_outer_intersep', connection_upper_y='outer_SOL')
     regions['outer_core'] = Region(
             name='outer_core', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=jys12 + 1, yupper_ind=jys22 + 1,
-            connect_outer='outer_intersep', connect_lower='inner_core',
-            connect_upper='inner_core')
+            connection_outer_x='outer_intersep', connection_lower_y='inner_core',
+            connection_upper_y='inner_core')
     regions['outer_intersep'] = Region(
             name='outer_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
-            ylower_ind=jys12 + 1, yupper_ind=jys22 + 1, connect_inner='outer_core',
-            connect_outer='outer_SOL', connect_lower='inner_intersep',
-            connect_upper='lower_outer_intersep')
+            ylower_ind=jys12 + 1, yupper_ind=jys22 + 1, connection_inner_x='outer_core',
+            connection_outer_x='outer_SOL', connection_lower_y='inner_intersep',
+            connection_upper_y='lower_outer_intersep')
     regions['outer_SOL'] = Region(
             name='outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
             ylower_ind=jys12 + 1, yupper_ind=jys22 + 1,
-            connect_inner='outer_intersep', connect_lower='upper_outer_SOL',
-            connect_upper='lower_outer_SOL')
+            connection_inner_x='outer_intersep', connection_lower_y='upper_outer_SOL',
+            connection_upper_y='lower_outer_SOL')
     regions['lower_outer_PFR'] = Region(
             name='lower_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=jys22 + 1, yupper_ind=ny,
-            connect_outer='lower_outer_intersep', connect_lower='lower_inner_PFR')
+            connection_outer_x='lower_outer_intersep',
+            connection_lower_y='lower_inner_PFR')
     regions['lower_outer_intersep'] = Region(
             name='lower_outer_intersep', ds=ds, xinner_ind=ixs1, xouter_ind=ixs2,
-            ylower_ind=jys22 + 1, yupper_ind=ny, connect_inner='lower_outer_PFR',
-            connect_outer='lower_outer_SOL', connect_lower='outer_intersep')
+            ylower_ind=jys22 + 1, yupper_ind=ny, connection_inner_x='lower_outer_PFR',
+            connection_outer_x='lower_outer_SOL', connection_lower_y='outer_intersep')
     regions['lower_outer_SOL'] = Region(
             name='lower_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
             ylower_ind=jys22 + 1, yupper_ind=ny,
-            connect_inner='lower_outer_intersep', connect_lower='outer_SOL')
+            connection_inner_x='lower_outer_intersep', connection_lower_y='outer_SOL')
     return regions
 
 
@@ -413,52 +417,52 @@ def topology_connected_double_null(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner
     regions = {}
     regions['lower_inner_PFR'] = Region(
             name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-            ylower_ind=0, yupper_ind=jys11 + 1, connect_outer='lower_inner_SOL',
-            connect_upper='lower_outer_PFR')
+            ylower_ind=0, yupper_ind=jys11 + 1, connection_outer_x='lower_inner_SOL',
+            connection_upper_y='lower_outer_PFR')
     regions['lower_inner_SOL'] = Region(
             name='lower_inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
-            ylower_ind=0, yupper_ind=jys11 + 1, connect_inner='lower_inner_PFR',
-            connect_upper='inner_SOL')
+            ylower_ind=0, yupper_ind=jys11 + 1, connection_inner_x='lower_inner_PFR',
+            connection_upper_y='inner_SOL')
     regions['inner_core'] = Region(
             name='inner_core', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-            ylower_ind=jys11 + 1, yupper_ind=jys21 + 1, connect_outer='inner_SOL',
-            connect_lower='outer_core', connect_upper='outer_core')
+            ylower_ind=jys11 + 1, yupper_ind=jys21 + 1, connection_outer_x='inner_SOL',
+            connection_lower_y='outer_core', connection_upper_y='outer_core')
     regions['inner_SOL'] = Region(
             name='inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
-            ylower_ind=jys11 + 1, yupper_ind=jys21 + 1, connect_inner='inner_core',
-            connect_lower='lower_inner_SOL', connect_upper='upper_inner_SOL')
+            ylower_ind=jys11 + 1, yupper_ind=jys21 + 1, connection_inner_x='inner_core',
+            connection_lower_y='lower_inner_SOL', connection_upper_y='upper_inner_SOL')
     regions['upper_inner_PFR'] = Region(
             name='upper_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=jys21 + 1, yupper_ind=ny_inner,
-            connect_outer='upper_inner_SOL', connect_lower='upper_outer_PFR')
+            connection_outer_x='upper_inner_SOL', connection_lower_y='upper_outer_PFR')
     regions['upper_inner_SOL'] = Region(
             name='upper_inner_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
             ylower_ind=jys21 + 1, yupper_ind=ny_inner,
-            connect_inner='upper_inner_PFR', connect_lower='inner_SOL')
+            connection_inner_x='upper_inner_PFR', connection_lower_y='inner_SOL')
     regions['upper_outer_PFR'] = Region(
             name='upper_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=ny_inner, yupper_ind=jys12 + 1,
-            connect_outer='upper_outer_SOL', connect_upper='upper_inner_PFR')
+            connection_outer_x='upper_outer_SOL', connection_upper_y='upper_inner_PFR')
     regions['upper_outer_SOL'] = Region(
             name='upper_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
             ylower_ind=ny_inner, yupper_ind=jys12 + 1,
-            connect_inner='upper_outer_PFR', connect_upper='outer_SOL')
+            connection_inner_x='upper_outer_PFR', connection_upper_y='outer_SOL')
     regions['outer_core'] = Region(
             name='outer_core', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-            ylower_ind=jys12 + 1, yupper_ind=jys22 + 1, connect_outer='outer_SOL',
-            connect_lower='inner_core', connect_upper='inner_core')
+            ylower_ind=jys12 + 1, yupper_ind=jys22 + 1, connection_outer_x='outer_SOL',
+            connection_lower_y='inner_core', connection_upper_y='inner_core')
     regions['outer_SOL'] = Region(
             name='outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
-            ylower_ind=jys12 + 1, yupper_ind=jys22 + 1, connect_inner='outer_core',
-            connect_lower='upper_outer_SOL', connect_upper='lower_outer_SOL')
+            ylower_ind=jys12 + 1, yupper_ind=jys22 + 1, connection_inner_x='outer_core',
+            connection_lower_y='upper_outer_SOL', connection_upper_y='lower_outer_SOL')
     regions['lower_outer_PFR'] = Region(
             name='lower_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-            ylower_ind=jys22 + 1, yupper_ind=ny, connect_outer='lower_outer_SOL',
-            connect_lower='lower_inner_PFR')
+            ylower_ind=jys22 + 1, yupper_ind=ny, connection_outer_x='lower_outer_SOL',
+            connection_lower_y='lower_inner_PFR')
     regions['lower_outer_SOL'] = Region(
             name='lower_outer_SOL', ds=ds, xinner_ind=ixs2, xouter_ind=nx,
-            ylower_ind=jys22 + 1, yupper_ind=ny, connect_inner='lower_outer_PFR',
-            connect_lower='outer_SOL')
+            ylower_ind=jys22 + 1, yupper_ind=ny, connection_inner_x='lower_outer_PFR',
+            connection_lower_y='outer_SOL')
     return regions
 
 
@@ -470,27 +474,28 @@ def topology_single_null(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, j
     regions = {}
     regions['inner_PFR'] = Region(
             name='inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=0,
-            yupper_ind=jys11 + 1, connect_outer='inner_SOL',
-            connect_upper='outer_PFR')
+            yupper_ind=jys11 + 1, connection_outer_x='inner_SOL',
+            connection_upper_y='outer_PFR')
     regions['inner_SOL'] = Region(
             name='inner_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=0,
-            yupper_ind=jys11 + 1, connect_inner='inner_PFR', connect_upper='SOL')
+            yupper_ind=jys11 + 1, connection_inner_x='inner_PFR',
+            connection_upper_y='SOL')
     regions['core'] = Region(
             name='core', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=jys11 + 1,
-            yupper_ind=jys22 + 1, connect_outer='SOL', connect_lower='core',
-            connect_upper='core')
+            yupper_ind=jys22 + 1, connection_outer_x='SOL', connection_lower_y='core',
+            connection_upper_y='core')
     regions['SOL'] = Region(
             name='SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=jys11 + 1,
-            yupper_ind=jys22 + 1, connect_inner='core', connect_lower='inner_SOL',
-            connect_upper='outer_SOL')
+            yupper_ind=jys22 + 1, connection_inner_x='core',
+            connection_lower_y='inner_SOL', connection_upper_y='outer_SOL')
     regions['outer_PFR'] = Region(
             name='outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-            ylower_ind=jys22 + 1, yupper_ind=ny, connect_outer='outer_SOL',
-            connect_lower='inner_PFR')
+            ylower_ind=jys22 + 1, yupper_ind=ny, connection_outer_x='outer_SOL',
+            connection_lower_y='inner_PFR')
     regions['outer_SOL'] = Region(
             name='outer_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
-            ylower_ind=jys22 + 1, yupper_ind=ny, connect_inner='outer_PFR',
-            connect_lower='SOL')
+            ylower_ind=jys22 + 1, yupper_ind=ny, connection_inner_x='outer_PFR',
+            connection_lower_y='SOL')
     return regions
 
 
@@ -502,11 +507,11 @@ def topology_limiter(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, jys22
     regions = {}
     regions['core'] = Region(
             name='core', ds=ds, xinner_ind=0, xouter_ind=ixs1, ylower_ind=ybndry,
-            yupper_ind=ny - ybndry, connect_outer='SOL', connect_lower='core',
-            connect_upper='core')
+            yupper_ind=ny - ybndry, connection_outer_x='SOL', connection_lower_y='core',
+            connection_upper_y='core')
     regions['SOL'] = Region(
             name='SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx, ylower_ind=0,
-            yupper_ind=ny, connect_inner='core')
+            yupper_ind=ny, connection_inner_x='core')
     return regions
 
 
@@ -518,7 +523,7 @@ def topology_core(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, jys22, n
     regions = {}
     regions['core'] = Region(
             name='core', ds=ds, xinner_ind=0, xouter_ind=nx, ylower_ind=ybndry,
-            yupper_ind=ny - ybndry, connect_lower='core', connect_upper='core')
+            yupper_ind=ny - ybndry, connection_lower_y='core', connection_upper_y='core')
     return regions
 
 
@@ -542,36 +547,36 @@ def topology_xpoint(*, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, jys22,
     regions = {}
     regions['lower_inner_PFR'] = Region(
             name='lower_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-            ylower_ind=0, yupper_ind=jys11 + 1, connect_outer='lower_inner_SOL',
-            connect_upper='lower_outer_PFR')
+            ylower_ind=0, yupper_ind=jys11 + 1, connection_outer_x='lower_inner_SOL',
+            connection_upper_y='lower_outer_PFR')
     regions['lower_inner_SOL'] = Region(
             name='lower_inner_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
-            ylower_ind=0, yupper_ind=jys11 + 1, connect_inner='lower_inner_PFR',
-            connect_upper='upper_inner_SOL')
+            ylower_ind=0, yupper_ind=jys11 + 1, connection_inner_x='lower_inner_PFR',
+            connection_upper_y='upper_inner_SOL')
     regions['upper_inner_PFR'] = Region(
             name='upper_inner_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=jys11 + 1, yupper_ind=ny_inner,
-            connect_outer='upper_inner_SOL', connect_lower='upper_outer_PFR')
+            connection_outer_x='upper_inner_SOL', connection_lower_y='upper_outer_PFR')
     regions['upper_inner_SOL'] = Region(
             name='upper_inner_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
             ylower_ind=jys11 + 1, yupper_ind=ny_inner,
-            connect_inner='upper_inner_PFR', connect_lower='lower_inner_SOL')
+            connection_inner_x='upper_inner_PFR', connection_lower_y='lower_inner_SOL')
     regions['upper_outer_PFR'] = Region(
             name='upper_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
             ylower_ind=ny_inner, yupper_ind=jys22 + 1,
-            connect_outer='upper_outer_SOL', connect_upper='upper_inner_PFR')
+            connection_outer_x='upper_outer_SOL', connection_upper_y='upper_inner_PFR')
     regions['upper_outer_SOL'] = Region(
             name='upper_outer_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
             ylower_ind=ny_inner, yupper_ind=jys22 + 1,
-            connect_inner='upper_outer_PFR', connect_upper='lower_outer_SOL')
+            connection_inner_x='upper_outer_PFR', connection_upper_y='lower_outer_SOL')
     regions['lower_outer_PFR'] = Region(
             name='lower_outer_PFR', ds=ds, xinner_ind=0, xouter_ind=ixs1,
-            ylower_ind=jys22 + 1, yupper_ind=ny, connect_outer='lower_outer_SOL',
-            connect_lower='lower_inner_PFR')
+            ylower_ind=jys22 + 1, yupper_ind=ny, connection_outer_x='lower_outer_SOL',
+            connection_lower_y='lower_inner_PFR')
     regions['lower_outer_SOL'] = Region(
             name='lower_outer_SOL', ds=ds, xinner_ind=ixs1, xouter_ind=nx,
-            ylower_ind=jys22 + 1, yupper_ind=ny, connect_inner='lower_outer_PFR',
-            connect_lower='upper_outer_SOL')
+            ylower_ind=jys22 + 1, yupper_ind=ny, connection_inner_x='lower_outer_PFR',
+            connection_lower_y='upper_outer_SOL')
     return regions
 
 

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -199,7 +199,7 @@ class TestBoutDataArrayMethods:
             npt.assert_allclose(n_nal[t, 1, 3, 6].values, 1000.*t + 100.*1 + 10.*3. + 6., rtol=1.e-15, atol=0.)  # noqa: E501
 
     def test_highParallelResRegion_core(self, tmpdir_factory, bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 16, 7), nxpe=1,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
                                       nype=1, nt=1, grid='grid', guards={'y':2},
                                       topology='core')
 
@@ -235,7 +235,7 @@ class TestBoutDataArrayMethods:
     @pytest.mark.parametrize('res_factor', [2, 3, 7, 18])
     def test_highParallelResRegion_core_change_n(self, tmpdir_factory,
                                                  bout_xyt_example_files, res_factor):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 16, 7), nxpe=1,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
                                       nype=1, nt=1, grid='grid', guards={'y':2},
                                       topology='core')
 
@@ -270,7 +270,7 @@ class TestBoutDataArrayMethods:
         npt.assert_allclose(n_highres.values, expected.values, rtol=0., atol=1.e-2)
 
     def test_highParallelResRegion_sol(self, tmpdir_factory, bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 16, 7), nxpe=1,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
                                       nype=1, nt=1, grid='grid', guards={'y':2},
                                       topology='sol')
 
@@ -305,7 +305,7 @@ class TestBoutDataArrayMethods:
 
     def test_highParallelResRegion_singlenull(self, tmpdir_factory,
                                               bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 16, 7), nxpe=1,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
                                       nype=3, nt=1, grid='grid', guards={'y':2},
                                       topology='single-null')
 
@@ -356,7 +356,7 @@ class TestBoutDataArrayMethods:
             npt.assert_allclose(n_highres.values, expected.values, rtol=0., atol=1.e-2)
 
     def test_highParallelRes(self, tmpdir_factory, bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 16, 7), nxpe=1,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
                                       nype=3, nt=1, grid='grid', guards={'y':2},
                                       topology='single-null')
 

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -55,28 +55,28 @@ class TestBoutDataArrayMethods:
         n_al = n.bout.toFieldAligned()
         for t in range(ds.sizes['t']):
             for z in range(nz):
-                assert_allclose(n_al[t, 0, 0, z].values, 1000.*t + z % nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501
+                npt.assert_allclose(n_al[t, 0, 0, z].values, 1000.*t + z % nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 0, 1, z].values, 1000.*t + 10.*1. + (z + 1) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
+                npt.assert_allclose(n_al[t, 0, 1, z].values, 1000.*t + 10.*1. + (z + 1) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 0, 2, z].values, 1000.*t + 10.*2. + (z + 2) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
+                npt.assert_allclose(n_al[t, 0, 2, z].values, 1000.*t + 10.*2. + (z + 2) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 0, 3, z].values, 1000.*t + 10.*3. + (z + 3) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
+                npt.assert_allclose(n_al[t, 0, 3, z].values, 1000.*t + 10.*3. + (z + 3) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 1, 0, z].values, 1000.*t + 100.*1 + 10.*0. + (z + 4) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                npt.assert_allclose(n_al[t, 1, 0, z].values, 1000.*t + 100.*1 + 10.*0. + (z + 4) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 1, 1, z].values, 1000.*t + 100.*1 + 10.*1. + (z + 5) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                npt.assert_allclose(n_al[t, 1, 1, z].values, 1000.*t + 100.*1 + 10.*1. + (z + 5) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 1, 2, z].values, 1000.*t + 100.*1 + 10.*2. + (z + 6) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                npt.assert_allclose(n_al[t, 1, 2, z].values, 1000.*t + 100.*1 + 10.*2. + (z + 6) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z + 7) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                npt.assert_allclose(n_al[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z + 7) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
     def test_toFieldAligned_dask(self, tmpdir_factory, bout_xyt_example_files):
 

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -199,6 +199,7 @@ class TestBoutDataArrayMethods:
             npt.assert_allclose(n_nal[t, 1, 3, 5].values, 1000.*t + 100.*1 + 10.*3. + 5., rtol=1.e-15, atol=0.)  # noqa: E501
             npt.assert_allclose(n_nal[t, 1, 3, 6].values, 1000.*t + 100.*1 + 10.*3. + 6., rtol=1.e-15, atol=0.)  # noqa: E501
 
+    @pytest.mark.long
     def test_highParallelResRegion_core(self, tmpdir_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
                                       nype=1, nt=1, grid='grid', guards={'y':2},
@@ -233,7 +234,10 @@ class TestBoutDataArrayMethods:
 
         npt.assert_allclose(n_highres.values, expected.values, rtol=0., atol=1.e-2)
 
-    @pytest.mark.parametrize('res_factor', [2, 3, 7, 18])
+    @pytest.mark.parametrize('res_factor', [pytest.param(2, marks=pytest.mark.long),
+                                            3,
+                                            pytest.param(7, marks=pytest.mark.long),
+                                            pytest.param(18, marks=pytest.mark.long)])
     def test_highParallelResRegion_core_change_n(self, tmpdir_factory,
                                                  bout_xyt_example_files, res_factor):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
@@ -270,6 +274,7 @@ class TestBoutDataArrayMethods:
 
         npt.assert_allclose(n_highres.values, expected.values, rtol=0., atol=1.e-2)
 
+    @pytest.mark.long
     def test_highParallelResRegion_sol(self, tmpdir_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
                                       nype=1, nt=1, grid='grid', guards={'y':2},

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -132,7 +132,7 @@ class TestBoutDataArrayMethods:
     @pytest.mark.long
     def test_highParallelResRegion_core(self, tmpdir_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=1, nt=1, grid='grid', guards={'y':2},
+                                      nype=1, nt=1, grid='grid', guards={'y': 2},
                                       topology='core')
 
         ds = open_boutdataset(datapath=path,
@@ -171,7 +171,7 @@ class TestBoutDataArrayMethods:
     def test_highParallelResRegion_core_change_n(self, tmpdir_factory,
                                                  bout_xyt_example_files, res_factor):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=1, nt=1, grid='grid', guards={'y':2},
+                                      nype=1, nt=1, grid='grid', guards={'y': 2},
                                       topology='core')
 
         ds = open_boutdataset(datapath=path,
@@ -207,7 +207,7 @@ class TestBoutDataArrayMethods:
     @pytest.mark.long
     def test_highParallelResRegion_sol(self, tmpdir_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=1, nt=1, grid='grid', guards={'y':2},
+                                      nype=1, nt=1, grid='grid', guards={'y': 2},
                                       topology='sol')
 
         ds = open_boutdataset(datapath=path,
@@ -242,7 +242,7 @@ class TestBoutDataArrayMethods:
     def test_highParallelResRegion_singlenull(self, tmpdir_factory,
                                               bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=3, nt=1, grid='grid', guards={'y':2},
+                                      nype=3, nt=1, grid='grid', guards={'y': 2},
                                       topology='single-null')
 
         ds = open_boutdataset(datapath=path,
@@ -285,7 +285,7 @@ class TestBoutDataArrayMethods:
             npt.assert_allclose(n_highres.values, expected.values, rtol=0., atol=1.e-2)
 
         for region in ['outer_PFR', 'outer_SOL']:
-            n_highres = n.bout.highParallelResRegion(region).isel(theta=slice( -2))
+            n_highres = n.bout.highParallelResRegion(region).isel(theta=slice(-2))
 
             expected = f_fine.broadcast_like(n_highres)
 
@@ -293,7 +293,7 @@ class TestBoutDataArrayMethods:
 
     def test_highParallelRes(self, tmpdir_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=3, nt=1, grid='grid', guards={'y':2},
+                                      nype=3, nt=1, grid='grid', guards={'y': 2},
                                       topology='single-null')
 
         ds = open_boutdataset(datapath=path,
@@ -331,9 +331,10 @@ class TestBoutDataArrayMethods:
         npt.assert_allclose(n_highres.values, expected.values,
                             rtol=0., atol=1.1e-2)
 
-    def test_highParallelRes_toroidal_points(self, tmpdir_factory, bout_xyt_example_files):
+    def test_highParallelRes_toroidal_points(self, tmpdir_factory,
+                                             bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=3, nt=1, grid='grid', guards={'y':2},
+                                      nype=3, nt=1, grid='grid', guards={'y': 2},
                                       topology='single-null')
 
         ds = open_boutdataset(datapath=path,
@@ -349,7 +350,7 @@ class TestBoutDataArrayMethods:
     def test_highParallelRes_toroidal_points_list(self, tmpdir_factory,
                                                   bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=3, nt=1, grid='grid', guards={'y':2},
+                                      nype=3, nt=1, grid='grid', guards={'y': 2},
                                       topology='single-null')
 
         ds = open_boutdataset(datapath=path,

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -394,11 +394,11 @@ class TestBoutDataArrayMethods:
 
         f_fine = f_y(theta_fine)*(x + 1.)
 
-        n_highres_ds = n.bout.highParallelRes().isel(theta=slice(2, -2))
+        n_highres = n.bout.highParallelRes().isel(theta=slice(2, -2))
 
-        expected = f_fine.broadcast_like(n_highres_ds['n'])
+        expected = f_fine.broadcast_like(n_highres)
 
-        npt.assert_allclose(n_highres_ds['n'].values, expected.values,
+        npt.assert_allclose(n_highres.values, expected.values,
                             rtol=0., atol=1.1e-2)
 
     def test_highParallelRes_toroidal_points(self, tmpdir_factory, bout_xyt_example_files):
@@ -410,11 +410,11 @@ class TestBoutDataArrayMethods:
                               gridfilepath=Path(path).parent.joinpath('grid.nc'),
                               geometry='toroidal', keep_yboundaries=True)
 
-        n_highres_ds = ds['n'].bout.highParallelRes()
+        n_highres = ds['n'].bout.highParallelRes()
 
-        n_highres_ds_truncated = ds['n'].bout.highParallelRes(toroidal_points=2)
+        n_highres_truncated = ds['n'].bout.highParallelRes(toroidal_points=2)
 
-        xrt.assert_identical(n_highres_ds_truncated, n_highres_ds.isel(zeta=[0, 2]))
+        xrt.assert_identical(n_highres_truncated, n_highres.isel(zeta=[0, 2]))
 
     def test_highParallelRes_toroidal_points_list(self, tmpdir_factory,
                                                   bout_xyt_example_files):
@@ -426,11 +426,10 @@ class TestBoutDataArrayMethods:
                               gridfilepath=Path(path).parent.joinpath('grid.nc'),
                               geometry='toroidal', keep_yboundaries=True)
 
-        n_highres_ds = ds['n'].bout.highParallelRes()
+        n_highres = ds['n'].bout.highParallelRes()
 
         points_list = [1, 2]
 
-        n_highres_ds_truncated = ds['n'].bout.highParallelRes(
-                toroidal_points=points_list)
+        n_highres_truncated = ds['n'].bout.highParallelRes(toroidal_points=points_list)
 
-        xrt.assert_identical(n_highres_ds_truncated, n_highres_ds.isel(zeta=points_list))
+        xrt.assert_identical(n_highres_truncated, n_highres.isel(zeta=points_list))

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -25,7 +25,10 @@ class TestBoutDataArrayMethods:
         assert dict_equiv(ds.attrs, new_ds.attrs)
         assert dict_equiv(ds.metadata, new_ds.metadata)
 
-    @pytest.mark.parametrize('nz', [6, 7, 8, 9])
+    @pytest.mark.parametrize('nz', [pytest.param(6, marks=pytest.mark.long),
+                                    7,
+                                    pytest.param(8, marks=pytest.mark.long),
+                                    pytest.param(9, marks=pytest.mark.long)])
     def test_toFieldAligned(self, tmpdir_factory, bout_xyt_example_files, nz):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1,
                                       nype=1, nt=1)
@@ -74,7 +77,10 @@ class TestBoutDataArrayMethods:
             for z in range(nz):
                 npt.assert_allclose(n_al[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z + 7)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
-    @pytest.mark.parametrize('nz', [6, 7, 8, 9])
+    @pytest.mark.parametrize('nz', [pytest.param(6, marks=pytest.mark.long),
+                                    7,
+                                    pytest.param(8, marks=pytest.mark.long),
+                                    pytest.param(9, marks=pytest.mark.long)])
     def test_fromFieldAligned(self, tmpdir_factory, bout_xyt_example_files, nz):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1,
                                       nype=1, nt=1)

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -85,7 +85,7 @@ class TestBoutDatasetMethods:
         ds['n_aligned'] = ds['T']
         xrt.assert_allclose(ds.bout.getFieldAligned('n'), ds['T'])
 
-    def test_resetParallelInterpFactor(self):
+    def test_set_parallel_interpolation_factor(self):
         ds = Dataset()
         ds['a'] = DataArray()
         ds = _set_attrs_on_all_vars(ds, 'metadata', {})
@@ -95,7 +95,7 @@ class TestBoutDatasetMethods:
         with pytest.raises(KeyError):
             ds['a'].metadata['fine_interpolation_factor']
 
-        ds.bout.resetParallelInterpFactor(42)
+        ds.bout.set_parallel_interpolation_factor(42)
 
         assert ds.metadata['fine_interpolation_factor'] == 42
         assert ds['a'].metadata['fine_interpolation_factor'] == 42

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -103,7 +103,7 @@ class TestBoutDatasetMethods:
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
     def test_interpolate_parallel(self, tmpdir_factory, bout_xyt_example_files,
-                                    guards, keep_xboundaries, keep_yboundaries):
+                                  guards, keep_xboundaries, keep_yboundaries):
         # This test checks that the regions created in the new high-resolution Dataset by
         # interpolate_parallel are correct.
         # This test does not test the accuracy of the parallel interpolation (there are

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -102,10 +102,10 @@ class TestBoutDatasetMethods:
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
-    def test_getHighParallelResVars(self, tmpdir_factory, bout_xyt_example_files,
+    def test_interpolate_parallel(self, tmpdir_factory, bout_xyt_example_files,
                                     guards, keep_xboundaries, keep_yboundaries):
         # This test checks that the regions created in the new high-resolution Dataset by
-        # getHighParallelResVars are correct.
+        # interpolate_parallel are correct.
         # This test does not test the accuracy of the parallel interpolation (there are
         # other tests for that).
 
@@ -122,7 +122,7 @@ class TestBoutDatasetMethods:
                               keep_yboundaries=keep_yboundaries)
 
         # Get high parallel resolution version of ds, and check that
-        ds = ds.bout.getHighParallelResVars(('n', 'T'))
+        ds = ds.bout.interpolate_parallel(('n', 'T'))
 
         mxg = guards['x']
         myg = guards['y']

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -1,11 +1,14 @@
 import pytest
 
+import numpy.testing as npt
 from xarray import Dataset, DataArray, concat, open_dataset, open_mfdataset
 import xarray.testing as xrt
 import numpy as np
 from pathlib import Path
 
 from xbout.tests.test_load import bout_xyt_example_files, create_bout_ds
+from xbout.tests.test_region import (params_guards, params_guards_values,
+        params_boundaries, params_boundaries_values)
 from xbout import BoutDatasetAccessor, open_boutdataset
 from xbout.geometries import apply_geometry
 from xbout.utils import _set_attrs_on_all_vars
@@ -96,6 +99,335 @@ class TestBoutDatasetMethods:
 
         assert ds.metadata['fine_interpolation_factor'] == 42
         assert ds['a'].metadata['fine_interpolation_factor'] == 42
+
+    @pytest.mark.parametrize(params_guards, params_guards_values)
+    @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
+    def test_getHighParallelResVars(self, tmpdir_factory, bout_xyt_example_files,
+                                   guards, keep_xboundaries, keep_yboundaries):
+        # This test checks that the regions created in the new high-resolution Dataset by
+        # getHighParallelResVars are correct.
+        # This test does not test the accuracy of the parallel interpolation (there are
+        # other tests for that).
+
+        # Note using more than MXG x-direction points and MYG y-direction points per
+        # output file ensures tests for whether boundary cells are present do not fail
+        # when using minimal numbers of processors
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+                                      nype=6, nt=1, guards=guards, grid='grid',
+                                      topology='disconnected-double-null')
+
+        ds = open_boutdataset(datapath=path,
+                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
+                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
+                              keep_yboundaries=keep_yboundaries)
+
+        # Get high parallel resolution version of ds, and check that
+        ds = ds.bout.getHighParallelResVars(('n', 'T'))
+
+        mxg = guards['x']
+        myg = guards['y']
+
+        if keep_xboundaries:
+            ixs1 = ds.metadata['ixseps1']
+        else:
+            ixs1 = ds.metadata['ixseps1'] - guards['x']
+
+        if keep_xboundaries:
+            ixs2 = ds.metadata['ixseps2']
+        else:
+            ixs2 = ds.metadata['ixseps2'] - guards['x']
+
+        if keep_yboundaries:
+            ybndry = guards['y']
+        else:
+            ybndry = 0
+        jys11 = ds.metadata['jyseps1_1'] + ybndry
+        jys21 = ds.metadata['jyseps2_1'] + ybndry
+        ny_inner = ds.metadata['ny_inner'] + 2*ybndry
+        jys12 = ds.metadata['jyseps1_2'] + 3*ybndry
+        jys22 = ds.metadata['jyseps2_2'] + 3*ybndry
+        ny = ds.metadata['ny'] + 4*ybndry
+
+        for var in ['n', 'T']:
+            v = ds[var]
+
+            v_lower_inner_PFR = v.bout.fromRegion('lower_inner_PFR')
+
+            # Remove attributes that are expected to be different
+            del v_lower_inner_PFR.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg), theta=slice(jys11 + 1)),
+                                 v_lower_inner_PFR.isel(
+                                     theta=slice(-myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                                 v_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
+
+            v_lower_inner_intersep = v.bout.fromRegion('lower_inner_intersep')
+
+            # Remove attributes that are expected to be different
+            del v_lower_inner_intersep.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys11 + 1)),
+                                 v_lower_inner_intersep.isel(
+                                     theta=slice(-myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                                 v_lower_inner_intersep.isel(theta=slice(-myg, None)).values)
+
+            v_lower_inner_SOL = v.bout.fromRegion('lower_inner_SOL')
+
+            # Remove attributes that are expected to be different
+            del v_lower_inner_SOL.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1)),
+                                 v_lower_inner_SOL.isel(
+                                     theta=slice(-myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                                 v_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
+
+            v_inner_core = v.bout.fromRegion('inner_core')
+
+            # Remove attributes that are expected to be different
+            del v_inner_core.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys11 + 1, jys21 + 1)),
+                                 v_inner_core.isel(
+                                     theta=slice(myg, -myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                                 v_inner_core.isel(theta=slice(myg)).values)
+                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                                 v_inner_core.isel(theta=slice(-myg, None)).values)
+
+            v_inner_intersep = v.bout.fromRegion('inner_intersep')
+
+            # Remove attributes that are expected to be different
+            del v_inner_intersep.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys11 + 1, jys21 + 1)),
+                                 v_inner_intersep.isel(
+                                     theta=slice(myg, -myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                                 v_inner_intersep.isel(theta=slice(myg)).values)
+                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                                 v_inner_intersep.isel(theta=slice(-myg, None)).values)
+
+            v_inner_sol = v.bout.fromRegion('inner_SOL')
+
+            # Remove attributes that are expected to be different
+            del v_inner_sol.attrs['region']
+            xrt.assert_identical(
+                    v.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1, jys21 + 1)),
+                    v_inner_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                                 v_inner_sol.isel(theta=slice(myg)).values)
+                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                                 v_inner_sol.isel(theta=slice(-myg, None)).values)
+
+            v_upper_inner_PFR = v.bout.fromRegion('upper_inner_PFR')
+
+            # Remove attributes that are expected to be different
+            del v_upper_inner_PFR.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys21 + 1, ny_inner)),
+                                 v_upper_inner_PFR.isel(theta=slice(myg, None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                                 v_upper_inner_PFR.isel(theta=slice(myg)).values)
+
+            v_upper_inner_intersep = v.bout.fromRegion('upper_inner_intersep')
+
+            # Remove attributes that are expected to be different
+            del v_upper_inner_intersep.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys21 + 1, ny_inner)),
+                                 v_upper_inner_intersep.isel(theta=slice(myg, None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                                 v_upper_inner_intersep.isel(theta=slice(myg)).values)
+
+            v_upper_inner_SOL = v.bout.fromRegion('upper_inner_SOL')
+
+            # Remove attributes that are expected to be different
+            del v_upper_inner_SOL.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys21 + 1, ny_inner)),
+                                 v_upper_inner_SOL.isel(theta=slice(myg, None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                                 v_upper_inner_SOL.isel(theta=slice(myg)).values)
+
+            v_upper_outer_PFR = v.bout.fromRegion('upper_outer_PFR')
+
+            # Remove attributes that are expected to be different
+            del v_upper_outer_PFR.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(ny_inner, jys12 + 1)),
+                                 v_upper_outer_PFR.isel(
+                                     theta=slice(-myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                                 v_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
+
+            v_upper_outer_intersep = v.bout.fromRegion('upper_outer_intersep')
+
+            # Remove attributes that are expected to be different
+            del v_upper_outer_intersep.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(ny_inner, jys12 + 1)),
+                                 v_upper_outer_intersep.isel(
+                                     theta=slice(-myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                                 v_upper_outer_intersep.isel(theta=slice(-myg, None)).values)
+
+            v_upper_outer_SOL = v.bout.fromRegion('upper_outer_SOL')
+
+            # Remove attributes that are expected to be different
+            del v_upper_outer_SOL.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(ny_inner, jys12 + 1)),
+                                 v_upper_outer_SOL.isel(
+                                     theta=slice(-myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                                 v_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
+
+            v_outer_core = v.bout.fromRegion('outer_core')
+
+            # Remove attributes that are expected to be different
+            del v_outer_core.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys12 + 1, jys22 + 1)),
+                                 v_outer_core.isel(
+                                     theta=slice(myg, -myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                                 v_outer_core.isel(theta=slice(myg)).values)
+                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                                 v_outer_core.isel(theta=slice(-myg, None)).values)
+
+            v_outer_intersep = v.bout.fromRegion('outer_intersep')
+
+            # Remove attributes that are expected to be different
+            del v_outer_intersep.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys12 + 1, jys22 + 1)),
+                                 v_outer_intersep.isel(
+                                     theta=slice(myg, -myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                                 v_outer_intersep.isel(theta=slice(myg)).values)
+                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                                 v_outer_intersep.isel(theta=slice(-myg, None)).values)
+
+            v_outer_sol = v.bout.fromRegion('outer_SOL')
+
+            # Remove attributes that are expected to be different
+            del v_outer_sol.attrs['region']
+            xrt.assert_identical(
+                    v.isel(x=slice(ixs2 - mxg, None), theta=slice(jys12 + 1, jys22 + 1)),
+                    v_outer_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                                 v_outer_sol.isel(theta=slice(myg)).values)
+                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                                 v_outer_sol.isel(theta=slice(-myg, None)).values)
+
+            v_lower_outer_PFR = v.bout.fromRegion('lower_outer_PFR')
+
+            # Remove attributes that are expected to be different
+            del v_lower_outer_PFR.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys22 + 1, None)),
+                                 v_lower_outer_PFR.isel(theta=slice(myg, None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
+                                        theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                                 v_lower_outer_PFR.isel(theta=slice(myg)).values)
+
+            v_lower_outer_intersep = v.bout.fromRegion('lower_outer_intersep')
+
+            # Remove attributes that are expected to be different
+            del v_lower_outer_intersep.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys22 + 1, None)),
+                                 v_lower_outer_intersep.isel(theta=slice(myg, None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                        theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                                 v_lower_outer_intersep.isel(theta=slice(myg)).values)
+
+            v_lower_outer_SOL = v.bout.fromRegion('lower_outer_SOL')
+
+            # Remove attributes that are expected to be different
+            del v_lower_outer_SOL.attrs['region']
+            xrt.assert_identical(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys22 + 1, None)),
+                                 v_lower_outer_SOL.isel(theta=slice(myg, None)))
+            if myg > 0:
+                # check y-guards, which were 'communicated' by fromRegion
+                # Coordinates are not equal, so only compare array values
+                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                                 v_lower_outer_SOL.isel(theta=slice(myg)).values)
 
 
 class TestLoadInputFile:

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from xbout.tests.test_load import bout_xyt_example_files, create_bout_ds
 from xbout.tests.test_region import (params_guards, params_guards_values,
-        params_boundaries, params_boundaries_values)
+                                     params_boundaries, params_boundaries_values)
 from xbout import BoutDatasetAccessor, open_boutdataset
 from xbout.geometries import apply_geometry
 from xbout.utils import _set_attrs_on_all_vars
@@ -103,7 +103,7 @@ class TestBoutDatasetMethods:
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
     def test_getHighParallelResVars(self, tmpdir_factory, bout_xyt_example_files,
-                                   guards, keep_xboundaries, keep_yboundaries):
+                                    guards, keep_xboundaries, keep_yboundaries):
         # This test checks that the regions created in the new high-resolution Dataset by
         # getHighParallelResVars are correct.
         # This test does not test the accuracy of the parallel interpolation (there are
@@ -178,13 +178,15 @@ class TestBoutDatasetMethods:
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                         theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
-                                 v_lower_inner_intersep.isel(theta=slice(-myg, None)).values)
+                                 v_lower_inner_intersep.isel(
+                                     theta=slice(-myg, None)).values)
 
             v_lower_inner_SOL = v.bout.fromRegion('lower_inner_SOL')
 
             # Remove attributes that are expected to be different
             del v_lower_inner_SOL.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1)),
+            xrt.assert_identical(v.isel(x=slice(ixs2 - mxg, None),
+                                        theta=slice(jys11 + 1)),
                                  v_lower_inner_SOL.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
@@ -317,7 +319,8 @@ class TestBoutDatasetMethods:
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                         theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
-                                 v_upper_outer_intersep.isel(theta=slice(-myg, None)).values)
+                                 v_upper_outer_intersep.isel(
+                                     theta=slice(-myg, None)).values)
 
             v_upper_outer_SOL = v.bout.fromRegion('upper_outer_SOL')
 

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -112,7 +112,7 @@ class TestBoutDatasetMethods:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 7), nxpe=3,
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
                                       nype=6, nt=1, guards=guards, grid='grid',
                                       topology='disconnected-double-null')
 

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -151,7 +151,7 @@ class TestBoutDatasetMethods:
         for var in ['n', 'T']:
             v = ds[var]
 
-            v_lower_inner_PFR = v.bout.fromRegion('lower_inner_PFR')
+            v_lower_inner_PFR = v.bout.from_region('lower_inner_PFR')
 
             # Remove attributes that are expected to be different
             del v_lower_inner_PFR.attrs['region']
@@ -159,13 +159,13 @@ class TestBoutDatasetMethods:
                                  v_lower_inner_PFR.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
                                         theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
                                  v_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
 
-            v_lower_inner_intersep = v.bout.fromRegion('lower_inner_intersep')
+            v_lower_inner_intersep = v.bout.from_region('lower_inner_intersep')
 
             # Remove attributes that are expected to be different
             del v_lower_inner_intersep.attrs['region']
@@ -174,14 +174,14 @@ class TestBoutDatasetMethods:
                                  v_lower_inner_intersep.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                         theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
                                  v_lower_inner_intersep.isel(
                                      theta=slice(-myg, None)).values)
 
-            v_lower_inner_SOL = v.bout.fromRegion('lower_inner_SOL')
+            v_lower_inner_SOL = v.bout.from_region('lower_inner_SOL')
 
             # Remove attributes that are expected to be different
             del v_lower_inner_SOL.attrs['region']
@@ -190,13 +190,13 @@ class TestBoutDatasetMethods:
                                  v_lower_inner_SOL.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
                                         theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
                                  v_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
 
-            v_inner_core = v.bout.fromRegion('inner_core')
+            v_inner_core = v.bout.from_region('inner_core')
 
             # Remove attributes that are expected to be different
             del v_inner_core.attrs['region']
@@ -205,7 +205,7 @@ class TestBoutDatasetMethods:
                                  v_inner_core.isel(
                                      theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
                                         theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
@@ -214,7 +214,7 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
                                  v_inner_core.isel(theta=slice(-myg, None)).values)
 
-            v_inner_intersep = v.bout.fromRegion('inner_intersep')
+            v_inner_intersep = v.bout.from_region('inner_intersep')
 
             # Remove attributes that are expected to be different
             del v_inner_intersep.attrs['region']
@@ -223,7 +223,7 @@ class TestBoutDatasetMethods:
                                  v_inner_intersep.isel(
                                      theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                         theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
@@ -232,7 +232,7 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
                                  v_inner_intersep.isel(theta=slice(-myg, None)).values)
 
-            v_inner_sol = v.bout.fromRegion('inner_SOL')
+            v_inner_sol = v.bout.from_region('inner_SOL')
 
             # Remove attributes that are expected to be different
             del v_inner_sol.attrs['region']
@@ -240,7 +240,7 @@ class TestBoutDatasetMethods:
                     v.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1, jys21 + 1)),
                     v_inner_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
                                         theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
@@ -249,7 +249,7 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
                                  v_inner_sol.isel(theta=slice(-myg, None)).values)
 
-            v_upper_inner_PFR = v.bout.fromRegion('upper_inner_PFR')
+            v_upper_inner_PFR = v.bout.from_region('upper_inner_PFR')
 
             # Remove attributes that are expected to be different
             del v_upper_inner_PFR.attrs['region']
@@ -257,13 +257,13 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys21 + 1, ny_inner)),
                                  v_upper_inner_PFR.isel(theta=slice(myg, None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
                                         theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
                                  v_upper_inner_PFR.isel(theta=slice(myg)).values)
 
-            v_upper_inner_intersep = v.bout.fromRegion('upper_inner_intersep')
+            v_upper_inner_intersep = v.bout.from_region('upper_inner_intersep')
 
             # Remove attributes that are expected to be different
             del v_upper_inner_intersep.attrs['region']
@@ -271,13 +271,13 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys21 + 1, ny_inner)),
                                  v_upper_inner_intersep.isel(theta=slice(myg, None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                         theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
                                  v_upper_inner_intersep.isel(theta=slice(myg)).values)
 
-            v_upper_inner_SOL = v.bout.fromRegion('upper_inner_SOL')
+            v_upper_inner_SOL = v.bout.from_region('upper_inner_SOL')
 
             # Remove attributes that are expected to be different
             del v_upper_inner_SOL.attrs['region']
@@ -285,13 +285,13 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys21 + 1, ny_inner)),
                                  v_upper_inner_SOL.isel(theta=slice(myg, None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
                                         theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
                                  v_upper_inner_SOL.isel(theta=slice(myg)).values)
 
-            v_upper_outer_PFR = v.bout.fromRegion('upper_outer_PFR')
+            v_upper_outer_PFR = v.bout.from_region('upper_outer_PFR')
 
             # Remove attributes that are expected to be different
             del v_upper_outer_PFR.attrs['region']
@@ -300,13 +300,13 @@ class TestBoutDatasetMethods:
                                  v_upper_outer_PFR.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
                                         theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
                                  v_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
 
-            v_upper_outer_intersep = v.bout.fromRegion('upper_outer_intersep')
+            v_upper_outer_intersep = v.bout.from_region('upper_outer_intersep')
 
             # Remove attributes that are expected to be different
             del v_upper_outer_intersep.attrs['region']
@@ -315,14 +315,14 @@ class TestBoutDatasetMethods:
                                  v_upper_outer_intersep.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                         theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
                                  v_upper_outer_intersep.isel(
                                      theta=slice(-myg, None)).values)
 
-            v_upper_outer_SOL = v.bout.fromRegion('upper_outer_SOL')
+            v_upper_outer_SOL = v.bout.from_region('upper_outer_SOL')
 
             # Remove attributes that are expected to be different
             del v_upper_outer_SOL.attrs['region']
@@ -331,13 +331,13 @@ class TestBoutDatasetMethods:
                                  v_upper_outer_SOL.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
                                         theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
                                  v_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
 
-            v_outer_core = v.bout.fromRegion('outer_core')
+            v_outer_core = v.bout.from_region('outer_core')
 
             # Remove attributes that are expected to be different
             del v_outer_core.attrs['region']
@@ -346,7 +346,7 @@ class TestBoutDatasetMethods:
                                  v_outer_core.isel(
                                      theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
                                         theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
@@ -355,7 +355,7 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
                                  v_outer_core.isel(theta=slice(-myg, None)).values)
 
-            v_outer_intersep = v.bout.fromRegion('outer_intersep')
+            v_outer_intersep = v.bout.from_region('outer_intersep')
 
             # Remove attributes that are expected to be different
             del v_outer_intersep.attrs['region']
@@ -364,7 +364,7 @@ class TestBoutDatasetMethods:
                                  v_outer_intersep.isel(
                                      theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                         theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
@@ -373,7 +373,7 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
                                  v_outer_intersep.isel(theta=slice(-myg, None)).values)
 
-            v_outer_sol = v.bout.fromRegion('outer_SOL')
+            v_outer_sol = v.bout.from_region('outer_SOL')
 
             # Remove attributes that are expected to be different
             del v_outer_sol.attrs['region']
@@ -381,7 +381,7 @@ class TestBoutDatasetMethods:
                     v.isel(x=slice(ixs2 - mxg, None), theta=slice(jys12 + 1, jys22 + 1)),
                     v_outer_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
                                         theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
@@ -390,7 +390,7 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
                                  v_outer_sol.isel(theta=slice(-myg, None)).values)
 
-            v_lower_outer_PFR = v.bout.fromRegion('lower_outer_PFR')
+            v_lower_outer_PFR = v.bout.from_region('lower_outer_PFR')
 
             # Remove attributes that are expected to be different
             del v_lower_outer_PFR.attrs['region']
@@ -398,13 +398,13 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys22 + 1, None)),
                                  v_lower_outer_PFR.isel(theta=slice(myg, None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
                                         theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
                                  v_lower_outer_PFR.isel(theta=slice(myg)).values)
 
-            v_lower_outer_intersep = v.bout.fromRegion('lower_outer_intersep')
+            v_lower_outer_intersep = v.bout.from_region('lower_outer_intersep')
 
             # Remove attributes that are expected to be different
             del v_lower_outer_intersep.attrs['region']
@@ -412,13 +412,13 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys22 + 1, None)),
                                  v_lower_outer_intersep.isel(theta=slice(myg, None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
                                         theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
                                  v_lower_outer_intersep.isel(theta=slice(myg)).values)
 
-            v_lower_outer_SOL = v.bout.fromRegion('lower_outer_SOL')
+            v_lower_outer_SOL = v.bout.from_region('lower_outer_SOL')
 
             # Remove attributes that are expected to be different
             del v_lower_outer_SOL.attrs['region']
@@ -426,7 +426,7 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys22 + 1, None)),
                                  v_lower_outer_SOL.isel(theta=slice(myg, None)))
             if myg > 0:
-                # check y-guards, which were 'communicated' by fromRegion
+                # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
                 npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
                                         theta=slice(jys22 + 1 - myg, jys22 + 1)).values,

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -102,8 +102,12 @@ class TestBoutDatasetMethods:
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
+    @pytest.mark.parametrize(
+        "vars_to_interpolate", [('n', 'T'), pytest.param(..., marks=pytest.mark.long)]
+    )
     def test_interpolate_parallel(self, tmpdir_factory, bout_xyt_example_files,
-                                  guards, keep_xboundaries, keep_yboundaries):
+                                  guards, keep_xboundaries, keep_yboundaries,
+                                  vars_to_interpolate):
         # This test checks that the regions created in the new high-resolution Dataset by
         # interpolate_parallel are correct.
         # This test does not test the accuracy of the parallel interpolation (there are
@@ -122,7 +126,7 @@ class TestBoutDatasetMethods:
                               keep_yboundaries=keep_yboundaries)
 
         # Get high parallel resolution version of ds, and check that
-        ds = ds.bout.interpolate_parallel(('n', 'T'))
+        ds = ds.bout.interpolate_parallel(vars_to_interpolate)
 
         mxg = guards['x']
         myg = guards['y']

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -432,6 +432,26 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
                                  v_lower_outer_SOL.isel(theta=slice(myg)).values)
 
+    def test_interpolate_parallel_all_variables_arg(self, tmpdir_factory,
+                                                    bout_xyt_example_files):
+        # Check that passing 'variables=...' to interpolate_parallel() does actually
+        # interpolate all the variables
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1,
+                                      nype=1, nt=1, grid='grid', topology='sol')
+
+        ds = open_boutdataset(datapath=path,
+                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
+                              geometry='toroidal')
+
+        # Get high parallel resolution version of ds, and check that
+        ds = ds.bout.interpolate_parallel(...)
+
+        interpolated_variables = [v for v in ds]
+
+        assert set(interpolated_variables) == set(('n', 'T', 'g11', 'g22', 'g33', 'g12',
+                'g13', 'g23', 'g_11', 'g_22', 'g_33', 'g_12', 'g_13', 'g_23', 'G1', 'G2',
+                'G3', 'J', 'Bxy', 'dx', 'dy'))
+
 
 class TestLoadInputFile:
     @pytest.mark.skip

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -525,16 +525,6 @@ class TestSave:
         # Load it again
         recovered = reload_boutdataset(savepath)
 
-        # Compare
-        for coord in original.coords.values():
-            # Get rid of the options if they exist, because options are not dealt with
-            # totally consistently: they exist if a coord was created from a variable
-            # loaded from the BOUT++ output, but not if the coord was calculated from
-            # some parameters or loaded from a grid file
-            try:
-                del coord.attrs["options"]
-            except KeyError:
-                pass
         xrt.assert_identical(original.load(), recovered.load())
 
     @pytest.mark.skip("saving and loading as float32 does not work")
@@ -607,15 +597,6 @@ class TestSave:
         recovered = reload_boutdataset(savepath, pre_squashed=True)
 
         # Compare
-        for coord in original.coords.values():
-            # Get rid of the options if they exist, because options are not dealt with
-            # totally consistently: they exist if a coord was created from a variable
-            # loaded from the BOUT++ output, but not if the coord was calculated from
-            # some parameters or loaded from a grid file
-            try:
-                del coord.attrs["options"]
-            except KeyError:
-                pass
         xrt.assert_identical(recovered, original)
 
 

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -452,9 +452,10 @@ class TestBoutDatasetMethods:
 
         interpolated_variables = [v for v in ds]
 
-        assert set(interpolated_variables) == set(('n', 'T', 'g11', 'g22', 'g33', 'g12',
-                'g13', 'g23', 'g_11', 'g_22', 'g_33', 'g_12', 'g_13', 'g_23', 'G1', 'G2',
-                'G3', 'J', 'Bxy', 'dx', 'dy'))
+        assert set(interpolated_variables) == set((
+            'n', 'T', 'g11', 'g22', 'g33', 'g12', 'g13', 'g23', 'g_11', 'g_22', 'g_33',
+            'g_12', 'g_13', 'g_23', 'G1', 'G2', 'G3', 'J', 'Bxy', 'dx', 'dy'
+        ))
 
 
 class TestLoadInputFile:

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -95,7 +95,7 @@ class TestBoutDatasetMethods:
         with pytest.raises(KeyError):
             ds['a'].metadata['fine_interpolation_factor']
 
-        ds.bout.set_parallel_interpolation_factor(42)
+        ds.bout.fine_interpolation_factor = 42
 
         assert ds.metadata['fine_interpolation_factor'] == 42
         assert ds['a'].metadata['fine_interpolation_factor'] == 42

--- a/xbout/tests/test_geometries.py
+++ b/xbout/tests/test_geometries.py
@@ -23,7 +23,7 @@ class TestGeometryRegistration:
         assert "Schwarzschild" in REGISTERED_GEOMETRIES.keys()
 
         original = Dataset()
-        original['dy'] = DataArray(np.ones((3,4)), dims=('x', 'y'))
+        original['dy'] = DataArray(np.ones((3, 4)), dims=('x', 'y'))
         original.attrs['metadata'] = {}
         updated = apply_geometry(ds=original, geometry_name="Schwarzschild")
         assert_equal(updated['event_horizon'], DataArray(4.0))

--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -60,6 +60,7 @@ class TestOpenGrid:
         @register_geometry(name="Schwarzschild")
         def add_schwarzschild_coords(ds, coordinates=None):
             ds['event_horizon'] = 4.0
+            ds['event_horizon'].attrs = ds.attrs.copy()
             return ds
 
         example_grid = create_example_grid_file

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -322,6 +322,7 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
     n = DataArray(data, dims=['t', 'x', 'y', 'z'])
     for v in [n, T]:
         v.attrs['direction_y'] = 'Standard'
+        v.attrs['cell_location'] = 'CELL_CENTRE'
     ds = Dataset({'n': n, 'T': T})
 
     # BOUT_VERSION needed so that we know that number of points in z is MZ, not MZ-1 (as

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -374,8 +374,7 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
         ds['ny_inner'] = ny//2
     elif topology == 'xpoint':
         if nype < 4:
-            raise ValueError('Not enough processors for xpoint topology: '
-                             + 'nype=' + str(nype))
+            raise ValueError(f'Not enough processors for xpoint topology: nype={nype}')
         ds['ixseps1'] = nx//2
         ds['ixseps2'] = nx//2
         ds['jyseps1_1'] = MYSUB - 1
@@ -386,8 +385,7 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
         ds['jyseps2_2'] = ny - MYSUB - 1
     elif topology == 'single-null':
         if nype < 3:
-            raise ValueError('Not enough processors for single-null topology: '
-                             + 'nype=' + str(nype))
+            raise ValueError(f'Not enough processors for xpoint topology: nype={nype}')
         ds['ixseps1'] = nx//2
         ds['ixseps2'] = nx
         ds['jyseps1_1'] = MYSUB - 1
@@ -398,7 +396,7 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
     elif topology == 'connected-double-null':
         if nype < 6:
             raise ValueError('Not enough processors for connected-double-null topology: '
-                             + 'nype=' + str(nype))
+                             f'nype={nype}')
         ds['ixseps1'] = nx//2
         ds['ixseps2'] = nx//2
         ds['jyseps1_1'] = MYSUB - 1
@@ -410,12 +408,12 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
     elif topology == 'disconnected-double-null':
         if nype < 6:
             raise ValueError('Not enough processors for disconnected-double-null '
-                             + 'topology: nype=' + str(nype))
+                             f'topology: nype={nype}')
         ds['ixseps1'] = nx//2
         ds['ixseps2'] = nx//2 + 4
         if ds['ixseps2'] >= nx:
             raise ValueError('Not enough points in the x-direction. ixseps2='
-                             + str(ds['ixseps2']) + ' > nx=' + str(nx))
+                             f'{ds["ixseps2"]} > nx={nx}')
         ds['jyseps1_1'] = MYSUB - 1
         ny_inner = 3*MYSUB
         ds['ny_inner'] = ny_inner
@@ -423,7 +421,7 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
         ds['jyseps1_2'] = ny_inner + MYSUB - 1
         ds['jyseps2_2'] = ny - MYSUB - 1
     else:
-        raise ValueError('Unrecognised topology=' + str(topology))
+        raise ValueError(f'Unrecognised topology={topology}')
 
     one = DataArray(np.ones((x_length, y_length)), dims=['x', 'y'])
     zero = DataArray(np.zeros((x_length, y_length)), dims=['x', 'y'])

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -9,14 +9,14 @@ from xbout.tests.test_load import bout_xyt_example_files
 from xbout import open_boutdataset
 
 
-class TestRegion:
+params_guards = "guards"
+params_guards_values = [{'x': 0, 'y': 0}, {'x': 2, 'y': 0}, {'x': 0, 'y': 2},
+                        {'x': 2, 'y': 2}]
+params_boundaries = "keep_xboundaries, keep_yboundaries"
+params_boundaries_values = [(False, False), (True, False), (False, True),
+                            (True, True)]
 
-    params_guards = "guards"
-    params_guards_values = [{'x': 0, 'y': 0}, {'x': 2, 'y': 0}, {'x': 0, 'y': 2},
-                            {'x': 2, 'y': 2}]
-    params_boundaries = "keep_xboundaries, keep_yboundaries"
-    params_boundaries_values = [(False, False), (True, False), (False, True),
-                                (True, True)]
+class TestRegion:
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
@@ -1283,3 +1283,5 @@ class TestRegion:
             npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
                                     theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
                              n_lower_outer_SOL.isel(theta=slice(yguards)).values)
+
+

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -1124,7 +1124,7 @@ class TestRegion:
                              n_upper_inner_PFR.isel(theta=slice(yguards)).values)
 
         n_upper_inner_intersep = n.bout.from_region('upper_inner_intersep',
-                                                   with_guards=with_guards)
+                                                    with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_upper_inner_intersep.attrs['region']
@@ -1170,7 +1170,7 @@ class TestRegion:
                              n_upper_outer_PFR.isel(theta=slice(-yguards, None)).values)
 
         n_upper_outer_intersep = n.bout.from_region('upper_outer_intersep',
-                                                   with_guards=with_guards)
+                                                    with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_upper_outer_intersep.attrs['region']
@@ -1273,7 +1273,7 @@ class TestRegion:
                              n_lower_outer_PFR.isel(theta=slice(yguards)).values)
 
         n_lower_outer_intersep = n.bout.from_region('lower_outer_intersep',
-                                                   with_guards=with_guards)
+                                                    with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_outer_intersep.attrs['region']

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -20,6 +20,7 @@ params_boundaries_values = [pytest.param(False, False, marks=pytest.mark.long),
                             pytest.param(False, True, marks=pytest.mark.long),
                             (True, True)]
 
+
 class TestRegion:
 
     @pytest.mark.long
@@ -1292,5 +1293,3 @@ class TestRegion:
             npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
                                     theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
                              n_lower_outer_SOL.isel(theta=slice(yguards)).values)
-
-

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -1006,7 +1006,8 @@ class TestRegion:
 
         n = ds['n']
 
-        n_lower_inner_PFR = n.bout.from_region('lower_inner_PFR', with_guards=with_guards)
+        n_lower_inner_PFR = n.bout.from_region('lower_inner_PFR',
+                                               with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_inner_PFR.attrs['region']
@@ -1021,7 +1022,7 @@ class TestRegion:
                              n_lower_inner_PFR.isel(theta=slice(-yguards, None)).values)
 
         n_lower_inner_intersep = n.bout.from_region('lower_inner_intersep',
-                                                   with_guards=with_guards)
+                                                    with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_inner_intersep.attrs['region']
@@ -1037,7 +1038,8 @@ class TestRegion:
                            theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
                     n_lower_inner_intersep.isel(theta=slice(-yguards, None)).values)
 
-        n_lower_inner_SOL = n.bout.from_region('lower_inner_SOL', with_guards=with_guards)
+        n_lower_inner_SOL = n.bout.from_region('lower_inner_SOL',
+                                               with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_inner_SOL.attrs['region']
@@ -1106,7 +1108,8 @@ class TestRegion:
                                     theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
                              n_inner_sol.isel(theta=slice(-yguards, None)).values)
 
-        n_upper_inner_PFR = n.bout.from_region('upper_inner_PFR', with_guards=with_guards)
+        n_upper_inner_PFR = n.bout.from_region('upper_inner_PFR',
+                                               with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_upper_inner_PFR.attrs['region']
@@ -1135,7 +1138,8 @@ class TestRegion:
                                     theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
                              n_upper_inner_intersep.isel(theta=slice(yguards)).values)
 
-        n_upper_inner_SOL = n.bout.from_region('upper_inner_SOL', with_guards=with_guards)
+        n_upper_inner_SOL = n.bout.from_region('upper_inner_SOL',
+                                               with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_upper_inner_SOL.attrs['region']
@@ -1149,7 +1153,8 @@ class TestRegion:
                                     theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
                              n_upper_inner_SOL.isel(theta=slice(yguards)).values)
 
-        n_upper_outer_PFR = n.bout.from_region('upper_outer_PFR', with_guards=with_guards)
+        n_upper_outer_PFR = n.bout.from_region('upper_outer_PFR',
+                                               with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_upper_outer_PFR.attrs['region']
@@ -1181,7 +1186,8 @@ class TestRegion:
                              n_upper_outer_intersep.isel(
                                  theta=slice(-yguards, None)).values)
 
-        n_upper_outer_SOL = n.bout.from_region('upper_outer_SOL', with_guards=with_guards)
+        n_upper_outer_SOL = n.bout.from_region('upper_outer_SOL',
+                                               with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_upper_outer_SOL.attrs['region']
@@ -1251,7 +1257,8 @@ class TestRegion:
                                     theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
                              n_outer_sol.isel(theta=slice(-yguards, None)).values)
 
-        n_lower_outer_PFR = n.bout.from_region('lower_outer_PFR', with_guards=with_guards)
+        n_lower_outer_PFR = n.bout.from_region('lower_outer_PFR',
+                                               with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_outer_PFR.attrs['region']
@@ -1280,7 +1287,8 @@ class TestRegion:
                                     theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
                              n_lower_outer_intersep.isel(theta=slice(yguards)).values)
 
-        n_lower_outer_SOL = n.bout.from_region('lower_outer_SOL', with_guards=with_guards)
+        n_lower_outer_SOL = n.bout.from_region('lower_outer_SOL',
+                                               with_guards=with_guards)
 
         # Remove attributes that are expected to be different
         del n_lower_outer_SOL.attrs['region']
@@ -1290,6 +1298,7 @@ class TestRegion:
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
-                             n_lower_outer_SOL.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n.isel(x=slice(ixs2 - xguards, None),
+                           theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
+                    n_lower_outer_SOL.isel(theta=slice(yguards)).values)

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -10,14 +10,19 @@ from xbout import open_boutdataset
 
 
 params_guards = "guards"
-params_guards_values = [{'x': 0, 'y': 0}, {'x': 2, 'y': 0}, {'x': 0, 'y': 2},
+params_guards_values = [pytest.param({'x': 0, 'y': 0}, marks=pytest.mark.long),
+                        pytest.param({'x': 2, 'y': 0}, marks=pytest.mark.long),
+                        pytest.param({'x': 0, 'y': 2}, marks=pytest.mark.long),
                         {'x': 2, 'y': 2}]
 params_boundaries = "keep_xboundaries, keep_yboundaries"
-params_boundaries_values = [(False, False), (True, False), (False, True),
+params_boundaries_values = [pytest.param(False, False, marks=pytest.mark.long),
+                            pytest.param(True, False, marks=pytest.mark.long),
+                            pytest.param(False, True, marks=pytest.mark.long),
                             (True, True)]
 
 class TestRegion:
 
+    @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
     def test_region_core(self, tmpdir_factory, bout_xyt_example_files, guards,
@@ -53,6 +58,7 @@ class TestRegion:
                 n.isel(theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
                 n_core.isel(theta=slice(ybndry, -ybndry if ybndry != 0 else None)))
 
+    @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
     def test_region_sol(self, tmpdir_factory, bout_xyt_example_files, guards,
@@ -133,6 +139,7 @@ class TestRegion:
                        theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
                 n_core.isel(theta=slice(ybndry, -ybndry if ybndry != 0 else None)))
 
+    @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
     def test_region_xpoint(self, tmpdir_factory, bout_xyt_example_files, guards,
@@ -282,6 +289,7 @@ class TestRegion:
                                     theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
                              n_lower_outer_SOL.isel(theta=slice(myg)).values)
 
+    @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
     def test_region_singlenull(self, tmpdir_factory, bout_xyt_example_files, guards,
@@ -403,6 +411,7 @@ class TestRegion:
                                     theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
                              n_outer_SOL.isel(theta=slice(myg)).values)
 
+    @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
     def test_region_connecteddoublenull(self, tmpdir_factory, bout_xyt_example_files,

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -43,6 +43,7 @@ def _separate_metadata(ds):
 
     return ds.drop(scalar_vars), metadata
 
+
 def _update_metadata_increased_resolution(da, n):
     """
     Update the metadata variables to account for a y-direction resolution increased by a

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -61,7 +61,9 @@ def _update_metadata_increased_resolution(da, n):
     da.attrs['metadata'] = deepcopy(da.metadata)
 
     def update_jyseps(name):
-        da.metadata[name] = n*(da.metadata[name] + 1) - 1
+        # If any jyseps<=0, need to leave as is
+        if da.metadata[name] > 0:
+            da.metadata[name] = n*(da.metadata[name] + 1) - 1
     update_jyseps('jyseps1_1')
     update_jyseps('jyseps2_1')
     update_jyseps('jyseps1_2')

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -87,4 +87,9 @@ def _update_metadata_increased_resolution(da, n):
     update_ny('ny_inner')
     update_ny('MYSUB')
 
+    # Update attrs of coordinates to be consistent with da
+    for coord in da.coords:
+        da[coord].attrs = {}
+        _add_attrs_to_var(da, coord)
+
     return da

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from itertools import chain
 
 import numpy as np
 
@@ -6,12 +7,23 @@ import numpy as np
 def _set_attrs_on_all_vars(ds, key, attr_data, copy=False):
     ds.attrs[key] = attr_data
     if copy:
-        for da in ds.values():
-            da.attrs[key] = deepcopy(attr_data)
+        for v in chain(ds.data_vars, ds.coords):
+            ds[v].attrs[key] = deepcopy(attr_data)
     else:
-        for da in ds.values():
-            da.attrs[key] = attr_data
+        for v in chain(ds.data_vars, ds.coords):
+            ds[v].attrs[key] = attr_data
     return ds
+
+
+def _add_attrs_to_var(ds, varname, copy=False):
+    if copy:
+        for attr in ["metadata", "options", "geometry", "regions"]:
+            if attr in ds.attrs and attr not in ds[varname].attrs:
+                ds[varname].attrs[attr] = deepcopy(ds.attrs[attr])
+    else:
+        for attr in ["metadata", "options", "geometry", "regions"]:
+            if attr in ds.attrs and attr not in ds[varname].attrs:
+                ds[varname].attrs[attr] = ds.attrs[attr]
 
 
 def _check_filetype(path):


### PR DESCRIPTION
Provides methods `BoutDataArray.getHighRes()` to get a version of a variable interpolated in the parallel direction to increase the poloidal resolution, or `BoutDataSet.getHighResVars(['var1', 'var2', ...)` to get a `Dataset` with high-resolution versions of a list of variables. An example from TORPEX simulations - before interpolation
![base](https://user-images.githubusercontent.com/3958036/77232893-9a3ccc00-6b9b-11ea-8512-21dd253b23dd.gif)
and after
![highres](https://user-images.githubusercontent.com/3958036/77232899-a032ad00-6b9b-11ea-98e2-59a9bd23693b.gif)

Also adds a feature to the tests - can use `@pytest.mark.long` to mark a test as long, in which case it is skipped by default. Long tests are run if `--long` argument is passed to pytest, and the Travis tests do run the long tests.

Includes #107, this PR will be only 1,384 additions and 363 deletions after that is merged.
