### PR TITLE
Change name from xBOUT to xbout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version_dict = {}
 with open("xbout/_version.py") as f:
     exec(f.read(), version_dict)
 
-name = 'xBOUT'
+name = 'xbout'
 version = version_dict['__version__']
 release = version
 


### PR DESCRIPTION
as xbout is provided, the name should probably be xbout not xBOUT.
I am not sure this is sufficient to make sure the pypi name is xbout rather then xBOUT.