### PR TITLE
Add missing dependency on boutdata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'Pillow>=6.1.0'
     ],
     extras_require=extras_require,
-    tests_require=['pytest >= 3.3.0'],
+    tests_require=['pytest >= 3.3.0', 'boutdata'],
     long_description=long_description,
     long_description_content_type="text/markdown",
     classifiers=[


### PR DESCRIPTION
The tests fail as they require `boutdata`

Full output:
```
reading manifest file 'xBOUT.egg-info/SOURCES.txt'
writing manifest file 'xBOUT.egg-info/SOURCES.txt'
running build_ext
Traceback (most recent call last):
  File "setup.py", line 67, in <module>
    'source_dir': ('setup.py', 'docs'),
  File "/usr/lib/python3.7/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib64/python3.7/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib64/python3.7/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.7/site-packages/setuptools/command/test.py", line 237, in run
    self.run_tests()
  File "/usr/lib/python3.7/site-packages/setuptools/command/test.py", line 259, in run_tests
    exit=False,
  File "/usr/lib64/python3.7/unittest/main.py", line 100, in __init__
    self.parseArgs(argv)
  File "/usr/lib64/python3.7/unittest/main.py", line 124, in parseArgs
    self._do_discovery(argv[2:])
  File "/usr/lib64/python3.7/unittest/main.py", line 244, in _do_discovery
    self.createTests(from_discovery=True, Loader=Loader)
  File "/usr/lib64/python3.7/unittest/main.py", line 154, in createTests
    self.test = loader.discover(self.start, self.pattern, self.top)
  File "/usr/lib64/python3.7/unittest/loader.py", line 349, in discover
    tests = list(self._find_tests(start_dir, pattern))
  File "/usr/lib64/python3.7/unittest/loader.py", line 406, in _find_tests
    full_path, pattern, namespace)
  File "/usr/lib64/python3.7/unittest/loader.py", line 483, in _find_test_path
    tests = self.loadTestsFromModule(package, pattern=pattern)
  File "/usr/lib/python3.7/site-packages/setuptools/command/test.py", line 55, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/usr/lib64/python3.7/unittest/loader.py", line 191, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "/usr/lib/python3.7/site-packages/setuptools/command/test.py", line 55, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/usr/lib64/python3.7/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/xBOUT-master/xbout/tests/test_against_collect.py", line 8, in <module>
    boutdata = pytest.importorskip("boutdata", reason="boutdata is not available")
  File "/xBOUT-master/.eggs/pytest-5.4.1-py3.7.egg/_pytest/outcomes.py", line 214, in importorskip
    raise Skipped(reason, allow_module_level=True) from None
Skipped: boutdata is not available
```