### PR TITLE
Fixes for transforming to/from field-aligned

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -123,18 +123,22 @@ class BoutDataArrayAccessor:
         Transform DataArray to field-aligned coordinates, which are shifted with respect
         to the base coordinates by an angle zShift
         """
+        if (self.data.cell_location == 'CELL_CENTRE'
+                or self.data.cell_location == 'CELL_ZLOW'):
+            zShift_coord = 'zShift'
+        else:
+            zShift_coord = 'zShift_' + self.data.cell_location
+
         if self.data.direction_y != "Standard":
             raise ValueError(f"Cannot shift a {self.data.direction_y} type field to "
                              "field-aligned coordinates")
-        if hasattr(self.data, "cell_location") and not (
-            self.data.cell_location == "CELL_CENTRE"
-            or self.data.cell_location == "CELL_ZLOW"
-        ):
-            raise ValueError(
-                f"to_field_aligned does not support staggered grids yet, but "
-                f"location is {self.data.cell_location}."
-            )
-        result = self._shift_z(self.data['zShift'])
+
+        if zShift_coord not in self.data.coords:
+            raise ValueError(f"{zShift_coord} missing, cannot shift "
+                             f"{self.data.cell_location} field {self.data.name} to "
+                             f"field-aligned coordinates")
+
+        result = self._shift_z(self.data[zShift_coord])
         result.attrs["direction_y"] = "Aligned"
         return result
 
@@ -143,18 +147,22 @@ class BoutDataArrayAccessor:
         Transform DataArray from field-aligned coordinates, which are shifted with
         respect to the base coordinates by an angle zShift
         """
+        if (self.data.cell_location == 'CELL_CENTRE'
+                or self.data.cell_location == 'CELL_ZLOW'):
+            zShift_coord = 'zShift'
+        else:
+            zShift_coord = 'zShift_' + self.data.cell_location
+
         if self.data.direction_y != "Aligned":
             raise ValueError(f"Cannot shift a {self.data.direction_y} type field from "
                              "field-aligned coordinates")
-        if hasattr(self.data, "cell_location") and not (
-            self.data.cell_location == "CELL_CENTRE"
-            or self.data.cell_location == "CELL_ZLOW"
-        ):
-            raise ValueError(
-                f"from_field_aligned does not support staggered grids yet, but "
-                f"location is {self.data.cell_location}."
-            )
-        result = self._shift_z(-self.data['zShift'])
+
+        if zShift_coord not in self.data.coords:
+            raise ValueError(f"{zShift_coord} missing, cannot shift "
+                             f"{self.data.cell_location} field {self.data.name} from "
+                             f"field-aligned coordinates")
+
+        result = self._shift_z(-self.data[zShift_coord])
         result.attrs["direction_y"] = "Standard"
         return result
 

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -124,8 +124,8 @@ class BoutDataArrayAccessor:
         to the base coordinates by an angle zShift
         """
         if self.data.direction_y != "Standard":
-            raise ValueError("Cannot shift a " + self.direction_y + " type field to "
-                             + "field-aligned coordinates")
+            raise ValueError(f"Cannot shift a {self.data.direction_y} type field to "
+                             "field-aligned coordinates")
         if hasattr(self.data, "cell_location") and not (
             self.data.cell_location == "CELL_CENTRE"
             or self.data.cell_location == "CELL_ZLOW"
@@ -144,8 +144,8 @@ class BoutDataArrayAccessor:
         respect to the base coordinates by an angle zShift
         """
         if self.data.direction_y != "Aligned":
-            raise ValueError("Cannot shift a " + self.direction_y + " type field to "
-                             + "field-aligned coordinates")
+            raise ValueError(f"Cannot shift a {self.data.direction_y} type field from "
+                             "field-aligned coordinates")
         if hasattr(self.data, "cell_location") and not (
             self.data.cell_location == "CELL_CENTRE"
             or self.data.cell_location == "CELL_ZLOW"

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -66,7 +66,7 @@ class BoutDataArrayAccessor:
 
         return ds
 
-    def _shiftZ(self, zShift):
+    def _shift_z(self, zShift):
         """
         Shift a DataArray in the periodic, toroidal direction using FFTs.
 
@@ -118,7 +118,7 @@ class BoutDataArrayAccessor:
         # data_shifted
         return self.data.copy(data=data_shifted)
 
-    def toFieldAligned(self):
+    def to_field_aligned(self):
         """
         Transform DataArray to field-aligned coordinates, which are shifted with respect
         to the base coordinates by an angle zShift
@@ -131,14 +131,14 @@ class BoutDataArrayAccessor:
             or self.data.cell_location == "CELL_ZLOW"
         ):
             raise ValueError(
-                f"toFieldAligned does not support staggered grids yet, but "
+                f"to_field_aligned does not support staggered grids yet, but "
                 f"location is {self.data.cell_location}."
             )
-        result = self._shiftZ(self.data['zShift'])
+        result = self._shift_z(self.data['zShift'])
         result.attrs["direction_y"] = "Aligned"
         return result
 
-    def fromFieldAligned(self):
+    def from_field_aligned(self):
         """
         Transform DataArray from field-aligned coordinates, which are shifted with
         respect to the base coordinates by an angle zShift
@@ -151,10 +151,10 @@ class BoutDataArrayAccessor:
             or self.data.cell_location == "CELL_ZLOW"
         ):
             raise ValueError(
-                f"fromFieldAligned does not support staggered grids yet, but "
+                f"from_field_aligned does not support staggered grids yet, but "
                 f"location is {self.data.cell_location}."
             )
-        result = self._shiftZ(-self.data['zShift'])
+        result = self._shift_z(-self.data['zShift'])
         result.attrs["direction_y"] = "Standard"
         return result
 
@@ -301,7 +301,7 @@ class BoutDataArrayAccessor:
 
         if zcoord in da.dims and da.direction_y != 'Aligned':
             aligned_input = False
-            da = da.bout.toFieldAligned()
+            da = da.bout.to_field_aligned()
         else:
             aligned_input = True
 
@@ -362,7 +362,7 @@ class BoutDataArrayAccessor:
 
         if not aligned_input:
             # Want output in non-aligned coordinates
-            da = da.bout.fromFieldAligned()
+            da = da.bout.from_field_aligned()
 
         if toroidal_points is not None and zcoord in da.sizes:
             if isinstance(toroidal_points, int):

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -135,7 +135,7 @@ class BoutDataArrayAccessor:
                 f"location is {self.data.cell_location}."
             )
         result = self._shiftZ(self.data['zShift'])
-        result["direction_y"] = "Aligned"
+        result.attrs["direction_y"] = "Aligned"
         return result
 
     def fromFieldAligned(self):
@@ -155,7 +155,7 @@ class BoutDataArrayAccessor:
                 f"location is {self.data.cell_location}."
             )
         result = self._shiftZ(-self.data['zShift'])
-        result["direction_y"] = "Standard"
+        result.attrs["direction_y"] = "Standard"
         return result
 
     @property

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -55,7 +55,7 @@ class BoutDatasetAccessor:
     #    return 'boutdata.BoutDataset(', {}, ',', {}, ')'.format(self.datapath,
     #  self.prefix)
 
-    def getFieldAligned(self, name, caching=True):
+    def get_field_aligned(self, name, caching=True):
         """
         Get a field-aligned version of a variable, calculating (and caching in the
         Dataset) if necessary
@@ -76,7 +76,7 @@ class BoutDatasetAccessor:
             return result
         except KeyError:
             if caching:
-                self.data[aligned_name] = self.data[name].bout.toFieldAligned()
+                self.data[aligned_name] = self.data[name].bout.to_field_aligned()
             return self.data[aligned_name]
 
     @property

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -30,7 +30,7 @@ class TestBoutDataArrayMethods:
                                     7,
                                     pytest.param(8, marks=pytest.mark.long),
                                     pytest.param(9, marks=pytest.mark.long)])
-    def test_toFieldAligned(self, tmpdir_factory, bout_xyt_example_files, nz):
+    def test_to_field_aligned(self, tmpdir_factory, bout_xyt_example_files, nz):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1,
                                       nype=1, nt=1)
         ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
@@ -52,7 +52,7 @@ class TestBoutDataArrayMethods:
                         n[t, x, y, z] = 1000.*t + 100.*x + 10.*y + z
 
         n.attrs['direction_y'] = 'Standard'
-        n_al = n.bout.toFieldAligned()
+        n_al = n.bout.to_field_aligned()
         for t in range(ds.sizes['t']):
             for z in range(nz):
                 npt.assert_allclose(n_al[t, 0, 0, z].values, 1000.*t + z % nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501
@@ -78,7 +78,7 @@ class TestBoutDataArrayMethods:
             for z in range(nz):
                 npt.assert_allclose(n_al[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z + 7) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
-    def test_toFieldAligned_dask(self, tmpdir_factory, bout_xyt_example_files):
+    def test_to_field_aligned_dask(self, tmpdir_factory, bout_xyt_example_files):
 
         nz = 6
 
@@ -108,7 +108,7 @@ class TestBoutDataArrayMethods:
         assert isinstance(n.data, dask.array.Array)
 
         n.attrs['direction_y'] = 'Standard'
-        n_al = n.bout.toFieldAligned()
+        n_al = n.bout.to_field_aligned()
         for t in range(ds.sizes['t']):
             for z in range(nz):
                 npt.assert_allclose(n_al[t, 0, 0, z].values, 1000.*t + z % nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501
@@ -138,7 +138,7 @@ class TestBoutDataArrayMethods:
                                     7,
                                     pytest.param(8, marks=pytest.mark.long),
                                     pytest.param(9, marks=pytest.mark.long)])
-    def test_fromFieldAligned(self, tmpdir_factory, bout_xyt_example_files, nz):
+    def test_from_field_aligned(self, tmpdir_factory, bout_xyt_example_files, nz):
         path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1,
                                       nype=1, nt=1)
         ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
@@ -160,7 +160,7 @@ class TestBoutDataArrayMethods:
                         n[t, x, y, z] = 1000.*t + 100.*x + 10.*y + z
 
         n.attrs['direction_y'] = 'Aligned'
-        n_nal = n.bout.fromFieldAligned()
+        n_nal = n.bout.from_field_aligned()
         for t in range(ds.sizes['t']):
             for z in range(nz):
                 npt.assert_allclose(n_nal[t, 0, 0, z].values, 1000.*t + z % nz, rtol=1.e-15, atol=5.e-16)                      # noqa: E501

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -60,7 +60,7 @@ class TestBoutDatasetMethods:
 
         print(ds.bout.extra_data)
 
-    def test_getFieldAligned(self, tmpdir_factory, bout_xyt_example_files):
+    def test_get_field_aligned(self, tmpdir_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(tmpdir_factory, nxpe=3, nype=4, nt=1)
         ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
 
@@ -72,19 +72,19 @@ class TestBoutDatasetMethods:
 
         n = ds['n']
         n.attrs['direction_y'] = 'Standard'
-        n_aligned_from_array = n.bout.toFieldAligned()
+        n_aligned_from_array = n.bout.to_field_aligned()
 
         # check n_aligned does not exist yet
         assert 'n_aligned' not in ds
 
-        n_aligned_from_ds = ds.bout.getFieldAligned('n')
+        n_aligned_from_ds = ds.bout.get_field_aligned('n')
         xrt.assert_allclose(n_aligned_from_ds, n_aligned_from_array)
         xrt.assert_allclose(ds['n_aligned'], n_aligned_from_array)
 
         # check getting the cached version
         ds['n_aligned'] = ds['T']
         ds['n_aligned'].attrs['direction_y'] = 'Aligned'
-        xrt.assert_allclose(ds.bout.getFieldAligned('n'), ds['T'])
+        xrt.assert_allclose(ds.bout.get_field_aligned('n'), ds['T'])
 
     def test_set_parallel_interpolation_factor(self):
         ds = Dataset()

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -83,6 +83,7 @@ class TestBoutDatasetMethods:
 
         # check getting the cached version
         ds['n_aligned'] = ds['T']
+        ds['n_aligned'].attrs['direction_y'] = 'Aligned'
         xrt.assert_allclose(ds.bout.getFieldAligned('n'), ds['T'])
 
     def test_set_parallel_interpolation_factor(self):


### PR DESCRIPTION
Renames methods to `to_field_aligned` and `from_field_aligned` to follow PEP8 naming convention.

Add support for shifting staggered fields if staggered `zShift` coordinates are present.