### PR TITLE
Check that splittings aren't negative values

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -439,21 +439,26 @@ def _read_splitting(filepath, info=True):
     ds = xr.open_dataset(str(filepath))
 
     # Account for case of no parallelisation, when nxpe etc won't be in dataset
-    def get_scalar(ds, key, default=1, info=True):
+    def get_scalar(ds, key, default=1, only_positive=False, info=True):
         if key in ds:
-            return ds[key].values
+            val = ds[key].values
+            if only_positive and (val < 0):
+                raise ValueError(f"{key} read from dump files is {val}, but negative" 
+                                 f" values are not valid")
+            else:
+               return val
         else:
             if info is True:
                 print("{key} not found, setting to {default}"
                       .format(key=key, default=default))
             return default
 
-    nxpe = get_scalar(ds, 'NXPE', default=1)
-    nype = get_scalar(ds, 'NYPE', default=1)
-    mxg = get_scalar(ds, 'MXG', default=2)
-    myg = get_scalar(ds, 'MYG', default=0)
-    mxsub = get_scalar(ds, 'MXSUB', default=ds.dims['x'] - 2 * mxg)
-    mysub = get_scalar(ds, 'MYSUB', default=ds.dims['y'] - 2 * myg)
+    nxpe = get_scalar(ds, 'NXPE', default=1, only_positive=True)
+    nype = get_scalar(ds, 'NYPE', default=1, only_positive=True)
+    mxg = get_scalar(ds, 'MXG', default=2, only_positive=True)
+    myg = get_scalar(ds, 'MYG', default=0, only_positive=True)
+    mxsub = get_scalar(ds, 'MXSUB', default=ds.dims['x'] - 2 * mxg, only_positive=True)
+    mysub = get_scalar(ds, 'MYSUB', default=ds.dims['y'] - 2 * myg, only_positive=True)
 
     # Check whether this is a single file squashed from the multiple output files of a
     # parallel run (i.e. NXPE*NYPE > 1 even though there is only a single file to read).

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -464,12 +464,12 @@ def _read_splitting(filepath, info=True):
                 )
             return default
 
-    nxpe = get_nonnegative_scalar(ds, 'NXPE', default=1)
-    nype = get_nonnegative_scalar(ds, 'NYPE', default=1)
-    mxg = get_nonnegative_scalar(ds, 'MXG', default=2)
-    myg = get_nonnegative_scalar(ds, 'MYG', default=0)
-    mxsub = get_nonnegative_scalar(ds, 'MXSUB', default=ds.dims['x'] - 2 * mxg)
-    mysub = get_nonnegative_scalar(ds, 'MYSUB', default=ds.dims['y'] - 2 * myg)
+    nxpe = get_nonnegative_scalar(ds, 'NXPE', default=1, info)
+    nype = get_nonnegative_scalar(ds, 'NYPE', default=1, info)
+    mxg = get_nonnegative_scalar(ds, 'MXG', default=2, info)
+    myg = get_nonnegative_scalar(ds, 'MYG', default=0, info)
+    mxsub = get_nonnegative_scalar(ds, 'MXSUB', default=ds.dims['x'] - 2 * mxg, info)
+    mysub = get_nonnegative_scalar(ds, 'MYSUB', default=ds.dims['y'] - 2 * myg, info)
 
     # Check whether this is a single file squashed from the multiple output files of a
     # parallel run (i.e. NXPE*NYPE > 1 even though there is only a single file to read).

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -443,10 +443,10 @@ def _read_splitting(filepath, info=True):
         if key in ds:
             val = ds[key].values
             if only_positive and (val < 0):
-                raise ValueError(f"{key} read from dump files is {val}, but negative" 
+                raise ValueError(f"{key} read from dump files is {val}, but negative"
                                  f" values are not valid")
             else:
-               return val
+                return val
         else:
             if info is True:
                 print("{key} not found, setting to {default}"

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -457,8 +457,11 @@ def _read_splitting(filepath, info=True):
                 return val
         else:
             if info is True:
-                print("{key} not found, setting to {default}"
-                      .format(key=key, default=default))
+                print(f"{key} not found, setting to {default}")
+            if default < 0:
+                raise ValueError(
+                    f"Default for {key} is {val}, but negative values are not valid"
+                )
             return default
 
     nxpe = get_nonnegative_scalar(ds, 'NXPE', default=1)

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -464,12 +464,16 @@ def _read_splitting(filepath, info=True):
                 )
             return default
 
-    nxpe = get_nonnegative_scalar(ds, 'NXPE', default=1, info)
-    nype = get_nonnegative_scalar(ds, 'NYPE', default=1, info)
-    mxg = get_nonnegative_scalar(ds, 'MXG', default=2, info)
-    myg = get_nonnegative_scalar(ds, 'MYG', default=0, info)
-    mxsub = get_nonnegative_scalar(ds, 'MXSUB', default=ds.dims['x'] - 2 * mxg, info)
-    mysub = get_nonnegative_scalar(ds, 'MYSUB', default=ds.dims['y'] - 2 * myg, info)
+    nxpe = get_nonnegative_scalar(ds, 'NXPE', default=1, info=info)
+    nype = get_nonnegative_scalar(ds, 'NYPE', default=1, info=info)
+    mxg = get_nonnegative_scalar(ds, 'MXG', default=2, info=info)
+    myg = get_nonnegative_scalar(ds, 'MYG', default=0, info=info)
+    mxsub = get_nonnegative_scalar(
+        ds, 'MXSUB', default=ds.dims['x'] - 2 * mxg, info=info
+    )
+    mysub = get_nonnegative_scalar(
+        ds, 'MYSUB', default=ds.dims['y'] - 2 * myg, info=info
+    )
 
     # Check whether this is a single file squashed from the multiple output files of a
     # parallel run (i.e. NXPE*NYPE > 1 even though there is only a single file to read).

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -447,10 +447,10 @@ def _read_splitting(filepath, info=True):
     ds = xr.open_dataset(str(filepath))
 
     # Account for case of no parallelisation, when nxpe etc won't be in dataset
-    def get_scalar(ds, key, default=1, only_positive=False, info=True):
+    def get_nonnegative_scalar(ds, key, default=1, info=True):
         if key in ds:
             val = ds[key].values
-            if only_positive and (val < 0):
+            if val < 0:
                 raise ValueError(f"{key} read from dump files is {val}, but negative"
                                  f" values are not valid")
             else:
@@ -461,12 +461,12 @@ def _read_splitting(filepath, info=True):
                       .format(key=key, default=default))
             return default
 
-    nxpe = get_scalar(ds, 'NXPE', default=1, only_positive=True)
-    nype = get_scalar(ds, 'NYPE', default=1, only_positive=True)
-    mxg = get_scalar(ds, 'MXG', default=2, only_positive=True)
-    myg = get_scalar(ds, 'MYG', default=0, only_positive=True)
-    mxsub = get_scalar(ds, 'MXSUB', default=ds.dims['x'] - 2 * mxg, only_positive=True)
-    mysub = get_scalar(ds, 'MYSUB', default=ds.dims['y'] - 2 * myg, only_positive=True)
+    nxpe = get_nonnegative_scalar(ds, 'NXPE', default=1)
+    nype = get_nonnegative_scalar(ds, 'NYPE', default=1)
+    mxg = get_nonnegative_scalar(ds, 'MXG', default=2)
+    myg = get_nonnegative_scalar(ds, 'MYG', default=0)
+    mxsub = get_nonnegative_scalar(ds, 'MXSUB', default=ds.dims['x'] - 2 * mxg)
+    mysub = get_nonnegative_scalar(ds, 'MYSUB', default=ds.dims['y'] - 2 * myg)
 
     # Check whether this is a single file squashed from the multiple output files of a
     # parallel run (i.e. NXPE*NYPE > 1 even though there is only a single file to read).


### PR DESCRIPTION
A simple error check, which turns this unhelpful error
```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-1-9ab194b06ef4> in <module>
----> 1 ds = open_boutdataset('./BOUT.dmp.*.nc')

/marconi_work/FUA33_SOLBOUT3/tnichola/pycode/xBOUT/xbout/load.py in open_boutdataset(datapath, inputfilepath, geometry, gridfilepath, chunks, keep_xboundaries, keep_yboundaries, run_name, info, pre_squashed, **kwargs)
    115                                           keep_xboundaries=keep_xboundaries,
    116                                           keep_yboundaries=keep_yboundaries,
--> 117                                           **kwargs)
    118         else:
    119             # Its a grid file

/marconi_work/FUA33_SOLBOUT3/tnichola/pycode/xBOUT/xbout/load.py in _auto_open_mfboutdataset(datapath, chunks, info, keep_xboundaries, keep_yboundaries, **kwargs)
    392                            data_vars=_BOUT_TIME_DEPENDENT_META_VARS,
    393                            preprocess=_preprocess, engine=filetype,
--> 394                            chunks=chunks, **kwargs)
    395 
    396     # Remove any duplicate time values from concatenation

/marconi_work/FUA33_SOLBOUT3/tnichola/pycode/xarray/xarray/backends/api.py in open_mfdataset(paths, chunks, concat_dim, compat, preprocess, engine, lock, data_vars, coords, combine, autoclose, parallel, join, attrs_file, **kwargs)
    993         combined.attrs = datasets[paths.index(attrs_file)].attrs
    994     else:
--> 995         combined.attrs = datasets[0].attrs
    996 
    997     return combined

IndexError: list index out of range
```
into one that actual tells you what the problem is (that your files are messed up in some way that means NXPE or similar is negative).