### PR TITLE
save and reload

### DIFF
--- a/xbout/__init__.py
+++ b/xbout/__init__.py
@@ -1,4 +1,4 @@
-from .load import open_boutdataset, collect
+from .load import open_boutdataset, reload_boutdataset, collect
 
 from . import geometries
 from .geometries import register_geometry, REGISTERED_GEOMETRIES

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -119,7 +119,11 @@ class BoutDatasetAccessor:
             raise ValueError('Must provide a path to which to save the data.')
 
         if save_dtype is not None:
-            to_save = to_save.astype(save_dtype)
+            # Workaround to keep attributes while calling astype. See
+            # https://github.com/pydata/xarray/issues/2049
+            # https://github.com/pydata/xarray/pull/2070
+            for da in chain(to_save.values(), to_save.coords.values()):
+                da.data = da.data.astype(save_dtype)
 
         # make shallow copy of Dataset, so we do not modify the attributes of the data
         # when we change things to save

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -121,6 +121,10 @@ class BoutDatasetAccessor:
         if save_dtype is not None:
             to_save = to_save.astype(save_dtype)
 
+        # make shallow copy of Dataset, so we do not modify the attributes of the data
+        # when we change things to save
+        to_save = to_save.copy()
+
         options = to_save.attrs.pop('options')
         if options:
             # TODO Convert Ben's options class to a (flattened) nested

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -143,14 +143,14 @@ class BoutDatasetAccessor:
 
         # Store the metadata as individual attributes instead because
         # netCDF can't handle storing arbitrary objects in attrs
-        def dict_to_attrs(obj, key):
-            for key, value in obj.attrs.pop(key).items():
-                obj.attrs[key] = value
+        def dict_to_attrs(obj, section):
+            for key, value in obj.attrs.pop(section).items():
+                obj.attrs[section + ":" + key] = value
         dict_to_attrs(to_save, 'metadata')
         # Must do this for all variables and coordinates in dataset too
         for varname, da in chain(to_save.data_vars.items(), to_save.coords.items()):
             try:
-                dict_to_attrs(da, key='metadata')
+                dict_to_attrs(da, 'metadata')
             except KeyError:
                 pass
 

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -125,15 +125,17 @@ class BoutDatasetAccessor:
         if options:
             # TODO Convert Ben's options class to a (flattened) nested
             # dictionary then store it in ds.attrs?
-            raise NotImplementedError("Haven't decided how to write options "
-                                      "file back out yet")
-        else:
-            # Delete placeholders for options on each variable and coordinate
-            for var in chain(to_save.data_vars, to_save.coords):
-                try:
-                    del to_save[var].attrs['options']
-                except KeyError:
-                    pass
+            warnings.warn(
+                "Haven't decided how to write options file back out yet - deleting "
+                "options for now. To re-load this Dataset, pass the same inputfilepath "
+                "to open_boutdataset when re-loading."
+            )
+        # Delete placeholders for options on each variable and coordinate
+        for var in chain(to_save.data_vars, to_save.coords):
+            try:
+                del to_save[var].attrs['options']
+            except KeyError:
+                pass
 
         # Store the metadata as individual attributes instead because
         # netCDF can't handle storing arbitrary objects in attrs

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -133,7 +133,7 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
             if grid is None:
                 raise ValueError("Grid file is required to provide %s. Pass the grid "
                                  "file name as the 'gridfilepath' argument to "
-                                 "open_boutdataset().")
+                                 "open_boutdataset().", v)
             ds[v] = grid[v]
 
     # Rename 't' if user requested it

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -131,9 +131,10 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     for v in needed_variables:
         if v not in ds:
             if grid is None:
-                raise ValueError("Grid file is required to provide %s. Pass the grid "
-                                 "file name as the 'gridfilepath' argument to "
-                                 "open_boutdataset().", v)
+                raise ValueError(
+                    f"Grid file is required to provide {v}. Pass the grid file name as "
+                    f"the 'gridfilepath' argument to open_boutdataset()."
+                )
             ds[v] = grid[v]
 
     # Rename 't' if user requested it

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -2,6 +2,7 @@ from copy import copy
 from warnings import warn
 from pathlib import Path
 from functools import partial
+from itertools import chain
 import configparser
 
 import xarray as xr
@@ -87,7 +88,7 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
         Name to give to the whole dataset, e.g. 'JET_ELM_high_resolution'.
         Useful if you are going to open multiple simulations and compare the
         results.
-    info : bool, optional
+    info : bool or "terse", optional
     pre_squashed :  bool, optional
         Set true when loading from data which was saved as separate variables
         using ds.bout.save().
@@ -132,15 +133,7 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
                     latest_top_left['t'] = -1
                 ds[var] = ds[var].isel(latest_top_left).squeeze(drop=True)
 
-    if inputfilepath:
-        # Use Ben's options class to store all input file options
-        with open(inputfilepath, 'r') as f:
-            config_string = "[dummysection]\n" + f.read()
-        options = configparser.ConfigParser()
-        options.read_string(config_string)
-    else:
-        options = None
-    ds = _set_attrs_on_all_vars(ds, 'options', options)
+    ds = _add_options(ds, inputfilepath)
 
     if geometry is None:
         if geometry in ds.attrs:
@@ -173,6 +166,86 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
     elif info:
         print("Read in:\n{}".format(ds.bout))
 
+    return ds
+
+
+def reload_boutdataset(
+    datapath, inputfilepath=None, chunks={}, info=True, pre_squashed=False, **kwargs
+):
+    """
+    Reload a BoutDataset saved by bout.save(), restoring it to the state the original
+    Dataset was in when bout.save() was called
+
+    Parameters
+    ----------
+    datapath : str
+        Path to netCDF file where the Dataset to be re-loaded was saved
+    inputfilepath : str, optional
+        'options' are not saved. 'inputfilepath' must be provided if 'options' should
+        be recreated for the reloaded Dataset
+    chunks : dict, optional
+        Passed to `xarray.open_mfdataset` or `xarray.open_dataset`
+    info : bool or "terse", optional
+    pre_squashed :  bool, optional
+        Set true when loading from data which was saved as separate variables
+        using ds.bout.save().
+    kwargs : optional
+        Keyword arguments are passed down to `xarray.open_mfdataset` or
+        `xarray.open_dataset`
+    """
+    if pre_squashed:
+        ds = xr.open_mfdataset(datapath, chunks=chunks, combine='nested',
+                               concat_dim=None, **kwargs)
+    else:
+        ds = xr.open_dataset(datapath, chunks=chunks, **kwargs)
+
+    def attrs_to_dict(obj, section):
+        result = {}
+        section = section + ":"
+        sectionlength = len(section)
+        for key in list(obj.attrs):
+            if key[:sectionlength] == section:
+                result[key[sectionlength:]] = obj.attrs.pop(key)
+        return result
+
+    def attrs_remove_section(obj, section):
+        section = section + ":"
+        sectionlength = len(section)
+        has_metadata = False
+        for key in list(obj.attrs):
+            if key[:sectionlength] == section:
+                has_metadata = True
+                del obj.attrs[key]
+        return has_metadata
+
+    # Restore metadata from attrs
+    metadata = attrs_to_dict(ds, "metadata")
+    ds.attrs["metadata"] = metadata
+    # Must do this for all variables and coordinates in dataset too
+    for da in chain(ds.data_vars.values(), ds.coords.values()):
+        if attrs_remove_section(da, "metadata"):
+            da.attrs["metadata"] = metadata
+
+    ds = _add_options(ds, inputfilepath)
+
+    if info == 'terse':
+        print("Read in dataset from {}".format(str(Path(datapath))))
+    elif info:
+        print("Read in:\n{}".format(ds.bout))
+
+    return ds
+
+
+def _add_options(ds, inputfilepath):
+    if inputfilepath:
+        # Use Ben's options class to store all input file options
+        with open(inputfilepath, 'r') as f:
+            config_string = "[dummysection]\n" + f.read()
+        options = configparser.ConfigParser()
+        options.read_string(config_string)
+    else:
+        options = None
+    ds = _set_attrs_on_all_vars(ds, 'options', options)
     return ds
 
 

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -170,7 +170,7 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
 
 
 def reload_boutdataset(
-    datapath, inputfilepath=None, chunks={}, info=True, pre_squashed=False, **kwargs
+    datapath, inputfilepath=None, chunks=None, info=True, pre_squashed=False, **kwargs
 ):
     """
     Reload a BoutDataset saved by bout.save(), restoring it to the state the original

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -42,7 +42,7 @@ except ValueError:
 
 
 def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
-                     geometry=None, gridfilepath=None, chunks={},
+                     geometry=None, gridfilepath=None, chunks=None,
                      keep_xboundaries=True, keep_yboundaries=False,
                      run_name=None, info=True, pre_squashed=False, **kwargs):
     """
@@ -100,6 +100,9 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
     -------
     ds : xarray.Dataset
     """
+
+    if chunks is None:
+        chunks = {}
 
     if pre_squashed:
         ds = xr.open_mfdataset(datapath, chunks=chunks, combine='nested',
@@ -363,9 +366,12 @@ def _is_dump_files(datapath):
         return True
 
 
-def _auto_open_mfboutdataset(datapath, chunks={}, info=True,
+def _auto_open_mfboutdataset(datapath, chunks=None, info=True,
                              keep_xboundaries=False, keep_yboundaries=False,
                              **kwargs):
+    if chunks is None:
+        chunks = {}
+
     filepaths, filetype = _expand_filepaths(datapath)
 
     # Open just one file to read processor splitting

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -105,17 +105,13 @@ class TestLoadInputFile:
 class TestLoadLogFile:
     pass
 
-@pytest.mark.skip(reason="Need to sort out issue with saving metadata")
 class TestSave:
-    @pytest.mark.parametrize("options", [False, True])
-    def test_save_all(self, tmpdir_factory, bout_xyt_example_files, options):
+    def test_save_all(self, tmpdir_factory, bout_xyt_example_files):
         # Create data
         path = bout_xyt_example_files(tmpdir_factory, nxpe=4, nype=5, nt=1)
 
         # Load it as a boutdataset
         original = open_boutdataset(datapath=path, inputfilepath=None)
-        if not options:
-            original.attrs['options'] = {}
 
         # Save it to a netCDF file
         savepath = str(Path(path).parent) + 'temp_boutdata.nc'
@@ -127,6 +123,7 @@ class TestSave:
         # Compare
         xrt.assert_equal(original, recovered)
 
+    @pytest.mark.skip("saving and loading as float32 does not work")
     @pytest.mark.parametrize("save_dtype", [np.float64, np.float32])
     def test_save_dtype(self, tmpdir_factory, bout_xyt_example_files, save_dtype):
 


### PR DESCRIPTION
Changes to allow a BoutDataset to be saved to a file and re-loaded, replicating the state of the original BoutDataset.

Activates previously-skipped tests of `save()` as well as adding tests using `reload_boutdataset()`.

Needs to deal with `options`. Previously it was an error to save a `BoutDataset` that had non-empty `options`. Now just warn instead - temporary workaround (until #94, #97 are resolved) as now the `BoutDataset` can be saved, but the input file must be given again when re-loading the `BoutDataset`.