### PR TITLE
Use real instead of complex FFTs in zShift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0"
-  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.13.0 dask==1.0.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
+  - PIP_PACKAGES="setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.13.0 dask==1.0.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3.
 install:
   - pip install --upgrade ${PIP_PACKAGES}
   - pip install -r requirements.txt

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from pprint import pformat as prettyformat
 from functools import partial
 
+import dask.array
 import numpy as np
 
 import xarray as xr
@@ -67,6 +68,12 @@ class BoutDataArrayAccessor:
         # implement inverse Fourier transforms (although there is an open PR
         # https://github.com/xgcm/xrft/pull/81 to add this).
 
+        # Use dask.array.fft if self.data.data is a dask array
+        if isinstance(self.data.data, dask.array.Array):
+            fft = dask.array.fft
+        else:
+            fft = np.fft
+
         nz = self.data.metadata['nz']
         zlength = nz*self.data.metadata['dz']
         nmodes = nz // 2 + 1
@@ -79,7 +86,7 @@ class BoutDataArrayAccessor:
         fft_dims[axis] = 'kz'
 
         # Fourier transform to get the DataArray in k-space
-        data_fft = np.fft.rfft(self.data.values, axis=axis)
+        data_fft = fft.rfft(self.data.data, axis=axis)
 
         # Complex phase for rotation by angle zShift
         kz = 2.*np.pi*xr.DataArray(np.arange(0, nmodes), dims='kz')/zlength
@@ -92,9 +99,9 @@ class BoutDataArrayAccessor:
         phase = phase.expand_dims(extra_dims)
         phase = phase.transpose(*fft_dims)
 
-        data_shifted_fft = data_fft * np.exp(phase.values)
+        data_shifted_fft = data_fft * np.exp(phase.data)
 
-        data_shifted = np.fft.irfft(data_shifted_fft, n=nz)
+        data_shifted = fft.irfft(data_shifted_fft, n=nz)
 
         # Return a DataArray with the same attributes as self, but values from
         # data_shifted

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -68,6 +68,7 @@ class BoutDataArrayAccessor:
         # https://github.com/xgcm/xrft/pull/81 to add this).
 
         nz = self.data.metadata['nz']
+        zlength = nz*self.data.metadata['dz']
 
         # Get axis position of dimension to transform
         axis = self.data.dims.index(self.data.metadata['bout_zdim'])
@@ -80,7 +81,7 @@ class BoutDataArrayAccessor:
         data_fft = np.fft.fft(self.data.values, axis=axis)
 
         # Complex phase for rotation by angle zShift
-        zperiod = 1./(self.data.metadata['ZMAX'] - self.data.metadata['ZMIN'])
+        zperiod = int(round(2.*np.pi / zlength))
         kz = xr.DataArray(np.arange(0, nz*zperiod, zperiod), dims='kz')
         phases = 1.j * zShift * kz
 

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -174,9 +174,9 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
         phi0 = 2*np.pi*ds.metadata['ZMIN']
         phi1 = phi0 + nz*ds.metadata['dz']
         if not np.isclose(phi1, 2.*np.pi*ds.metadata['ZMAX'], rtol=1.e-15, atol=0.):
-            warn('Size of toroidal domain as calculated from nz*dz (' + str(phi1 - phi0)
-                 + ' is not the same as 2pi*(ZMAX - ZMIN) ('
-                 + str(2.*np.pi*ds.metadata['ZMAX'] - phi0) + '): using value from dz')
+            warn(f"Size of toroidal domain as calculated from nz*dz ({phi1 - phi0}) is "
+                 f"not the same as 2pi*(ZMAX - ZMIN) "
+                 f"({2.*np.pi*ds.metadata['ZMAX'] - phi0}): using value from dz")
         phi = xr.DataArray(np.linspace(start=phi0, stop=phi1, num=nz, endpoint=False),
                            dims=coordinates['z'])
         ds = ds.assign_coords(**{coordinates['z']: phi})

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -171,7 +171,7 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     if 'z' in ds.dims:
         ds = ds.rename(z=coordinates['z'])
         nz = ds.dims[coordinates['z']]
-        phi = xr.DataArray(np.linspace(start=ds.metadata['ZMIN'],
+        phi = xr.DataArray(np.linspace(start=2 * np.pi * ds.metadata['ZMIN'],
                                        stop=2 * np.pi * ds.metadata['ZMAX'], num=nz),
                            dims=coordinates['z'])
         ds = ds.assign_coords(**{coordinates['z']: phi})

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -171,8 +171,13 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     if 'z' in ds.dims:
         ds = ds.rename(z=coordinates['z'])
         nz = ds.dims[coordinates['z']]
-        phi = xr.DataArray(np.linspace(start=2 * np.pi * ds.metadata['ZMIN'],
-                                       stop=2 * np.pi * ds.metadata['ZMAX'], num=nz),
+        phi0 = 2*np.pi*ds.metadata['ZMIN']
+        phi1 = phi0 + nz*ds.metadata['dz']
+        if not np.isclose(phi1, 2.*np.pi*ds.metadata['ZMAX'], rtol=1.e-15, atol=0.):
+            warn('Size of toroidal domain as calculated from nz*dz (' + str(phi1 - phi0)
+                 + ' is not the same as 2pi*(ZMAX - ZMIN) ('
+                 + str(2.*np.pi*ds.metadata['ZMAX'] - phi0) + '): using value from dz')
+        phi = xr.DataArray(np.linspace(start=phi0, stop=phi1, num=nz, endpoint=False),
                            dims=coordinates['z'])
         ds = ds.assign_coords(**{coordinates['z']: phi})
 

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -1,3 +1,5 @@
+import pytest
+
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -20,8 +22,10 @@ class TestBoutDataArrayMethods:
         assert dict_equiv(ds.attrs, new_ds.attrs)
         assert dict_equiv(ds.metadata, new_ds.metadata)
 
-    def test_toFieldAligned(self, tmpdir_factory, bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, nxpe=1, nype=1, nt=1)
+    @pytest.mark.parametrize('nz', [6, 7, 8, 9])
+    def test_toFieldAligned(self, tmpdir_factory, bout_xyt_example_files, nz):
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1,
+                                      nype=1, nt=1)
         ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
 
         ds['psixy'] = ds['x']
@@ -37,78 +41,40 @@ class TestBoutDataArrayMethods:
             for x in range(ds.sizes['x']):
                 for y in range(ds.sizes['theta']):
                     zShift[x, y] = (x*ds.sizes['theta'] + y) * 2.*np.pi/ds.sizes['zeta']
-                    for z in range(ds.sizes['zeta']):
+                    for z in range(nz):
                         n[t, x, y, z] = 1000.*t + 100.*x + 10.*y + z
 
         n.attrs['direction_y'] = 'Standard'
         n_al = n.bout.toFieldAligned()
         for t in range(ds.sizes['t']):
-            assert_allclose(n_al[t, 0, 0, 0].values, 1000.*t + 0., rtol=1.e-15, atol=5.e-16)                # noqa: E501
-            assert_allclose(n_al[t, 0, 0, 1].values, 1000.*t + 1., rtol=1.e-15, atol=0.)                    # noqa: E501
-            assert_allclose(n_al[t, 0, 0, 2].values, 1000.*t + 2., rtol=1.e-15, atol=0.)                    # noqa: E501
-            assert_allclose(n_al[t, 0, 0, 3].values, 1000.*t + 3., rtol=1.e-15, atol=0.)                    # noqa: E501
-            assert_allclose(n_al[t, 0, 0, 4].values, 1000.*t + 4., rtol=1.e-15, atol=0.)                    # noqa: E501
-            assert_allclose(n_al[t, 0, 0, 5].values, 1000.*t + 5., rtol=1.e-15, atol=0.)                    # noqa: E501
-            assert_allclose(n_al[t, 0, 0, 6].values, 1000.*t + 6., rtol=1.e-15, atol=0.)                    # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_al[t, 0, 0, z].values, 1000.*t + z%nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501
 
-            assert_allclose(n_al[t, 0, 1, 0].values, 1000.*t + 10.*1. + 1., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 1, 1].values, 1000.*t + 10.*1. + 2., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 1, 2].values, 1000.*t + 10.*1. + 3., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 1, 3].values, 1000.*t + 10.*1. + 4., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 1, 4].values, 1000.*t + 10.*1. + 5., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 1, 5].values, 1000.*t + 10.*1. + 6., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 1, 6].values, 1000.*t + 10.*1. + 0., rtol=1.e-15, atol=0.)           # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_al[t, 0, 1, z].values, 1000.*t + 10.*1. + (z + 1)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
-            assert_allclose(n_al[t, 0, 2, 0].values, 1000.*t + 10.*2. + 2., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 2, 1].values, 1000.*t + 10.*2. + 3., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 2, 2].values, 1000.*t + 10.*2. + 4., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 2, 3].values, 1000.*t + 10.*2. + 5., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 2, 4].values, 1000.*t + 10.*2. + 6., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 2, 5].values, 1000.*t + 10.*2. + 0., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 2, 6].values, 1000.*t + 10.*2. + 1., rtol=1.e-15, atol=0.)           # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_al[t, 0, 2, z].values, 1000.*t + 10.*2. + (z + 2)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
-            assert_allclose(n_al[t, 0, 3, 0].values, 1000.*t + 10.*3. + 3., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 3, 1].values, 1000.*t + 10.*3. + 4., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 3, 2].values, 1000.*t + 10.*3. + 5., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 3, 3].values, 1000.*t + 10.*3. + 6., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 3, 4].values, 1000.*t + 10.*3. + 0., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 3, 5].values, 1000.*t + 10.*3. + 1., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_al[t, 0, 3, 6].values, 1000.*t + 10.*3. + 2., rtol=1.e-15, atol=0.)           # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_al[t, 0, 3, z].values, 1000.*t + 10.*3. + (z + 3)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
-            assert_allclose(n_al[t, 1, 0, 0].values, 1000.*t + 100.*1 + 10.*0. + 4., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 0, 1].values, 1000.*t + 100.*1 + 10.*0. + 5., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 0, 2].values, 1000.*t + 100.*1 + 10.*0. + 6., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 0, 3].values, 1000.*t + 100.*1 + 10.*0. + 0., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 0, 4].values, 1000.*t + 100.*1 + 10.*0. + 1., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 0, 5].values, 1000.*t + 100.*1 + 10.*0. + 2., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 0, 6].values, 1000.*t + 100.*1 + 10.*0. + 3., rtol=1.e-15, atol=0.)  # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_al[t, 1, 0, z].values, 1000.*t + 100.*1 + 10.*0. + (z + 4)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
-            assert_allclose(n_al[t, 1, 1, 0].values, 1000.*t + 100.*1 + 10.*1. + 5., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 1, 1].values, 1000.*t + 100.*1 + 10.*1. + 6., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 1, 2].values, 1000.*t + 100.*1 + 10.*1. + 0., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 1, 3].values, 1000.*t + 100.*1 + 10.*1. + 1., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 1, 4].values, 1000.*t + 100.*1 + 10.*1. + 2., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 1, 5].values, 1000.*t + 100.*1 + 10.*1. + 3., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 1, 6].values, 1000.*t + 100.*1 + 10.*1. + 4., rtol=1.e-15, atol=0.)  # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_al[t, 1, 1, z].values, 1000.*t + 100.*1 + 10.*1. + (z + 5)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
-            assert_allclose(n_al[t, 1, 2, 0].values, 1000.*t + 100.*1 + 10.*2. + 6., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 2, 1].values, 1000.*t + 100.*1 + 10.*2. + 0., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 2, 2].values, 1000.*t + 100.*1 + 10.*2. + 1., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 2, 3].values, 1000.*t + 100.*1 + 10.*2. + 2., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 2, 4].values, 1000.*t + 100.*1 + 10.*2. + 3., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 2, 5].values, 1000.*t + 100.*1 + 10.*2. + 4., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 2, 6].values, 1000.*t + 100.*1 + 10.*2. + 5., rtol=1.e-15, atol=0.)  # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_al[t, 1, 2, z].values, 1000.*t + 100.*1 + 10.*2. + (z + 6)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
-            assert_allclose(n_al[t, 1, 3, 0].values, 1000.*t + 100.*1 + 10.*3. + 0., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 3, 1].values, 1000.*t + 100.*1 + 10.*3. + 1., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 3, 2].values, 1000.*t + 100.*1 + 10.*3. + 2., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 3, 3].values, 1000.*t + 100.*1 + 10.*3. + 3., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 3, 4].values, 1000.*t + 100.*1 + 10.*3. + 4., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 3, 5].values, 1000.*t + 100.*1 + 10.*3. + 5., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_al[t, 1, 3, 6].values, 1000.*t + 100.*1 + 10.*3. + 6., rtol=1.e-15, atol=0.)  # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_al[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z + 7)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
-    def test_fromFieldAligned(self, tmpdir_factory, bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, nxpe=1, nype=1, nt=1)
+    @pytest.mark.parametrize('nz', [6, 7, 8, 9])
+    def test_fromFieldAligned(self, tmpdir_factory, bout_xyt_example_files, nz):
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1,
+                                      nype=1, nt=1)
         ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
 
         ds['psixy'] = ds['x']
@@ -130,66 +96,26 @@ class TestBoutDataArrayMethods:
         n.attrs['direction_y'] = 'Aligned'
         n_nal = n.bout.fromFieldAligned()
         for t in range(ds.sizes['t']):
-            assert_allclose(n_nal[t, 0, 0, 0].values, 1000.*t + 0., rtol=1.e-15, atol=5.e-16)                # noqa: E501
-            assert_allclose(n_nal[t, 0, 0, 1].values, 1000.*t + 1., rtol=1.e-15, atol=0.)                    # noqa: E501
-            assert_allclose(n_nal[t, 0, 0, 2].values, 1000.*t + 2., rtol=1.e-15, atol=0.)                    # noqa: E501
-            assert_allclose(n_nal[t, 0, 0, 3].values, 1000.*t + 3., rtol=1.e-15, atol=0.)                    # noqa: E501
-            assert_allclose(n_nal[t, 0, 0, 4].values, 1000.*t + 4., rtol=1.e-15, atol=0.)                    # noqa: E501
-            assert_allclose(n_nal[t, 0, 0, 5].values, 1000.*t + 5., rtol=1.e-15, atol=0.)                    # noqa: E501
-            assert_allclose(n_nal[t, 0, 0, 6].values, 1000.*t + 6., rtol=1.e-15, atol=0.)                    # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_nal[t, 0, 0, z].values, 1000.*t + z%nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501
 
-            assert_allclose(n_nal[t, 0, 1, 0].values, 1000.*t + 10.*1. + 6., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 1, 1].values, 1000.*t + 10.*1. + 0., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 1, 2].values, 1000.*t + 10.*1. + 1., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 1, 3].values, 1000.*t + 10.*1. + 2., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 1, 4].values, 1000.*t + 10.*1. + 3., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 1, 5].values, 1000.*t + 10.*1. + 4., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 1, 6].values, 1000.*t + 10.*1. + 5., rtol=1.e-15, atol=0.)           # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_nal[t, 0, 1, z].values, 1000.*t + 10.*1. + (z - 1)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
-            assert_allclose(n_nal[t, 0, 2, 0].values, 1000.*t + 10.*2. + 5., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 2, 1].values, 1000.*t + 10.*2. + 6., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 2, 2].values, 1000.*t + 10.*2. + 0., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 2, 3].values, 1000.*t + 10.*2. + 1., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 2, 4].values, 1000.*t + 10.*2. + 2., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 2, 5].values, 1000.*t + 10.*2. + 3., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 2, 6].values, 1000.*t + 10.*2. + 4., rtol=1.e-15, atol=0.)           # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_nal[t, 0, 2, z].values, 1000.*t + 10.*2. + (z - 2)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
-            assert_allclose(n_nal[t, 0, 3, 0].values, 1000.*t + 10.*3. + 4., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 3, 1].values, 1000.*t + 10.*3. + 5., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 3, 2].values, 1000.*t + 10.*3. + 6., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 3, 3].values, 1000.*t + 10.*3. + 0., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 3, 4].values, 1000.*t + 10.*3. + 1., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 3, 5].values, 1000.*t + 10.*3. + 2., rtol=1.e-15, atol=0.)           # noqa: E501
-            assert_allclose(n_nal[t, 0, 3, 6].values, 1000.*t + 10.*3. + 3., rtol=1.e-15, atol=0.)           # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_nal[t, 0, 3, z].values, 1000.*t + 10.*3. + (z - 3)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
-            assert_allclose(n_nal[t, 1, 0, 0].values, 1000.*t + 100.*1 + 10.*0. + 3., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 0, 1].values, 1000.*t + 100.*1 + 10.*0. + 4., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 0, 2].values, 1000.*t + 100.*1 + 10.*0. + 5., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 0, 3].values, 1000.*t + 100.*1 + 10.*0. + 6., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 0, 4].values, 1000.*t + 100.*1 + 10.*0. + 0., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 0, 5].values, 1000.*t + 100.*1 + 10.*0. + 1., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 0, 6].values, 1000.*t + 100.*1 + 10.*0. + 2., rtol=1.e-15, atol=0.)  # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_nal[t, 1, 0, z].values, 1000.*t + 100.*1 + 10.*0. + (z - 4)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
-            assert_allclose(n_nal[t, 1, 1, 0].values, 1000.*t + 100.*1 + 10.*1. + 2., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 1, 1].values, 1000.*t + 100.*1 + 10.*1. + 3., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 1, 2].values, 1000.*t + 100.*1 + 10.*1. + 4., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 1, 3].values, 1000.*t + 100.*1 + 10.*1. + 5., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 1, 4].values, 1000.*t + 100.*1 + 10.*1. + 6., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 1, 5].values, 1000.*t + 100.*1 + 10.*1. + 0., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 1, 6].values, 1000.*t + 100.*1 + 10.*1. + 1., rtol=1.e-15, atol=0.)  # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_nal[t, 1, 1, z].values, 1000.*t + 100.*1 + 10.*1. + (z - 5)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
-            assert_allclose(n_nal[t, 1, 2, 0].values, 1000.*t + 100.*1 + 10.*2. + 1., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 2, 1].values, 1000.*t + 100.*1 + 10.*2. + 2., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 2, 2].values, 1000.*t + 100.*1 + 10.*2. + 3., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 2, 3].values, 1000.*t + 100.*1 + 10.*2. + 4., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 2, 4].values, 1000.*t + 100.*1 + 10.*2. + 5., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 2, 5].values, 1000.*t + 100.*1 + 10.*2. + 6., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 2, 6].values, 1000.*t + 100.*1 + 10.*2. + 0., rtol=1.e-15, atol=0.)  # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_nal[t, 1, 2, z].values, 1000.*t + 100.*1 + 10.*2. + (z - 6)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
-            assert_allclose(n_nal[t, 1, 3, 0].values, 1000.*t + 100.*1 + 10.*3. + 0., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 3, 1].values, 1000.*t + 100.*1 + 10.*3. + 1., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 3, 2].values, 1000.*t + 100.*1 + 10.*3. + 2., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 3, 3].values, 1000.*t + 100.*1 + 10.*3. + 3., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 3, 4].values, 1000.*t + 100.*1 + 10.*3. + 4., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 3, 5].values, 1000.*t + 100.*1 + 10.*3. + 5., rtol=1.e-15, atol=0.)  # noqa: E501
-            assert_allclose(n_nal[t, 1, 3, 6].values, 1000.*t + 100.*1 + 10.*3. + 6., rtol=1.e-15, atol=0.)  # noqa: E501
+            for z in range(nz):
+                assert_allclose(n_nal[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z - 7)%nz, rtol=1.e-15, atol=0.)  # noqa: E501

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -48,28 +48,28 @@ class TestBoutDataArrayMethods:
         n_al = n.bout.toFieldAligned()
         for t in range(ds.sizes['t']):
             for z in range(nz):
-                assert_allclose(n_al[t, 0, 0, z].values, 1000.*t + z%nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501
+                assert_allclose(n_al[t, 0, 0, z].values, 1000.*t + z % nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 0, 1, z].values, 1000.*t + 10.*1. + (z + 1)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
+                assert_allclose(n_al[t, 0, 1, z].values, 1000.*t + 10.*1. + (z + 1) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 0, 2, z].values, 1000.*t + 10.*2. + (z + 2)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
+                assert_allclose(n_al[t, 0, 2, z].values, 1000.*t + 10.*2. + (z + 2) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 0, 3, z].values, 1000.*t + 10.*3. + (z + 3)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
+                assert_allclose(n_al[t, 0, 3, z].values, 1000.*t + 10.*3. + (z + 3) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 1, 0, z].values, 1000.*t + 100.*1 + 10.*0. + (z + 4)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                assert_allclose(n_al[t, 1, 0, z].values, 1000.*t + 100.*1 + 10.*0. + (z + 4) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 1, 1, z].values, 1000.*t + 100.*1 + 10.*1. + (z + 5)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                assert_allclose(n_al[t, 1, 1, z].values, 1000.*t + 100.*1 + 10.*1. + (z + 5) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 1, 2, z].values, 1000.*t + 100.*1 + 10.*2. + (z + 6)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                assert_allclose(n_al[t, 1, 2, z].values, 1000.*t + 100.*1 + 10.*2. + (z + 6) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_al[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z + 7)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                assert_allclose(n_al[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z + 7) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
     @pytest.mark.parametrize('nz', [6, 7, 8, 9])
     def test_fromFieldAligned(self, tmpdir_factory, bout_xyt_example_files, nz):
@@ -97,25 +97,25 @@ class TestBoutDataArrayMethods:
         n_nal = n.bout.fromFieldAligned()
         for t in range(ds.sizes['t']):
             for z in range(nz):
-                assert_allclose(n_nal[t, 0, 0, z].values, 1000.*t + z%nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501
+                assert_allclose(n_nal[t, 0, 0, z].values, 1000.*t + z % nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_nal[t, 0, 1, z].values, 1000.*t + 10.*1. + (z - 1)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
+                assert_allclose(n_nal[t, 0, 1, z].values, 1000.*t + 10.*1. + (z - 1) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_nal[t, 0, 2, z].values, 1000.*t + 10.*2. + (z - 2)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
+                assert_allclose(n_nal[t, 0, 2, z].values, 1000.*t + 10.*2. + (z - 2) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_nal[t, 0, 3, z].values, 1000.*t + 10.*3. + (z - 3)%nz, rtol=1.e-15, atol=0.)           # noqa: E501
+                assert_allclose(n_nal[t, 0, 3, z].values, 1000.*t + 10.*3. + (z - 3) % nz, rtol=1.e-15, atol=0.)           # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_nal[t, 1, 0, z].values, 1000.*t + 100.*1 + 10.*0. + (z - 4)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                assert_allclose(n_nal[t, 1, 0, z].values, 1000.*t + 100.*1 + 10.*0. + (z - 4) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_nal[t, 1, 1, z].values, 1000.*t + 100.*1 + 10.*1. + (z - 5)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                assert_allclose(n_nal[t, 1, 1, z].values, 1000.*t + 100.*1 + 10.*1. + (z - 5) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_nal[t, 1, 2, z].values, 1000.*t + 100.*1 + 10.*2. + (z - 6)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                assert_allclose(n_nal[t, 1, 2, z].values, 1000.*t + 100.*1 + 10.*2. + (z - 6) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
             for z in range(nz):
-                assert_allclose(n_nal[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z - 7)%nz, rtol=1.e-15, atol=0.)  # noqa: E501
+                assert_allclose(n_nal[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z - 7) % nz, rtol=1.e-15, atol=0.)  # noqa: E501

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -376,7 +376,7 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
 
     ds['dx'] = 0.5*one
     ds['dy'] = 2.*one
-    ds['dz'] = 0.7
+    ds['dz'] = 2.*np.pi/nz
 
     ds['iteration'] = t_length
     ds['t_array'] = DataArray(np.arange(t_length, dtype=float)*10., dims='t')


### PR DESCRIPTION
Since we know the input and output are real, using `np.fft.rfft` and `np.fft.irfft` instead of `np.fft.fft` and `np.fft.ifft` should be slightly more efficient, and also requires less special handling of even vs. odd `nz`.

Also includes a change to get the toroidal domain size as `nz*dz` rather than `2.*pi*(ZMAX - ZMIN)` since `dz` is the variable actually used by BOUT++, so it should be more certain to be correct.