### PR TITLE
Better handling of single-region variables; method to drop y-boundary cells

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -403,7 +403,10 @@ class BoutDataArrayAccessor:
 
         myg = self.data.metadata['MYG']
 
-        if self.metadata['keep_yboundaries'] == 0 or myg == 0:
+        if (
+            (self.metadata['keep_yboundaries'] == 0 or myg == 0)
+            and not remove_extra_upper
+        ):
             # Ensure we do not modify any other references to metadata
             self.data.attrs['metadata'] = deepcopy(self.data.metadata)
             self.data.metadata['keep_yboundaries'] = 0
@@ -412,6 +415,8 @@ class BoutDataArrayAccessor:
                 return self.to_dataset()
             else:
                 return self.data
+        if self.metadata['keep_yboundaries'] == 0:
+            myg = 0
 
         ycoord = self.data.metadata['bout_ydim']
         parts = []

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -444,10 +444,15 @@ class BoutDataArrayAccessor:
         if remove_extra_upper:
             # modify jyseps*, ny_inner, ny so that sliced variable gets consistent
             # regions
-            result.metadata['ny_inner'] -= 1
-            result.metadata['jyseps1_2'] -= 1
-            result.metadata['jyseps2_2'] -= 1
-            result.metadata['ny'] -= 2
+            if result.metadata['jyseps1_2'] == result.metadata['jyseps2_1']:
+                # single-null
+                result.metadata['ny'] -= 1
+            else:
+                # double-null
+                result.metadata['ny_inner'] -= 1
+                result.metadata['jyseps1_2'] -= 1
+                result.metadata['jyseps2_2'] -= 1
+                result.metadata['ny'] -= 2
 
         if return_dataset:
             return result

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -423,6 +423,7 @@ class BoutDataArrayAccessor:
             if part_region.connection_upper_y is None:
                 part = part.isel({ycoord: slice(
                     -myg if not remove_extra_upper else -myg-1)})
+            del part.attrs["regions"]
             parts.append(part.bout.to_dataset())
 
         result = xr.combine_by_coords(parts)
@@ -442,10 +443,6 @@ class BoutDataArrayAccessor:
             result.metadata['jyseps1_2'] -= 1
             result.metadata['jyseps2_2'] -= 1
             result.metadata['ny'] -= 2
-
-        # regions are not correct now that number of y-points has changed
-        del result.attrs['regions']
-        del result[self.data.name].attrs['regions']
 
         if return_dataset:
             return result

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -382,7 +382,7 @@ class BoutDataArrayAccessor:
 
         return da
 
-    def remove_yboundaries(self, return_dataset=False):
+    def remove_yboundaries(self, return_dataset=False, remove_extra_upper=False):
         """
         Remove y-boundary points, if present, from the DataArray
 
@@ -411,7 +411,8 @@ class BoutDataArrayAccessor:
             if part.region.connection_lower_y is None:
                 part = part.isel({ycoord: slice(myg, None)})
             if part.region.connection_upper_y is None:
-                part = part.isel({ycoord: slice(-myg)})
+                part = part.isel({ycoord: slice(
+                    -myg if not remove_extra_upper else -myg-1)})
             parts.append(part.bout.to_dataset())
 
         result = xr.combine_by_coords(parts)
@@ -423,6 +424,14 @@ class BoutDataArrayAccessor:
         # result is as if we had not kept y-boundaries when loading
         result.metadata['keep_yboundaries'] = 0
         result[self.data.name].metadata['keep_yboundaries'] = 0
+
+        if remove_extra_upper:
+            # modify jyseps*, ny_inner, ny so that sliced variable gets consistent
+            # regions
+            result.metadata['ny_inner'] -= 1
+            result.metadata['jyseps1_2'] -= 1
+            result.metadata['jyseps2_2'] -= 1
+            result.metadata['ny'] -= 2
 
         del result.attrs['region']
         del result[self.data.name].attrs['region']

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -400,7 +400,7 @@ class BoutDataArrayAccessor:
             self.data.metadata['keep_yboundaries'] = 0
             # no y-boundary points to remove
             if return_dataset:
-                return self.data.to_dataset()
+                return self.to_dataset()
             else:
                 return self.data
 

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -225,11 +225,12 @@ class BoutDatasetAccessor:
         ycoord = self.data.metadata['bout_ydim']
         for v in self.data:
             if xcoord in self.data[v].dims and ycoord in self.data[v].dims:
-                variables.append(self.data[v].bout.remove_yboundaries(return_dataset=True,
-                                                                      **kwargs))
+                variables.append(
+                    self.data[v].bout.remove_yboundaries(return_dataset=True, **kwargs)
+                )
             elif ycoord in self.data[v].dims:
                 raise ValueError(f'{v} only has a {ycoord}-dimension so cannot split '
-                                  'into regions.')
+                                 f'into regions.')
             else:
                 variable = self.data[v]
                 if 'keep_yboundaries' in variable.metadata:

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -215,7 +215,7 @@ class BoutDatasetAccessor:
 
         return ds
 
-    def remove_yboundaries(self):
+    def remove_yboundaries(self, **kwargs):
         """
         Remove y-boundary points, if present, from the Dataset
         """
@@ -225,7 +225,8 @@ class BoutDatasetAccessor:
         ycoord = self.data.metadata['bout_ydim']
         for v in self.data:
             if xcoord in self.data[v].dims and ycoord in self.data[v].dims:
-                variables.append(self.data[v].bout.remove_yboundaries(return_dataset=True))
+                variables.append(self.data[v].bout.remove_yboundaries(return_dataset=True,
+                                                                      **kwargs))
             elif ycoord in self.data[v].dims:
                 raise ValueError(f'{v} only has a {ycoord}-dimension so cannot split '
                                   'into regions.')
@@ -238,6 +239,8 @@ class BoutDatasetAccessor:
 
         result = xr.merge(variables)
         result.attrs = variables[0].attrs
+        # Copy metadata to get possibly modified jyseps*, ny_inner, ny
+        result.attrs['metadata'] = variables[0].metadata
 
         # call to re-create regions
         result = apply_geometry(result, self.data.geometry)

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -162,15 +162,15 @@ def register_geometry(name):
     return wrapper
 
 
-def _set_default_toroidal_coordinates(coordinates):
+def _set_default_toroidal_coordinates(coordinates, ds):
     if coordinates is None:
         coordinates = {}
 
     # Replace any values that have not been passed in with defaults
-    coordinates['t'] = coordinates.get('t', 't')
-    coordinates['x'] = coordinates.get('x', 'psi_poloidal')
-    coordinates['y'] = coordinates.get('y', 'theta')
-    coordinates['z'] = coordinates.get('z', 'zeta')
+    coordinates['t'] = coordinates.get('t', ds.metadata.get('bout_tdim', 't'))
+    coordinates['x'] = coordinates.get('x', ds.metadata.get('bout_xdim', 'psi_poloidal'))
+    coordinates['y'] = coordinates.get('y', ds.metadata.get('bout_ydim', 'theta'))
+    coordinates['z'] = coordinates.get('z', ds.metadata.get('bout_zdim', 'zeta'))
 
     return coordinates
 
@@ -178,7 +178,7 @@ def _set_default_toroidal_coordinates(coordinates):
 @register_geometry('toroidal')
 def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
 
-    coordinates = _set_default_toroidal_coordinates(coordinates)
+    coordinates = _set_default_toroidal_coordinates(coordinates, ds)
 
     if set(coordinates.values()).issubset(set(ds.coords).union(ds.dims)):
         # Loading a Dataset which already had the coordinates created for it
@@ -261,7 +261,7 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
 @register_geometry('s-alpha')
 def add_s_alpha_geometry_coords(ds, *, coordinates=None, grid=None):
 
-    coordinates = _set_default_toroidal_coordinates(coordinates)
+    coordinates = _set_default_toroidal_coordinates(coordinates, ds)
 
     if set(coordinates.values()).issubset(set(ds.coords).union(ds.dims)):
         # Loading a Dataset which already had the coordinates created for it

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -87,8 +87,8 @@ def plot_separatrices(da, ax, *, x='R', y='Z'):
     ycoord = da0.metadata['bout_ydim']
 
     for da_region in da_regions.values():
-        inner = da_region.region.connection_inner_x
-        if inner is not None:
+        inner = list(da_region.regions.values())[0].connection_inner_x
+        if inner in da_regions:
             da_inner = da_regions[inner]
             x_sep = 0.5*(da_inner[x].isel(**{xcoord: -1})
                          + da_region[x].isel(**{xcoord: 0}))
@@ -116,14 +116,14 @@ def plot_targets(da, ax, *, x='R', y='Z', hatching=True):
         y_boundary_guards = 0
 
     for da_region in da_regions.values():
-        if da_region.region.connection_lower_y is None:
+        if list(da_region.regions.values())[0].connection_lower_y is None:
             # lower target exists
             x_target = da_region.coords[x].isel(**{ycoord: y_boundary_guards})
             y_target = da_region.coords[y].isel(**{ycoord: y_boundary_guards})
             [line] = ax.plot(x_target, y_target, 'k-', linewidth=2)
             if hatching:
                 _add_hatching(line, ax)
-        if da_region.region.connection_upper_y is None:
+        if list(da_region.regions.values())[0].connection_upper_y is None:
             # upper target exists
             x_target = da_region.coords[x].isel(**{ycoord: -y_boundary_guards - 1})
             y_target = da_region.coords[y].isel(**{ycoord: -y_boundary_guards - 1})

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -118,6 +118,9 @@ class Region:
             result += f"\t{attr}\t{val}\n"
         return result
 
+    def __eq__(self, other):
+        return vars(self) == vars(other)
+
     def get_slices(self, mxg=0, myg=0):
         """
         Return x- and y-dimension slices that select this region from the global

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -131,19 +131,19 @@ class Region:
         xslice, yslice : slice, slice
         """
         xi = self.xinner_ind
-        if self.connection_inner_x is not None:
+        if self.connection_inner_x is not None and xi is not None:
             xi -= mxg
 
         xo = self.xouter_ind
-        if self.connection_outer_x is not None:
+        if self.connection_outer_x is not None and xo is not None:
             xi += mxg
 
         yl = self.ylower_ind
-        if self.connection_lower_y is not None:
+        if self.connection_lower_y is not None and yl is not None:
             yl -= myg
 
         yu = self.yupper_ind
-        if self.connection_upper_y is not None:
+        if self.connection_upper_y is not None and yu is not None:
             yu += myg
 
         return {self.xcoord: slice(xi, xo), self.ycoord: slice(yl, yu)}
@@ -663,20 +663,32 @@ def _concat_inner_guards(da, da_global, mxg):
     if mxg <= 0:
         return da
 
+    if len(da.regions) > 1:
+        raise ValueError('da passed should have only one region')
+    region = list(da.regions.values())[0]
+
+    if region.connection_inner_x not in da_global.regions:
+        # No connection, or plotting restricted set of regions not including this
+        # connection
+        return da
+
     myg_da = da_global.metadata['MYG']
     keep_yboundaries = da_global.metadata['keep_yboundaries']
     xcoord = da_global.metadata['bout_xdim']
     ycoord = da_global.metadata['bout_ydim']
 
-    da_inner = da_global.bout.from_region(da.region.connection_inner_x, with_guards=0)
+    da_inner = da_global.bout.from_region(region.connection_inner_x, with_guards=0)
+    if len(da_inner.regions) > 1:
+        raise ValueError('da_inner should have only one region')
+    region_inner = list(da_inner.regions.values())[0]
 
-    if (myg_da > 0 and keep_yboundaries and da.region.connection_lower_y is not None
-            and da_inner.region.connection_lower_y is None):
+    if (myg_da > 0 and keep_yboundaries and region.connection_lower_y is not None
+            and region_inner.connection_lower_y is None):
         # da_inner may have more points in the y-direction, because it has an actual
         # boundary, not a connection. Need to remove any extra points
         da_inner = da_inner.isel(**{ycoord: slice(myg_da, None)})
-    if (myg_da > 0 and keep_yboundaries and da.region.connection_upper_y is not None
-            and da_inner.region.connection_upper_y is None):
+    if (myg_da > 0 and keep_yboundaries and region.connection_upper_y is not None
+            and region_inner.connection_upper_y is None):
         # da_inner may have more points in the y-direction, because it has an actual
         # boundary, not a connection. Need to remove any extra points
         da_inner = da_inner.isel(**{ycoord: slice(None, -myg_da)})
@@ -684,44 +696,44 @@ def _concat_inner_guards(da, da_global, mxg):
     # select just the points we need to fill the guard cells of da
     da_inner = da_inner.isel(**{xcoord: slice(-mxg, None)})
 
-    if (myg_da > 0 and keep_yboundaries and da.region.connection_lower_y is None
-            and da_inner.region.connection_lower_y is not None):
+    if (myg_da > 0 and keep_yboundaries and region.connection_lower_y is None
+            and region_inner.connection_lower_y is not None):
         # da_inner may have fewer points in the y-direction, because it has a connection,
         # not an actual boundary. Need to get the extra points from its connection
-        da_inner_lower = da_global.bout.from_region(da_inner.region.connection_lower_y,
+        da_inner_lower = da_global.bout.from_region(region_inner.connection_lower_y,
                                                     with_guards=0)
         da_inner_lower = da_inner_lower.isel(**{xcoord: slice(-mxg, None),
                                                 ycoord: slice(-myg_da, None)})
-        save_region = da_inner.region
+        save_regions = da_inner.regions
         da_inner = xr.concat((da_inner_lower, da_inner), ycoord, join='exact')
         # xr.concat takes attributes from the first variable, but we need da_inner's
-        # region
-        da_inner.attrs['region'] = save_region
-    if (myg_da > 0 and keep_yboundaries and da.region.connection_upper_y is None
-            and da_inner.region.connection_upper_y is not None):
+        # regions
+        da_inner.attrs['regions'] = save_regions
+    if (myg_da > 0 and keep_yboundaries and region.connection_upper_y is None
+            and region_inner.connection_upper_y is not None):
         # da_inner may have fewer points in the y-direction, because it has a connection,
         # not an actual boundary. Need to get the extra points from its connection
-        da_inner_upper = da_global.bout.from_region(da_inner.region.connection_upper_y,
+        da_inner_upper = da_global.bout.from_region(region_inner.connection_upper_y,
                                                     with_guards=0)
         da_inner_upper = da_inner_upper.isel(**{xcoord: slice(-mxg, None),
                                                 ycoord: slice(myg_da)})
         da_inner = xr.concat((da_inner, da_inner_upper), ycoord, join='exact')
-        # xr.concat takes attributes from the first variable, so region is OK
+        # xr.concat takes attributes from the first variable, so regions are OK
 
     if xcoord in da.coords:
         # Some coordinates may not be single-valued, so use local coordinates for
         # neighbouring region, not communicated ones. Ensures the coordinates are
         # continuous so that interpolation works correctly near the boundaries.
-        slices = da.region.get_inner_guards_slices(mxg=mxg)
+        slices = region.get_inner_guards_slices(mxg=mxg)
         new_xcoord = da_global[xcoord].isel(**{xcoord: slices[xcoord]})
         new_ycoord = da_global[ycoord].isel(**{ycoord: slices[ycoord]})
         da_inner = da_inner.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
 
-    save_region = da.region
+    save_regions = da.regions
     da = xr.concat((da_inner, da), xcoord, join='exact')
     # xr.concat takes attributes from the first variable (for xarray>=0.15.0, keeps attrs
     # that are the same in all objects for xarray<0.15.0)
-    da.attrs['region'] = save_region
+    da.attrs['regions'] = save_regions
 
     return da
 
@@ -735,20 +747,32 @@ def _concat_outer_guards(da, da_global, mxg):
     if mxg <= 0:
         return da
 
+    if len(da.regions) > 1:
+        raise ValueError('da passed should have only one region')
+    region = list(da.regions.values())[0]
+
+    if region.connection_outer_x not in da_global.regions:
+        # No connection, or plotting restricted set of regions not including this
+        # connection
+        return da
+
     myg_da = da_global.metadata['MYG']
     keep_yboundaries = da_global.metadata['keep_yboundaries']
     xcoord = da_global.metadata['bout_xdim']
     ycoord = da_global.metadata['bout_ydim']
 
-    da_outer = da_global.bout.from_region(da.region.connection_outer_x, with_guards=0)
+    da_outer = da_global.bout.from_region(region.connection_outer_x, with_guards=0)
+    if len(da_outer.regions) > 1:
+        raise ValueError('da_outer should have only one region')
+    region_outer = list(da_outer.regions.values())[0]
 
-    if (myg_da > 0 and keep_yboundaries and da.region.connection_lower_y is not None
-            and da_outer.region.connection_lower_y is None):
+    if (myg_da > 0 and keep_yboundaries and region.connection_lower_y is not None
+            and region_outer.connection_lower_y is None):
         # da_outer may have more points in the y-direction, because it has an actual
         # boundary, not a connection. Need to remove any extra points
         da_outer = da_outer.isel(**{ycoord: slice(myg_da, None)})
-    if (myg_da > 0 and keep_yboundaries and da.region.connection_upper_y is not None
-            and da_outer.region.connection_upper_y is None):
+    if (myg_da > 0 and keep_yboundaries and region.connection_upper_y is not None
+            and region_outer.connection_upper_y is None):
         # da_outer may have more points in the y-direction, because it has an actual
         # boundary, not a connection. Need to remove any extra points
         da_outer = da_outer.isel(**{ycoord: slice(None, -myg_da)})
@@ -756,43 +780,43 @@ def _concat_outer_guards(da, da_global, mxg):
     # select just the points we need to fill the guard cells of da
     da_outer = da_outer.isel(**{xcoord: slice(mxg)})
 
-    if (myg_da > 0 and keep_yboundaries and da.region.connection_lower_y is None
-            and da_outer.region.connection_lower_y is not None):
+    if (myg_da > 0 and keep_yboundaries and region.connection_lower_y is None
+            and region_outer.connection_lower_y is not None):
         # da_outer may have fewer points in the y-direction, because it has a connection,
         # not an actual boundary. Need to get the extra points from its connection
-        da_outer_lower = da_global.bout.from_region(da_outer.region.connection_lower_y,
+        da_outer_lower = da_global.bout.from_region(region_outer.connection_lower_y,
                                                     with_guards=0)
         da_outer_lower = da_outer_lower.isel(**{xcoord: slice(-mxg, None),
                                                 ycoord: slice(-myg_da, None)})
-        save_region = da_outer.region
+        save_regions = da_outer.regions
         da_outer = xr.concat((da_outer_lower, da_outer), ycoord, join='exact')
         # xr.concat takes attributes from the first variable, but we need da_outer's
-        # region
-        da_outer.attrs['region'] = save_region
-    if (myg_da > 0 and keep_yboundaries and da.region.connection_upper_y is None
-            and da_outer.region.connection_upper_y is not None):
+        # regions
+        da_outer.attrs['regions'] = save_regions
+    if (myg_da > 0 and keep_yboundaries and region.connection_upper_y is None
+            and region_outer.connection_upper_y is not None):
         # da_outer may have fewer points in the y-direction, because it has a connection,
         # not an actual boundary. Need to get the extra points from its connection
-        da_outer_upper = da_global.bout.from_region(da_outer.region.connection_upper_y,
+        da_outer_upper = da_global.bout.from_region(region_outer.connection_upper_y,
                                                     with_guards=0)
         da_outer_upper = da_outer_upper.isel(**{xcoord: slice(-mxg, None),
                                                 ycoord: slice(myg_da)})
         da_outer = xr.concat((da_outer, da_outer_upper), ycoord, join='exact')
-        # xr.concat takes attributes from the first variable, so region is OK
+        # xr.concat takes attributes from the first variable, so regions are OK
 
     if xcoord in da.coords:
         # Some coordinates may not be single-valued, so use local coordinates for
         # neighbouring region, not communicated ones. Ensures the coordinates are
         # continuous so that interpolation works correctly near the boundaries.
-        slices = da.region.get_outer_guards_slices(mxg=mxg)
+        slices = region.get_outer_guards_slices(mxg=mxg)
         new_xcoord = da_global[xcoord].isel(**{xcoord: slices[xcoord]})
         new_ycoord = da_global[ycoord].isel(**{ycoord: slices[ycoord]})
         da_outer = da_outer.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
 
-    save_region = da.region
+    save_regions = da.regions
     da = xr.concat((da, da_outer), xcoord, join='exact')
     # xarray<0.15.0 only keeps attrs that are the same on all variables passed to concat
-    da.attrs['region'] = save_region
+    da.attrs['regions'] = save_regions
 
     return da
 
@@ -806,10 +830,19 @@ def _concat_lower_guards(da, da_global, mxg, myg):
     if myg <= 0:
         return da
 
+    if len(da.regions) > 1:
+        raise ValueError('da passed should have only one region')
+    region = list(da.regions.values())[0]
+
+    if region.connection_lower_y not in da_global.regions:
+        # No connection, or plotting restricted set of regions not including this
+        # connection
+        return da
+
     xcoord = da_global.metadata['bout_xdim']
     ycoord = da_global.metadata['bout_ydim']
 
-    da_lower = da_global.bout.from_region(da.region.connection_lower_y,
+    da_lower = da_global.bout.from_region(region.connection_lower_y,
                                           with_guards={xcoord: mxg, ycoord: 0})
 
     # select just the points we need to fill the guard cells of da
@@ -819,7 +852,7 @@ def _concat_lower_guards(da, da_global, mxg, myg):
         # Some coordinates may not be single-valued, so use local coordinates for
         # neighbouring region, not communicated ones. Ensures the coordinates are
         # continuous so that interpolation works correctly near the boundaries.
-        slices = da.region.get_lower_guards_slices(mxg=mxg, myg=myg)
+        slices = region.get_lower_guards_slices(mxg=mxg, myg=myg)
 
         if slices[ycoord].start < 0:
             # For core-only or limiter topologies, the lower-y slice may be out of the
@@ -833,11 +866,11 @@ def _concat_lower_guards(da, da_global, mxg, myg):
         new_ycoord = da_global[ycoord].isel(**{ycoord: slices[ycoord]})
         da_lower = da_lower.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
 
-    save_region = da.region
+    save_regions = da.regions
     da = xr.concat((da_lower, da), ycoord, join='exact')
     # xr.concat takes attributes from the first variable (for xarray>=0.15.0, keeps attrs
     # that are the same in all objects for xarray<0.15.0)
-    da.attrs['region'] = save_region
+    da.attrs['regions'] = save_regions
 
     return da
 
@@ -851,10 +884,19 @@ def _concat_upper_guards(da, da_global, mxg, myg):
     if myg <= 0:
         return da
 
+    if len(da.regions) > 1:
+        raise ValueError('da passed should have only one region')
+    region = list(da.regions.values())[0]
+
+    if region.connection_upper_y not in da_global.regions:
+        # No connection, or plotting restricted set of regions not including this
+        # connection
+        return da
+
     xcoord = da_global.metadata['bout_xdim']
     ycoord = da_global.metadata['bout_ydim']
 
-    da_upper = da_global.bout.from_region(da.region.connection_upper_y,
+    da_upper = da_global.bout.from_region(region.connection_upper_y,
                                           with_guards={xcoord: mxg, ycoord: 0})
     # select just the points we need to fill the guard cells of da
     da_upper = da_upper.isel(**{ycoord: slice(myg)})
@@ -863,7 +905,7 @@ def _concat_upper_guards(da, da_global, mxg, myg):
         # Some coordinates may not be single-valued, so use local coordinates for
         # neighbouring region, not communicated ones. Ensures the coordinates are
         # continuous so that interpolation works correctly near the boundaries.
-        slices = da.region.get_upper_guards_slices(mxg=mxg, myg=myg)
+        slices = region.get_upper_guards_slices(mxg=mxg, myg=myg)
 
         if slices[ycoord].stop > da_global.sizes[ycoord]:
             # For core-only or limiter topologies, the upper-y slice may be out of the
@@ -877,9 +919,9 @@ def _concat_upper_guards(da, da_global, mxg, myg):
         new_ycoord = da_global[ycoord].isel(**{ycoord: slices[ycoord]})
         da_upper = da_upper.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
 
-    save_region = da.region
+    save_regions = da.regions
     da = xr.concat((da, da_upper), ycoord, join='exact')
     # xarray<0.15.0 only keeps attrs that are the same on all variables passed to concat
-    da.attrs['region'] = save_region
+    da.attrs['regions'] = save_regions
 
     return da

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -640,11 +640,11 @@ def _create_regions_toroidal(ds):
     ny += 2*ybndry + 2*ybndry_upper
 
     # Note, include guard cells in the created regions, fill them later
-    try:
+    if topology in topologies:
         regions = topologies[topology](ds=ds, ixs1=ixs1, ixs2=ixs2, nx=nx, jys11=jys11,
                                        jys21=jys21, ny_inner=ny_inner, jys12=jys12,
                                        jys22=jys22, ny=ny, ybndry=ybndry)
-    except KeyError:
+    else:
         raise NotImplementedError(f"Topology '{topology}' is not implemented")
 
     _check_connections(regions)

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -26,6 +26,32 @@ class TestBoutDataArrayMethods:
         assert dict_equiv(ds.attrs, new_ds.attrs)
         assert dict_equiv(ds.metadata, new_ds.metadata)
 
+    @pytest.mark.parametrize("mxg", [0, pytest.param(2, marks=pytest.mark.long)])
+    @pytest.mark.parametrize("myg", [pytest.param(0, marks=pytest.mark.long), 2])
+    def test_remove_yboundaries(self, tmpdir_factory, bout_xyt_example_files, mxg, myg):
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1,
+                nype=6, nt=1, grid='grid', guards={'x': mxg, 'y': myg},
+                topology='connected-double-null', syn_data_type='linear')
+
+        ds = open_boutdataset(datapath=path,
+                gridfilepath=Path(path).parent.joinpath('grid.nc'), geometry='toroidal',
+                keep_yboundaries=True)
+
+        path_no_yboundaries = bout_xyt_example_files(
+                tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',
+                guards={'x': mxg, 'y': 0}, topology='connected-double-null',
+                syn_data_type='linear')
+
+        ds_no_yboundaries = open_boutdataset(
+                datapath=path_no_yboundaries,
+                gridfilepath=Path(path).parent.joinpath('grid.nc'), geometry='toroidal',
+                keep_yboundaries=False)
+
+        n = ds['n'].bout.remove_yboundaries()
+
+        assert n.metadata['keep_yboundaries'] == 0
+        npt.assert_equal(n.values, ds_no_yboundaries['n'].values)
+
     @pytest.mark.parametrize('nz', [pytest.param(6, marks=pytest.mark.long),
                                     7,
                                     pytest.param(8, marks=pytest.mark.long),

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -33,28 +33,45 @@ class TestBoutDataArrayMethods:
     @pytest.mark.parametrize("remove_extra_upper",
                              [False, pytest.param(True, marks=pytest.mark.long)])
     def test_remove_yboundaries(
-        self, tmpdir_factory, bout_xyt_example_files, mxg, myg, remove_extra_upper
+        self, bout_xyt_example_files, mxg, myg, remove_extra_upper
     ):
-        path = bout_xyt_example_files(
-            tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',
-            guards={'x': mxg, 'y': myg}, topology='connected-double-null',
+        dataset_list, grid_ds = bout_xyt_example_files(
+            None,
+            lengths=(2, 3, 4, 3),
+            nxpe=1,
+            nype=6,
+            nt=1,
+            grid='grid',
+            guards={'x': mxg, 'y': myg},
+            topology='connected-double-null',
             syn_data_type='linear'
         )
 
         ds = open_boutdataset(
-            datapath=path, gridfilepath=Path(path).parent.joinpath('grid.nc'),
-            geometry='toroidal', keep_yboundaries=True
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_yboundaries=True
         )
 
-        path_no_yboundaries = bout_xyt_example_files(
-                tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',
-                guards={'x': mxg, 'y': 0}, topology='connected-double-null',
-                syn_data_type='linear')
+        dataset_list_no_yboundaries, grid_ds_no_yboundaries = bout_xyt_example_files(
+            None,
+            lengths=(2, 3, 4, 3),
+            nxpe=1,
+            nype=6,
+            nt=1,
+            grid='grid',
+            guards={'x': mxg, 'y': 0},
+            topology='connected-double-null',
+            syn_data_type='linear'
+        )
 
         ds_no_yboundaries = open_boutdataset(
-                datapath=path_no_yboundaries,
-                gridfilepath=Path(path).parent.joinpath('grid.nc'), geometry='toroidal',
-                keep_yboundaries=False)
+            datapath=dataset_list_no_yboundaries,
+            gridfilepath=grid_ds_no_yboundaries,
+            geometry='toroidal',
+            keep_yboundaries=False
+        )
 
         if remove_extra_upper:
             ds_no_yboundaries = xr.concat(

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -28,15 +28,21 @@ class TestBoutDataArrayMethods:
 
     @pytest.mark.parametrize("mxg", [0, pytest.param(2, marks=pytest.mark.long)])
     @pytest.mark.parametrize("myg", [pytest.param(0, marks=pytest.mark.long), 2])
-    @pytest.mark.parametrize("remove_extra_upper", [False, pytest.param(True, marks=pytest.mark.long)])
-    def test_remove_yboundaries(self, tmpdir_factory, bout_xyt_example_files, mxg, myg, remove_extra_upper):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1,
-                nype=6, nt=1, grid='grid', guards={'x': mxg, 'y': myg},
-                topology='connected-double-null', syn_data_type='linear')
+    @pytest.mark.parametrize("remove_extra_upper",
+                             [False, pytest.param(True, marks=pytest.mark.long)])
+    def test_remove_yboundaries(
+        self, tmpdir_factory, bout_xyt_example_files, mxg, myg, remove_extra_upper
+    ):
+        path = bout_xyt_example_files(
+            tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',
+            guards={'x': mxg, 'y': myg}, topology='connected-double-null',
+            syn_data_type='linear'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                gridfilepath=Path(path).parent.joinpath('grid.nc'), geometry='toroidal',
-                keep_yboundaries=True)
+        ds = open_boutdataset(
+            datapath=path, gridfilepath=Path(path).parent.joinpath('grid.nc'),
+            geometry='toroidal', keep_yboundaries=True
+        )
 
         path_no_yboundaries = bout_xyt_example_files(
                 tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -197,287 +197,315 @@ class TestBoutDatasetMethods:
 
         for var in ['n', 'T']:
             v = ds[var]
+            v_noregions = v.copy(deep=True)
+
+            # Remove attributes that are expected to be different
+            del v_noregions.attrs['regions']
 
             v_lower_inner_PFR = v.bout.from_region('lower_inner_PFR')
 
             # Remove attributes that are expected to be different
-            del v_lower_inner_PFR.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg), theta=slice(jys11 + 1)),
+            del v_lower_inner_PFR.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 + mxg),
+                                                  theta=slice(jys11 + 1)),
                                  v_lower_inner_PFR.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
+                npt.assert_equal(v_noregions.isel(x=slice(ixs1 + mxg),
                                         theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
                                  v_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
 
             v_lower_inner_intersep = v.bout.from_region('lower_inner_intersep')
 
             # Remove attributes that are expected to be different
-            del v_lower_inner_intersep.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys11 + 1)),
+            del v_lower_inner_intersep.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                                  theta=slice(jys11 + 1)),
                                  v_lower_inner_intersep.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
-                                 v_lower_inner_intersep.isel(
-                                     theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                         theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                        v_lower_inner_intersep.isel(theta=slice(-myg, None)).values)
 
             v_lower_inner_SOL = v.bout.from_region('lower_inner_SOL')
 
             # Remove attributes that are expected to be different
-            del v_lower_inner_SOL.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys11 + 1)),
+            del v_lower_inner_SOL.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                                  theta=slice(jys11 + 1)),
                                  v_lower_inner_SOL.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
-                                 v_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                         theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                        v_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
 
             v_inner_core = v.bout.from_region('inner_core')
 
             # Remove attributes that are expected to be different
-            del v_inner_core.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys11 + 1, jys21 + 1)),
+            del v_inner_core.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 + mxg),
+                                                  theta=slice(jys11 + 1, jys21 + 1)),
                                  v_inner_core.isel(
                                      theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
-                                 v_inner_core.isel(theta=slice(myg)).values)
-                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
-                                 v_inner_core.isel(theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 + mxg),
+                                         theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                        v_inner_core.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 + mxg),
+                                         theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                        v_inner_core.isel(theta=slice(-myg, None)).values)
 
             v_inner_intersep = v.bout.from_region('inner_intersep')
 
             # Remove attributes that are expected to be different
-            del v_inner_intersep.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys11 + 1, jys21 + 1)),
+            del v_inner_intersep.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                                  theta=slice(jys11 + 1, jys21 + 1)),
                                  v_inner_intersep.isel(
                                      theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
-                                 v_inner_intersep.isel(theta=slice(myg)).values)
-                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
-                                 v_inner_intersep.isel(theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                         theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                        v_inner_intersep.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                         theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                        v_inner_intersep.isel(theta=slice(-myg, None)).values)
 
             v_inner_sol = v.bout.from_region('inner_SOL')
 
             # Remove attributes that are expected to be different
-            del v_inner_sol.attrs['region']
+            del v_inner_sol.attrs['regions']
             xrt.assert_identical(
-                    v.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1, jys21 + 1)),
+                    v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                     theta=slice(jys11 + 1, jys21 + 1)),
                     v_inner_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
-                                 v_inner_sol.isel(theta=slice(myg)).values)
-                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
-                                 v_inner_sol.isel(theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                         theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                        v_inner_sol.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                         theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                        v_inner_sol.isel(theta=slice(-myg, None)).values)
 
             v_upper_inner_PFR = v.bout.from_region('upper_inner_PFR')
 
             # Remove attributes that are expected to be different
-            del v_upper_inner_PFR.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys21 + 1, ny_inner)),
+            del v_upper_inner_PFR.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 + mxg),
+                                                  theta=slice(jys21 + 1, ny_inner)),
                                  v_upper_inner_PFR.isel(theta=slice(myg, None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
-                                 v_upper_inner_PFR.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 + mxg),
+                                         theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                        v_upper_inner_PFR.isel(theta=slice(myg)).values)
 
             v_upper_inner_intersep = v.bout.from_region('upper_inner_intersep')
 
             # Remove attributes that are expected to be different
-            del v_upper_inner_intersep.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys21 + 1, ny_inner)),
+            del v_upper_inner_intersep.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                                  theta=slice(jys21 + 1, ny_inner)),
                                  v_upper_inner_intersep.isel(theta=slice(myg, None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
-                                 v_upper_inner_intersep.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                         theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                        v_upper_inner_intersep.isel(theta=slice(myg)).values)
 
             v_upper_inner_SOL = v.bout.from_region('upper_inner_SOL')
 
             # Remove attributes that are expected to be different
-            del v_upper_inner_SOL.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys21 + 1, ny_inner)),
+            del v_upper_inner_SOL.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                                  theta=slice(jys21 + 1, ny_inner)),
                                  v_upper_inner_SOL.isel(theta=slice(myg, None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
-                                 v_upper_inner_SOL.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                         theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                        v_upper_inner_SOL.isel(theta=slice(myg)).values)
 
             v_upper_outer_PFR = v.bout.from_region('upper_outer_PFR')
 
             # Remove attributes that are expected to be different
-            del v_upper_outer_PFR.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(ny_inner, jys12 + 1)),
+            del v_upper_outer_PFR.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 + mxg),
+                                                  theta=slice(ny_inner, jys12 + 1)),
                                  v_upper_outer_PFR.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
-                                 v_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 + mxg),
+                                         theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                        v_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
 
             v_upper_outer_intersep = v.bout.from_region('upper_outer_intersep')
 
             # Remove attributes that are expected to be different
-            del v_upper_outer_intersep.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(ny_inner, jys12 + 1)),
+            del v_upper_outer_intersep.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                                  theta=slice(ny_inner, jys12 + 1)),
                                  v_upper_outer_intersep.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
-                                 v_upper_outer_intersep.isel(
-                                     theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                         theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                        v_upper_outer_intersep.isel(theta=slice(-myg, None)).values)
 
             v_upper_outer_SOL = v.bout.from_region('upper_outer_SOL')
 
             # Remove attributes that are expected to be different
-            del v_upper_outer_SOL.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(ny_inner, jys12 + 1)),
+            del v_upper_outer_SOL.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                                  theta=slice(ny_inner, jys12 + 1)),
                                  v_upper_outer_SOL.isel(
                                      theta=slice(-myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
-                                 v_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                         theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                        v_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
 
             v_outer_core = v.bout.from_region('outer_core')
 
             # Remove attributes that are expected to be different
-            del v_outer_core.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys12 + 1, jys22 + 1)),
+            del v_outer_core.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 + mxg),
+                                                  theta=slice(jys12 + 1, jys22 + 1)),
                                  v_outer_core.isel(
                                      theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
-                                 v_outer_core.isel(theta=slice(myg)).values)
-                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
-                                 v_outer_core.isel(theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 + mxg),
+                                         theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                        v_outer_core.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 + mxg),
+                                         theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                        v_outer_core.isel(theta=slice(-myg, None)).values)
 
             v_outer_intersep = v.bout.from_region('outer_intersep')
 
             # Remove attributes that are expected to be different
-            del v_outer_intersep.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys12 + 1, jys22 + 1)),
+            del v_outer_intersep.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                                  theta=slice(jys12 + 1, jys22 + 1)),
                                  v_outer_intersep.isel(
                                      theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
-                                 v_outer_intersep.isel(theta=slice(myg)).values)
-                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
-                                 v_outer_intersep.isel(theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                         theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                        v_outer_intersep.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                         theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                        v_outer_intersep.isel(theta=slice(-myg, None)).values)
 
             v_outer_sol = v.bout.from_region('outer_SOL')
 
             # Remove attributes that are expected to be different
-            del v_outer_sol.attrs['region']
+            del v_outer_sol.attrs['regions']
             xrt.assert_identical(
-                    v.isel(x=slice(ixs2 - mxg, None), theta=slice(jys12 + 1, jys22 + 1)),
+                    v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                     theta=slice(jys12 + 1, jys22 + 1)),
                     v_outer_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
-                                 v_outer_sol.isel(theta=slice(myg)).values)
-                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
-                                 v_outer_sol.isel(theta=slice(-myg, None)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                         theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                        v_outer_sol.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                         theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                        v_outer_sol.isel(theta=slice(-myg, None)).values)
 
             v_lower_outer_PFR = v.bout.from_region('lower_outer_PFR')
 
             # Remove attributes that are expected to be different
-            del v_lower_outer_PFR.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys22 + 1, None)),
+            del v_lower_outer_PFR.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 + mxg),
+                                                  theta=slice(jys22 + 1, None)),
                                  v_lower_outer_PFR.isel(theta=slice(myg, None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 + mxg),
-                                        theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
-                                 v_lower_outer_PFR.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 + mxg),
+                                         theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                        v_lower_outer_PFR.isel(theta=slice(myg)).values)
 
             v_lower_outer_intersep = v.bout.from_region('lower_outer_intersep')
 
             # Remove attributes that are expected to be different
-            del v_lower_outer_intersep.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys22 + 1, None)),
+            del v_lower_outer_intersep.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                                  theta=slice(jys22 + 1, None)),
                                  v_lower_outer_intersep.isel(theta=slice(myg, None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                        theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
-                                 v_lower_outer_intersep.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                         theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                        v_lower_outer_intersep.isel(theta=slice(myg)).values)
 
             v_lower_outer_SOL = v.bout.from_region('lower_outer_SOL')
 
             # Remove attributes that are expected to be different
-            del v_lower_outer_SOL.attrs['region']
-            xrt.assert_identical(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys22 + 1, None)),
+            del v_lower_outer_SOL.attrs['regions']
+            xrt.assert_identical(v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                                  theta=slice(jys22 + 1, None)),
                                  v_lower_outer_SOL.isel(theta=slice(myg, None)))
             if myg > 0:
                 # check y-guards, which were 'communicated' by from_region
                 # Coordinates are not equal, so only compare array values
-                npt.assert_equal(v.isel(x=slice(ixs2 - mxg, None),
-                                        theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
-                                 v_lower_outer_SOL.isel(theta=slice(myg)).values)
+                npt.assert_equal(
+                        v_noregions.isel(x=slice(ixs2 - mxg, None),
+                                         theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                        v_lower_outer_SOL.isel(theta=slice(myg)).values)
 
     def test_interpolate_parallel_all_variables_arg(self, tmpdir_factory,
                                                     bout_xyt_example_files):

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -89,29 +89,33 @@ class TestBoutDatasetMethods:
     @pytest.mark.parametrize("mxg", [0, pytest.param(2, marks=pytest.mark.long)])
     @pytest.mark.parametrize("myg", [pytest.param(0, marks=pytest.mark.long), 2])
     def test_remove_yboundaries(self, tmpdir_factory, bout_xyt_example_files, mxg, myg):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1,
-                nype=6, nt=1, grid='grid', guards={'x': mxg, 'y': myg},
-                topology='connected-double-null', syn_data_type='linear')
+        path = bout_xyt_example_files(
+            tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',
+            guards={'x': mxg, 'y': myg}, topology='connected-double-null',
+            syn_data_type='linear'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                gridfilepath=Path(path).parent.joinpath('grid.nc'), geometry='toroidal',
-                keep_yboundaries=True)
+        ds = open_boutdataset(
+            datapath=path, gridfilepath=Path(path).parent.joinpath('grid.nc'),
+            geometry='toroidal', keep_yboundaries=True
+        )
 
         path_no_yboundaries = bout_xyt_example_files(
-                tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',
-                guards={'x': mxg, 'y': 0}, topology='connected-double-null',
-                syn_data_type='linear')
+            tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',
+            guards={'x': mxg, 'y': 0}, topology='connected-double-null',
+            syn_data_type='linear'
+        )
 
         ds_no_yboundaries = open_boutdataset(
-                datapath=path_no_yboundaries,
-                gridfilepath=Path(path).parent.joinpath('grid.nc'), geometry='toroidal',
-                keep_yboundaries=False)
+            datapath=path_no_yboundaries,
+            gridfilepath=Path(path).parent.joinpath('grid.nc'), geometry='toroidal',
+            keep_yboundaries=False
+        )
 
         ds = ds.bout.remove_yboundaries()
 
         assert ds.metadata['keep_yboundaries'] == 0
         for v in ds:
-            print('keep y',v)
             assert ds[v].metadata['keep_yboundaries'] == 0
 
         # expect theta coordinate to be different, so ignore

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -90,27 +90,42 @@ class TestBoutDatasetMethods:
 
     @pytest.mark.parametrize("mxg", [0, pytest.param(2, marks=pytest.mark.long)])
     @pytest.mark.parametrize("myg", [pytest.param(0, marks=pytest.mark.long), 2])
-    def test_remove_yboundaries(self, tmpdir_factory, bout_xyt_example_files, mxg, myg):
-        path = bout_xyt_example_files(
-            tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',
-            guards={'x': mxg, 'y': myg}, topology='connected-double-null',
+    def test_remove_yboundaries(self, bout_xyt_example_files, mxg, myg):
+        dataset_list, grid_ds = bout_xyt_example_files(
+            None,
+            lengths=(2, 3, 4, 3),
+            nxpe=1,
+            nype=6,
+            nt=1,
+            grid='grid',
+            guards={'x': mxg, 'y': myg},
+            topology='connected-double-null',
             syn_data_type='linear'
         )
 
         ds = open_boutdataset(
-            datapath=path, gridfilepath=Path(path).parent.joinpath('grid.nc'),
-            geometry='toroidal', keep_yboundaries=True
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_yboundaries=True
         )
 
-        path_no_yboundaries = bout_xyt_example_files(
-            tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',
-            guards={'x': mxg, 'y': 0}, topology='connected-double-null',
+        dataset_list_no_yboundaries, grid_ds_no_yboundaries = bout_xyt_example_files(
+            None,
+            lengths=(2, 3, 4, 3),
+            nxpe=1,
+            nype=6,
+            nt=1,
+            grid='grid',
+            guards={'x': mxg, 'y': 0},
+            topology='connected-double-null',
             syn_data_type='linear'
         )
 
         ds_no_yboundaries = open_boutdataset(
-            datapath=path_no_yboundaries,
-            gridfilepath=Path(path).parent.joinpath('grid.nc'), geometry='toroidal',
+            datapath=dataset_list_no_yboundaries,
+            gridfilepath=grid_ds_no_yboundaries,
+            geometry='toroidal',
             keep_yboundaries=False
         )
 

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -180,9 +180,16 @@ class TestBoutDatasetMethods:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        dataset_list, grid_ds = bout_xyt_example_files(None, lengths=(2, 3, 4, 3), nxpe=3,
-                                      nype=6, nt=1, guards=guards, grid='grid',
-                                      topology='disconnected-double-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            None,
+            lengths=(2, 3, 4, 3),
+            nxpe=3,
+            nype=6,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='disconnected-double-null'
+        )
 
         ds = open_boutdataset(
             datapath=dataset_list,
@@ -534,8 +541,15 @@ class TestBoutDatasetMethods:
     def test_interpolate_parallel_all_variables_arg(self, bout_xyt_example_files):
         # Check that passing 'variables=...' to interpolate_parallel() does actually
         # interpolate all the variables
-        dataset_list, grid_ds = bout_xyt_example_files(None, lengths=(2, 3, 4, 3), nxpe=1,
-                                      nype=1, nt=1, grid='grid', topology='sol')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            None,
+            lengths=(2, 3, 4, 3),
+            nxpe=1,
+            nype=1,
+            nt=1,
+            grid='grid',
+            topology='sol'
+        )
 
         ds = open_boutdataset(
             datapath=dataset_list, gridfilepath=grid_ds, geometry='toroidal'

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -86,6 +86,48 @@ class TestBoutDatasetMethods:
         ds['n_aligned'].attrs['direction_y'] = 'Aligned'
         xrt.assert_allclose(ds.bout.get_field_aligned('n'), ds['T'])
 
+    @pytest.mark.parametrize("mxg", [0, pytest.param(2, marks=pytest.mark.long)])
+    @pytest.mark.parametrize("myg", [pytest.param(0, marks=pytest.mark.long), 2])
+    def test_remove_yboundaries(self, tmpdir_factory, bout_xyt_example_files, mxg, myg):
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1,
+                nype=6, nt=1, grid='grid', guards={'x': mxg, 'y': myg},
+                topology='connected-double-null', syn_data_type='linear')
+
+        ds = open_boutdataset(datapath=path,
+                gridfilepath=Path(path).parent.joinpath('grid.nc'), geometry='toroidal',
+                keep_yboundaries=True)
+
+        path_no_yboundaries = bout_xyt_example_files(
+                tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1, nype=6, nt=1, grid='grid',
+                guards={'x': mxg, 'y': 0}, topology='connected-double-null',
+                syn_data_type='linear')
+
+        ds_no_yboundaries = open_boutdataset(
+                datapath=path_no_yboundaries,
+                gridfilepath=Path(path).parent.joinpath('grid.nc'), geometry='toroidal',
+                keep_yboundaries=False)
+
+        ds = ds.bout.remove_yboundaries()
+
+        assert ds.metadata['keep_yboundaries'] == 0
+        for v in ds:
+            print('keep y',v)
+            assert ds[v].metadata['keep_yboundaries'] == 0
+
+        # expect theta coordinate to be different, so ignore
+        ds = ds.drop('theta')
+        ds_no_yboundaries = ds_no_yboundaries.drop('theta')
+
+        # expect MYG can be different, so ignore
+        del ds.metadata['MYG']
+        del ds_no_yboundaries.metadata['MYG']
+        for v in ds:
+            del ds[v].metadata['MYG']
+            # metadata on variables is a reference to ds_no_yboundaries.metadata, so
+            # don't need to delete MYG again
+
+        xrt.assert_equal(ds, ds_no_yboundaries)
+
     def test_set_parallel_interpolation_factor(self):
         ds = Dataset()
         ds['a'] = DataArray()

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -299,10 +299,10 @@ def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, 
 
         t_array = DataArray((nx - 2*mxg)*ny*nz*np.arange(t_length, dtype=float),
                             dims='t')
-        x_array = DataArray(ny*nz*(xproc*lengths[1] + mxg
+        x_array = DataArray(ny*nz*(xproc*lengths[1]
                             + np.arange(lengths[1], dtype=float)),
                             dims='x')
-        y_array = DataArray(nz*(yproc*lengths[2] + myg
+        y_array = DataArray(nz*(yproc*lengths[2]
                             + np.arange(lengths[2], dtype=float)),
                             dims='y')
         z_array = DataArray(np.arange(z_length, dtype=float), dims='z')

--- a/xbout/tests/test_plot.py
+++ b/xbout/tests/test_plot.py
@@ -1,0 +1,76 @@
+import pytest
+
+from pathlib import Path
+from matplotlib import pyplot as plt
+
+from xbout import open_boutdataset
+from xbout.tests.test_load import bout_xyt_example_files
+from xbout.tests.test_region import (params_guards, params_guards_values,
+                                     params_boundaries, params_boundaries_values)
+
+
+class TestPlot:
+
+    @pytest.mark.parametrize(params_guards, params_guards_values)
+    @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
+    @pytest.mark.parametrize('with_guards', [0, pytest.param(1, marks=pytest.mark.long),
+                                             pytest.param(2, marks=pytest.mark.long)])
+    def test_region_disconnecteddoublenull(self, tmpdir_factory, bout_xyt_example_files,
+                                           guards, keep_xboundaries, keep_yboundaries,
+                                           with_guards):
+        # Note using more than MXG x-direction points and MYG y-direction points per
+        # output file ensures tests for whether boundary cells are present do not fail
+        # when using minimal numbers of processors
+        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 5, 4, 3), nxpe=3,
+                                      nype=6, nt=1, guards=guards, grid='grid',
+                                      topology='disconnected-double-null')
+
+        ds = open_boutdataset(datapath=path,
+                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
+                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
+                              keep_yboundaries=keep_yboundaries)
+
+        n = ds['n'].isel(t=-1, zeta=0)
+
+        n.bout.from_region('lower_inner_PFR', with_guards=with_guards).bout.pcolormesh()
+
+        n.bout.from_region('lower_inner_intersep',
+                           with_guards=with_guards).bout.contourf()
+
+        n.bout.from_region('lower_inner_SOL', with_guards=with_guards).bout.contour()
+
+        plt.figure()
+        n.bout.from_region('inner_core', with_guards=with_guards).plot()
+
+        n.bout.from_region('inner_intersep', with_guards=with_guards).bout.pcolormesh()
+
+        n.bout.from_region('inner_SOL', with_guards=with_guards).bout.contourf()
+
+        n.bout.from_region('upper_inner_PFR', with_guards=with_guards).bout.contour()
+
+        plt.figure()
+        n.bout.from_region('upper_inner_intersep', with_guards=with_guards).plot()
+
+        n.bout.from_region('upper_inner_SOL', with_guards=with_guards).bout.pcolormesh()
+
+        n.bout.from_region('upper_outer_PFR', with_guards=with_guards).bout.contourf()
+
+        n.bout.from_region('upper_outer_intersep',
+                           with_guards=with_guards).bout.contour()
+
+        plt.figure()
+        n.bout.from_region('upper_outer_SOL', with_guards=with_guards).plot()
+
+        n.bout.from_region('outer_core', with_guards=with_guards).bout.pcolormesh()
+
+        n.bout.from_region('outer_intersep', with_guards=with_guards).bout.contourf()
+
+        n.bout.from_region('outer_SOL', with_guards=with_guards).bout.contour()
+
+        plt.figure()
+        n.bout.from_region('lower_outer_PFR', with_guards=with_guards).plot()
+
+        n.bout.from_region('lower_outer_intersep',
+                           with_guards=with_guards).bout.pcolormesh()
+
+        n.bout.from_region('lower_outer_SOL', with_guards=with_guards).bout.contourf()

--- a/xbout/tests/test_plot.py
+++ b/xbout/tests/test_plot.py
@@ -15,20 +15,23 @@ class TestPlot:
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
     @pytest.mark.parametrize('with_guards', [0, pytest.param(1, marks=pytest.mark.long),
                                              pytest.param(2, marks=pytest.mark.long)])
-    def test_region_disconnecteddoublenull(self, tmpdir_factory, bout_xyt_example_files,
+    def test_region_disconnecteddoublenull(self, bout_xyt_example_files,
                                            guards, keep_xboundaries, keep_yboundaries,
                                            with_guards):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 5, 4, 3), nxpe=3,
+        dataset_list, grid_ds = bout_xyt_example_files(None, lengths=(2, 5, 4, 3), nxpe=3,
                                       nype=6, nt=1, guards=guards, grid='grid',
                                       topology='disconnected-double-null')
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
-                              keep_yboundaries=keep_yboundaries)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_xboundaries=keep_xboundaries,
+            keep_yboundaries=keep_yboundaries
+        )
 
         n = ds['n'].isel(t=-1, zeta=0)
 

--- a/xbout/tests/test_plot.py
+++ b/xbout/tests/test_plot.py
@@ -21,9 +21,16 @@ class TestPlot:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        dataset_list, grid_ds = bout_xyt_example_files(None, lengths=(2, 5, 4, 3), nxpe=3,
-                                      nype=6, nt=1, guards=guards, grid='grid',
-                                      topology='disconnected-double-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            None,
+            lengths=(2, 5, 4, 3),
+            nxpe=3,
+            nype=6,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='disconnected-double-null'
+        )
 
         ds = open_boutdataset(
             datapath=dataset_list,

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -49,7 +49,9 @@ class TestRegion:
         n_core = n.bout.from_region('core')
 
         # Remove attributes that are expected to be different
-        del n_core.attrs['region']
+        del n_core.attrs['regions']
+        del n.attrs['regions']
+
         # Select only non-boundary data
         if keep_yboundaries:
             ybndry = guards['y']
@@ -79,7 +81,9 @@ class TestRegion:
         n_sol = n.bout.from_region('SOL')
 
         # Remove attributes that are expected to be different
-        del n_sol.attrs['region']
+        del n_sol.attrs['regions']
+        del n.attrs['regions']
+
         xrt.assert_identical(n, n_sol)
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
@@ -112,16 +116,21 @@ class TestRegion:
             ybndry = 0
 
         n = ds['n']
+        n_noregions = n.copy(deep=False)
+
+        # Remove attributes that are expected to be different
+        del n_noregions.attrs['regions']
 
         n_sol = n.bout.from_region('SOL')
 
         # Remove attributes that are expected to be different
         # Corners may be different because core region 'communicates' in y
-        del n_sol.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs, None)), n_sol.isel(x=slice(mxg, None)))
+        del n_sol.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs, None)),
+                             n_sol.isel(x=slice(mxg, None)))
         xrt.assert_identical(
-                n.isel(x=slice(ixs - mxg, ixs),
-                       theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
+                n_noregions.isel(x=slice(ixs - mxg, ixs),
+                                 theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
                 n_sol.isel(x=slice(mxg),
                            theta=slice(ybndry, -ybndry if ybndry != 0 else None)))
 
@@ -134,10 +143,10 @@ class TestRegion:
         n_core = n.bout.from_region('core')
 
         # Remove attributes that are expected to be different
-        del n_core.attrs['region']
+        del n_core.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs + mxg),
-                       theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
+                n_noregions.isel(x=slice(ixs + mxg),
+                                 theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
                 n_core.isel(theta=slice(ybndry, -ybndry if ybndry != 0 else None)))
 
     @pytest.mark.long
@@ -175,120 +184,132 @@ class TestRegion:
         ny = ds.metadata['ny'] + 4*ybndry
 
         n = ds['n']
+        n_noregions = n.copy(deep=True)
+
+        # Remove attributes that are expected to be different
+        del n_noregions.attrs['regions']
 
         n_lower_inner_PFR = n.bout.from_region('lower_inner_PFR')
 
         # Remove attributes that are expected to be different
-        del n_lower_inner_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys1 + 1)),
+        del n_lower_inner_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs + mxg), theta=slice(jys1 + 1)),
                              n_lower_inner_PFR.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
-                             n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
+                    n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
 
         n_lower_inner_SOL = n.bout.from_region('lower_inner_SOL')
 
         # Remove attributes that are expected to be different
-        del n_lower_inner_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None), theta=slice(jys1 + 1)),
-                             n_lower_inner_SOL.isel(
-                                 theta=slice(-myg if myg != 0 else None)))
+        del n_lower_inner_SOL.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs - mxg, None), theta=slice(jys1 + 1)),
+                n_lower_inner_SOL.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
-                             n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
+                    n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
 
         n_upper_inner_PFR = n.bout.from_region('upper_inner_PFR')
 
         # Remove attributes that are expected to be different
-        del n_upper_inner_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys1 + 1, ny_inner)),
+        del n_upper_inner_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs + mxg),
+                                              theta=slice(jys1 + 1, ny_inner)),
                              n_upper_inner_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
-                             n_upper_inner_PFR.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
+                    n_upper_inner_PFR.isel(theta=slice(myg)).values)
 
         n_upper_inner_SOL = n.bout.from_region('upper_inner_SOL')
 
         # Remove attributes that are expected to be different
-        del n_upper_inner_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys1 + 1, ny_inner)),
+        del n_upper_inner_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs - mxg, None),
+                                              theta=slice(jys1 + 1, ny_inner)),
                              n_upper_inner_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
-                             n_upper_inner_SOL.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
+                    n_upper_inner_SOL.isel(theta=slice(myg)).values)
 
         n_upper_outer_PFR = n.bout.from_region('upper_outer_PFR')
 
         # Remove attributes that are expected to be different
-        del n_upper_outer_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(ny_inner, jys2 + 1)),
+        del n_upper_outer_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs + mxg),
+                                              theta=slice(ny_inner, jys2 + 1)),
                              n_upper_outer_PFR.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
-                             n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
+                    n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
 
         n_upper_outer_SOL = n.bout.from_region('upper_outer_SOL')
 
         # Remove attributes that are expected to be different
-        del n_upper_outer_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(ny_inner, jys2 + 1)),
+        del n_upper_outer_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs - mxg, None),
+                                              theta=slice(ny_inner, jys2 + 1)),
                              n_upper_outer_SOL.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
-                             n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
+                    n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
 
         n_lower_outer_PFR = n.bout.from_region('lower_outer_PFR')
 
         # Remove attributes that are expected to be different
-        del n_lower_outer_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys2 + 1, None)),
+        del n_lower_outer_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs + mxg),
+                                              theta=slice(jys2 + 1, None)),
                              n_lower_outer_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
-                             n_lower_outer_PFR.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
+                    n_lower_outer_PFR.isel(theta=slice(myg)).values)
 
         n_lower_outer_SOL = n.bout.from_region('lower_outer_SOL')
 
         # Remove attributes that are expected to be different
-        del n_lower_outer_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys2 + 1, None)),
+        del n_lower_outer_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs - mxg, None),
+                                              theta=slice(jys2 + 1, None)),
                              n_lower_outer_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
-                             n_lower_outer_SOL.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
+                    n_lower_outer_SOL.isel(theta=slice(myg)).values)
 
     @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
@@ -324,93 +345,107 @@ class TestRegion:
         ny = ds.metadata['ny'] + 2*ybndry
 
         n = ds['n']
+        n_noregions = n.copy(deep=True)
+
+        # Remove attributes that are expected to be different
+        del n_noregions.attrs['regions']
 
         n_inner_PFR = n.bout.from_region('inner_PFR')
 
         # Remove attributes that are expected to be different
-        del n_inner_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys1 + 1)),
+        del n_inner_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs + mxg), theta=slice(jys1 + 1)),
                              n_inner_PFR.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
-                             n_inner_PFR.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
+                    n_inner_PFR.isel(theta=slice(-myg, None)).values)
 
         n_inner_SOL = n.bout.from_region('inner_SOL')
 
         # Remove attributes that are expected to be different
-        del n_inner_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None), theta=slice(jys1 + 1)),
+        del n_inner_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs - mxg, None),
+                                              theta=slice(jys1 + 1)),
                              n_inner_SOL.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
-                             n_inner_SOL.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
+                    n_inner_SOL.isel(theta=slice(-myg, None)).values)
 
         n_core = n.bout.from_region('core')
 
         # Remove attributes that are expected to be different
-        del n_core.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys1 + 1, jys2 + 1)),
-                             n_core.isel(theta=slice(myg, -myg if myg != 0 else None)))
+        del n_core.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs + mxg), theta=slice(jys1 + 1, jys2 + 1)),
+                n_core.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
-                             n_core.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
-                             n_core.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
+                    n_core.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys1 + 1, jys1 + 1 + myg)).values,
+                    n_core.isel(theta=slice(-myg, None)).values)
 
         n_sol = n.bout.from_region('SOL')
 
         # Remove attributes that are expected to be different
-        del n_sol.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys1 + 1, jys2 + 1)),
+        del n_sol.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs - mxg, None),
+                                              theta=slice(jys1 + 1, jys2 + 1)),
                              n_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
-                             n_sol.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
-                             n_sol.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
+                    n_sol.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys2 + 1, jys2 + 1 + myg)).values,
+                    n_sol.isel(theta=slice(-myg, None)).values)
 
         n_outer_PFR = n.bout.from_region('outer_PFR')
 
         # Remove attributes that are expected to be different
-        del n_outer_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys2 + 1, None)),
+        del n_outer_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs + mxg),
+                                              theta=slice(jys2 + 1, None)),
                              n_outer_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
-                             n_outer_PFR.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys1 + 1 - myg, jys1 + 1)).values,
+                    n_outer_PFR.isel(theta=slice(myg)).values)
 
         n_outer_SOL = n.bout.from_region('outer_SOL')
 
         # Remove attributes that are expected to be different
-        del n_outer_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys2 + 1, None)),
+        del n_outer_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs - mxg, None),
+                                              theta=slice(jys2 + 1, None)),
                              n_outer_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
-                             n_outer_SOL.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys2 + 1 - myg, jys2 + 1)).values,
+                    n_outer_SOL.isel(theta=slice(myg)).values)
 
     @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
@@ -449,190 +484,209 @@ class TestRegion:
         ny = ds.metadata['ny'] + 4*ybndry
 
         n = ds['n']
+        n_noregions = n.copy(deep=True)
+
+        # Remove attributes that are expected to be different
+        del n_noregions.attrs['regions']
 
         n_lower_inner_PFR = n.bout.from_region('lower_inner_PFR')
 
         # Remove attributes that are expected to be different
-        del n_lower_inner_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg), theta=slice(jys11 + 1)),
-                             n_lower_inner_PFR.isel(
-                                 theta=slice(-myg if myg != 0 else None)))
+        del n_lower_inner_PFR.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs + mxg), theta=slice(jys11 + 1)),
+                n_lower_inner_PFR.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
-                             n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                    n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
 
         n_lower_inner_SOL = n.bout.from_region('lower_inner_SOL')
 
         # Remove attributes that are expected to be different
-        del n_lower_inner_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None), theta=slice(jys11 + 1)),
-                             n_lower_inner_SOL.isel(
-                                 theta=slice(-myg if myg != 0 else None)))
+        del n_lower_inner_SOL.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs - mxg, None), theta=slice(jys11 + 1)),
+                n_lower_inner_SOL.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
-                             n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                    n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
 
         n_inner_core = n.bout.from_region('inner_core')
 
         # Remove attributes that are expected to be different
-        del n_inner_core.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys11 + 1, jys21 + 1)),
-                             n_inner_core.isel(
-                                 theta=slice(myg, -myg if myg != 0 else None)))
+        del n_inner_core.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs + mxg), theta=slice(jys11 + 1, jys21 + 1)),
+                n_inner_core.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
-                             n_inner_core.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
-                             n_inner_core.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                    n_inner_core.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                    n_inner_core.isel(theta=slice(-myg, None)).values)
 
         n_inner_sol = n.bout.from_region('inner_SOL')
 
         # Remove attributes that are expected to be different
-        del n_inner_sol.attrs['region']
+        del n_inner_sol.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs - mxg, None), theta=slice(jys11 + 1, jys21 + 1)),
+                n_noregions.isel(x=slice(ixs - mxg, None),
+                                 theta=slice(jys11 + 1, jys21 + 1)),
                 n_inner_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
-                             n_inner_sol.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
-                             n_inner_sol.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                    n_inner_sol.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                    n_inner_sol.isel(theta=slice(-myg, None)).values)
 
         n_upper_inner_PFR = n.bout.from_region('upper_inner_PFR')
 
         # Remove attributes that are expected to be different
-        del n_upper_inner_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys21 + 1, ny_inner)),
-                             n_upper_inner_PFR.isel(theta=slice(myg, None)))
+        del n_upper_inner_PFR.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs + mxg), theta=slice(jys21 + 1, ny_inner)),
+                n_upper_inner_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
-                             n_upper_inner_PFR.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                    n_upper_inner_PFR.isel(theta=slice(myg)).values)
 
         n_upper_inner_SOL = n.bout.from_region('upper_inner_SOL')
 
         # Remove attributes that are expected to be different
-        del n_upper_inner_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys21 + 1, ny_inner)),
+        del n_upper_inner_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs - mxg, None),
+                                              theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
-                             n_upper_inner_SOL.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                    n_upper_inner_SOL.isel(theta=slice(myg)).values)
 
         n_upper_outer_PFR = n.bout.from_region('upper_outer_PFR')
 
         # Remove attributes that are expected to be different
-        del n_upper_outer_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(ny_inner, jys12 + 1)),
-                             n_upper_outer_PFR.isel(
-                                 theta=slice(-myg if myg != 0 else None)))
+        del n_upper_outer_PFR.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs + mxg), theta=slice(ny_inner, jys12 + 1)),
+                n_upper_outer_PFR.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
-                             n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                    n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
 
         n_upper_outer_SOL = n.bout.from_region('upper_outer_SOL')
 
         # Remove attributes that are expected to be different
-        del n_upper_outer_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(ny_inner, jys12 + 1)),
+        del n_upper_outer_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs - mxg, None),
+                                              theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_SOL.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
-                             n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                    n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
 
         n_outer_core = n.bout.from_region('outer_core')
 
         # Remove attributes that are expected to be different
-        del n_outer_core.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys12 + 1, jys22 + 1)),
-                             n_outer_core.isel(
-                                 theta=slice(myg, -myg if myg != 0 else None)))
+        del n_outer_core.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs + mxg), theta=slice(jys12 + 1, jys22 + 1)),
+                n_outer_core.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
-                             n_outer_core.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
-                             n_outer_core.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                    n_outer_core.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                    n_outer_core.isel(theta=slice(-myg, None)).values)
 
         n_outer_sol = n.bout.from_region('outer_SOL')
 
         # Remove attributes that are expected to be different
-        del n_outer_sol.attrs['region']
+        del n_outer_sol.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs - mxg, None), theta=slice(jys12 + 1, jys22 + 1)),
+                n_noregions.isel(x=slice(ixs - mxg, None),
+                                 theta=slice(jys12 + 1, jys22 + 1)),
                 n_outer_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
-                             n_outer_sol.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
-                             n_outer_sol.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                    n_outer_sol.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                    n_outer_sol.isel(theta=slice(-myg, None)).values)
 
         n_lower_outer_PFR = n.bout.from_region('lower_outer_PFR')
 
         # Remove attributes that are expected to be different
-        del n_lower_outer_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys22 + 1, None)),
+        del n_lower_outer_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs + mxg),
+                                              theta=slice(jys22 + 1, None)),
                              n_lower_outer_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs + mxg),
-                                    theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
-                             n_lower_outer_PFR.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs + mxg),
+                                     theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                    n_lower_outer_PFR.isel(theta=slice(myg)).values)
 
         n_lower_outer_SOL = n.bout.from_region('lower_outer_SOL')
 
         # Remove attributes that are expected to be different
-        del n_lower_outer_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys22 + 1, None)),
+        del n_lower_outer_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs - mxg, None),
+                                              theta=slice(jys22 + 1, None)),
                              n_lower_outer_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs - mxg, None),
-                                    theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
-                             n_lower_outer_SOL.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs - mxg, None),
+                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                    n_lower_outer_SOL.isel(theta=slice(myg)).values)
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
@@ -675,284 +729,311 @@ class TestRegion:
         ny = ds.metadata['ny'] + 4*ybndry
 
         n = ds['n']
+        n_noregions = n.copy(deep=True)
+
+        # Remove attributes that are expected to be different
+        del n_noregions.attrs['regions']
 
         n_lower_inner_PFR = n.bout.from_region('lower_inner_PFR')
 
         # Remove attributes that are expected to be different
-        del n_lower_inner_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg), theta=slice(jys11 + 1)),
-                             n_lower_inner_PFR.isel(
-                                 theta=slice(-myg if myg != 0 else None)))
+        del n_lower_inner_PFR.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(jys11 + 1)),
+                n_lower_inner_PFR.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
-                             n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + mxg),
+                                     theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                    n_lower_inner_PFR.isel(theta=slice(-myg, None)).values)
 
         n_lower_inner_intersep = n.bout.from_region('lower_inner_intersep')
 
         # Remove attributes that are expected to be different
-        del n_lower_inner_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys11 + 1)),
+        del n_lower_inner_intersep.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                              theta=slice(jys11 + 1)),
                              n_lower_inner_intersep.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
-                             n_lower_inner_intersep.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                     theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                    n_lower_inner_intersep.isel(theta=slice(-myg, None)).values)
 
         n_lower_inner_SOL = n.bout.from_region('lower_inner_SOL')
 
         # Remove attributes that are expected to be different
-        del n_lower_inner_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1)),
-                             n_lower_inner_SOL.isel(
-                                 theta=slice(-myg if myg != 0 else None)))
+        del n_lower_inner_SOL.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1)),
+                n_lower_inner_SOL.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
-                             n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                     theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                    n_lower_inner_SOL.isel(theta=slice(-myg, None)).values)
 
         n_inner_core = n.bout.from_region('inner_core')
 
         # Remove attributes that are expected to be different
-        del n_inner_core.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys11 + 1, jys21 + 1)),
-                             n_inner_core.isel(
-                                 theta=slice(myg, -myg if myg != 0 else None)))
+        del n_inner_core.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(jys11 + 1, jys21 + 1)),
+                n_inner_core.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
-                             n_inner_core.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
-                             n_inner_core.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + mxg),
+                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                    n_inner_core.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + mxg),
+                                     theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                    n_inner_core.isel(theta=slice(-myg, None)).values)
 
         n_inner_intersep = n.bout.from_region('inner_intersep')
 
         # Remove attributes that are expected to be different
-        del n_inner_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys11 + 1, jys21 + 1)),
+        del n_inner_intersep.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                              theta=slice(jys11 + 1, jys21 + 1)),
                              n_inner_intersep.isel(
                                  theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
-                             n_inner_intersep.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                     theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                    n_inner_intersep.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                     theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
                              n_inner_intersep.isel(theta=slice(-myg, None)).values)
 
         n_inner_sol = n.bout.from_region('inner_SOL')
 
         # Remove attributes that are expected to be different
-        del n_inner_sol.attrs['region']
+        del n_inner_sol.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1, jys21 + 1)),
+                n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                 theta=slice(jys11 + 1, jys21 + 1)),
                 n_inner_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
-                             n_inner_sol.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
-                             n_inner_sol.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                     theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                    n_inner_sol.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                     theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                    n_inner_sol.isel(theta=slice(-myg, None)).values)
 
         n_upper_inner_PFR = n.bout.from_region('upper_inner_PFR')
 
         # Remove attributes that are expected to be different
-        del n_upper_inner_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys21 + 1, ny_inner)),
+        del n_upper_inner_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 + mxg),
+                                              theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
-                             n_upper_inner_PFR.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + mxg),
+                                     theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                    n_upper_inner_PFR.isel(theta=slice(myg)).values)
 
         n_upper_inner_intersep = n.bout.from_region('upper_inner_intersep')
 
         # Remove attributes that are expected to be different
-        del n_upper_inner_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys21 + 1, ny_inner)),
+        del n_upper_inner_intersep.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                              theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_intersep.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
-                             n_upper_inner_intersep.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                     theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                    n_upper_inner_intersep.isel(theta=slice(myg)).values)
 
         n_upper_inner_SOL = n.bout.from_region('upper_inner_SOL')
 
         # Remove attributes that are expected to be different
-        del n_upper_inner_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys21 + 1, ny_inner)),
+        del n_upper_inner_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                              theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
-                             n_upper_inner_SOL.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                     theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                    n_upper_inner_SOL.isel(theta=slice(myg)).values)
 
         n_upper_outer_PFR = n.bout.from_region('upper_outer_PFR')
 
         # Remove attributes that are expected to be different
-        del n_upper_outer_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(ny_inner, jys12 + 1)),
-                             n_upper_outer_PFR.isel(
-                                 theta=slice(-myg if myg != 0 else None)))
+        del n_upper_outer_PFR.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(ny_inner, jys12 + 1)),
+                n_upper_outer_PFR.isel(theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
-                             n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + mxg),
+                                     theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                    n_upper_outer_PFR.isel(theta=slice(-myg, None)).values)
 
         n_upper_outer_intersep = n.bout.from_region('upper_outer_intersep')
 
         # Remove attributes that are expected to be different
-        del n_upper_outer_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(ny_inner, jys12 + 1)),
+        del n_upper_outer_intersep.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                              theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_intersep.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
-                             n_upper_outer_intersep.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                     theta=slice(jys21 + 1, jys21 + 1 + myg)).values,
+                    n_upper_outer_intersep.isel(theta=slice(-myg, None)).values)
 
         n_upper_outer_SOL = n.bout.from_region('upper_outer_SOL')
 
         # Remove attributes that are expected to be different
-        del n_upper_outer_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(ny_inner, jys12 + 1)),
+        del n_upper_outer_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                              theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_SOL.isel(
                                  theta=slice(-myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
-                             n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                     theta=slice(jys12 + 1, jys12 + 1 + myg)).values,
+                    n_upper_outer_SOL.isel(theta=slice(-myg, None)).values)
 
         n_outer_core = n.bout.from_region('outer_core')
 
         # Remove attributes that are expected to be different
-        del n_outer_core.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys12 + 1, jys22 + 1)),
-                             n_outer_core.isel(
-                                 theta=slice(myg, -myg if myg != 0 else None)))
+        del n_outer_core.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(jys12 + 1, jys22 + 1)),
+                n_outer_core.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
-                             n_outer_core.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
-                             n_outer_core.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + mxg),
+                                     theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                    n_outer_core.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + mxg),
+                                     theta=slice(jys11 + 1, jys11 + 1 + myg)).values,
+                    n_outer_core.isel(theta=slice(-myg, None)).values)
 
         n_outer_intersep = n.bout.from_region('outer_intersep')
 
         # Remove attributes that are expected to be different
-        del n_outer_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys12 + 1, jys22 + 1)),
+        del n_outer_intersep.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                              theta=slice(jys12 + 1, jys22 + 1)),
                              n_outer_intersep.isel(
                                  theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
-                             n_outer_intersep.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
-                             n_outer_intersep.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                     theta=slice(jys21 + 1 - myg, jys21 + 1)).values,
+                    n_outer_intersep.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                     theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                    n_outer_intersep.isel(theta=slice(-myg, None)).values)
 
         n_outer_sol = n.bout.from_region('outer_SOL')
 
         # Remove attributes that are expected to be different
-        del n_outer_sol.attrs['region']
+        del n_outer_sol.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs2 - mxg, None), theta=slice(jys12 + 1, jys22 + 1)),
+                n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                 theta=slice(jys12 + 1, jys22 + 1)),
                 n_outer_sol.isel(theta=slice(myg, -myg if myg != 0 else None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
-                             n_outer_sol.isel(theta=slice(myg)).values)
-            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
-                             n_outer_sol.isel(theta=slice(-myg, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                     theta=slice(jys12 + 1 - myg, jys12 + 1)).values,
+                    n_outer_sol.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                     theta=slice(jys22 + 1, jys22 + 1 + myg)).values,
+                    n_outer_sol.isel(theta=slice(-myg, None)).values)
 
         n_lower_outer_PFR = n.bout.from_region('lower_outer_PFR')
 
         # Remove attributes that are expected to be different
-        del n_lower_outer_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys22 + 1, None)),
-                             n_lower_outer_PFR.isel(theta=slice(myg, None)))
+        del n_lower_outer_PFR.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(jys22 + 1, None)),
+                n_lower_outer_PFR.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + mxg),
-                                    theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
-                             n_lower_outer_PFR.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + mxg),
+                                     theta=slice(jys11 + 1 - myg, jys11 + 1)).values,
+                    n_lower_outer_PFR.isel(theta=slice(myg)).values)
 
         n_lower_outer_intersep = n.bout.from_region('lower_outer_intersep')
 
         # Remove attributes that are expected to be different
-        del n_lower_outer_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys22 + 1, None)),
+        del n_lower_outer_intersep.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                              theta=slice(jys22 + 1, None)),
                              n_lower_outer_intersep.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
-                                    theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
-                             n_lower_outer_intersep.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg),
+                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                    n_lower_outer_intersep.isel(theta=slice(myg)).values)
 
         n_lower_outer_SOL = n.bout.from_region('lower_outer_SOL')
 
         # Remove attributes that are expected to be different
-        del n_lower_outer_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys22 + 1, None)),
+        del n_lower_outer_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                              theta=slice(jys22 + 1, None)),
                              n_lower_outer_SOL.isel(theta=slice(myg, None)))
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - mxg, None),
-                                    theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
-                             n_lower_outer_SOL.isel(theta=slice(myg)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - mxg, None),
+                                     theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
+                    n_lower_outer_SOL.isel(theta=slice(myg)).values)
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
@@ -1005,300 +1086,329 @@ class TestRegion:
             yguards = with_guards
 
         n = ds['n']
+        n_noregions = n.copy(deep=True)
+
+        # Remove attributes that are expected to be different
+        del n_noregions.attrs['regions']
 
         n_lower_inner_PFR = n.bout.from_region('lower_inner_PFR',
                                                with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_lower_inner_PFR.attrs['region']
+        del n_lower_inner_PFR.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs1 + xguards), theta=slice(jys11 + 1)),
+                n_noregions.isel(x=slice(ixs1 + xguards), theta=slice(jys11 + 1)),
                 n_lower_inner_PFR.isel(theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
-                             n_lower_inner_PFR.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + xguards),
+                                     theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
+                    n_lower_inner_PFR.isel(theta=slice(-yguards, None)).values)
 
         n_lower_inner_intersep = n.bout.from_region('lower_inner_intersep',
                                                     with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_lower_inner_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys11 + 1)),
+        del n_lower_inner_intersep.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                              theta=slice(jys11 + 1)),
                              n_lower_inner_intersep.isel(
                                  theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
-                    n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                           theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
+                    n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                     theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
                     n_lower_inner_intersep.isel(theta=slice(-yguards, None)).values)
 
         n_lower_inner_SOL = n.bout.from_region('lower_inner_SOL',
                                                with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_lower_inner_SOL.attrs['region']
+        del n_lower_inner_SOL.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs2 - xguards, None), theta=slice(jys11 + 1)),
+                n_noregions.isel(x=slice(ixs2 - xguards, None), theta=slice(jys11 + 1)),
                 n_lower_inner_SOL.isel(theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
-                             n_lower_inner_SOL.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                     theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
+                    n_lower_inner_SOL.isel(theta=slice(-yguards, None)).values)
 
         n_inner_core = n.bout.from_region('inner_core', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_inner_core.attrs['region']
+        del n_inner_core.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs1 + xguards), theta=slice(jys11 + 1, jys21 + 1)),
+                n_noregions.isel(x=slice(ixs1 + xguards),
+                                 theta=slice(jys11 + 1, jys21 + 1)),
                 n_inner_core.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
-                             n_inner_core.isel(theta=slice(yguards)).values)
-            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
-                             n_inner_core.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + xguards),
+                                     theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
+                    n_inner_core.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + xguards),
+                                     theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
+                    n_inner_core.isel(theta=slice(-yguards, None)).values)
 
         n_inner_intersep = n.bout.from_region('inner_intersep', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_inner_intersep.attrs['region']
+        del n_inner_intersep.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                       theta=slice(jys11 + 1, jys21 + 1)),
+                n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                 theta=slice(jys11 + 1, jys21 + 1)),
                 n_inner_intersep.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
-                             n_inner_intersep.isel(theta=slice(yguards)).values)
-            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
-                             n_inner_intersep.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                     theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
+                    n_inner_intersep.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                     theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
+                    n_inner_intersep.isel(theta=slice(-yguards, None)).values)
 
         n_inner_sol = n.bout.from_region('inner_SOL', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_inner_sol.attrs['region']
+        del n_inner_sol.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs2 - xguards, None), theta=slice(jys11 + 1, jys21 + 1)),
+                n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                 theta=slice(jys11 + 1, jys21 + 1)),
                 n_inner_sol.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
-                             n_inner_sol.isel(theta=slice(yguards)).values)
-            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
-                             n_inner_sol.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                     theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
+                    n_inner_sol.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                     theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
+                    n_inner_sol.isel(theta=slice(-yguards, None)).values)
 
         n_upper_inner_PFR = n.bout.from_region('upper_inner_PFR',
                                                with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_upper_inner_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys21 + 1, ny_inner)),
+        del n_upper_inner_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 + xguards),
+                                              theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_PFR.isel(theta=slice(yguards, None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
-                             n_upper_inner_PFR.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + xguards),
+                                     theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
+                    n_upper_inner_PFR.isel(theta=slice(yguards)).values)
 
         n_upper_inner_intersep = n.bout.from_region('upper_inner_intersep',
                                                     with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_upper_inner_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys21 + 1, ny_inner)),
+        del n_upper_inner_intersep.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                              theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_intersep.isel(theta=slice(yguards, None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
-                             n_upper_inner_intersep.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                     theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
+                    n_upper_inner_intersep.isel(theta=slice(yguards)).values)
 
         n_upper_inner_SOL = n.bout.from_region('upper_inner_SOL',
                                                with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_upper_inner_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys21 + 1, ny_inner)),
+        del n_upper_inner_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                              theta=slice(jys21 + 1, ny_inner)),
                              n_upper_inner_SOL.isel(theta=slice(yguards, None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
-                             n_upper_inner_SOL.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                     theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
+                    n_upper_inner_SOL.isel(theta=slice(yguards)).values)
 
         n_upper_outer_PFR = n.bout.from_region('upper_outer_PFR',
                                                with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_upper_outer_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(ny_inner, jys12 + 1)),
+        del n_upper_outer_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 + xguards),
+                                              theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_PFR.isel(
                                  theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
-                             n_upper_outer_PFR.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + xguards),
+                                     theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
+                    n_upper_outer_PFR.isel(theta=slice(-yguards, None)).values)
 
         n_upper_outer_intersep = n.bout.from_region('upper_outer_intersep',
                                                     with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_upper_outer_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(ny_inner, jys12 + 1)),
+        del n_upper_outer_intersep.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                              theta=slice(ny_inner, jys12 + 1)),
                              n_upper_outer_intersep.isel(
                                  theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
-                             n_upper_outer_intersep.isel(
-                                 theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                     theta=slice(jys21 + 1, jys21 + 1 + yguards)).values,
+                    n_upper_outer_intersep.isel(theta=slice(-yguards, None)).values)
 
         n_upper_outer_SOL = n.bout.from_region('upper_outer_SOL',
                                                with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_upper_outer_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(ny_inner, jys12 + 1)),
-                             n_upper_outer_SOL.isel(
-                                 theta=slice(-yguards if yguards != 0 else None)))
+        del n_upper_outer_SOL.attrs['regions']
+        xrt.assert_identical(
+                n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                 theta=slice(ny_inner, jys12 + 1)),
+                n_upper_outer_SOL.isel(theta=slice(-yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
-                             n_upper_outer_SOL.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                     theta=slice(jys12 + 1, jys12 + 1 + yguards)).values,
+                    n_upper_outer_SOL.isel(theta=slice(-yguards, None)).values)
 
         n_outer_core = n.bout.from_region('outer_core', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_outer_core.attrs['region']
+        del n_outer_core.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs1 + xguards), theta=slice(jys12 + 1, jys22 + 1)),
+                n_noregions.isel(x=slice(ixs1 + xguards),
+                                 theta=slice(jys12 + 1, jys22 + 1)),
                 n_outer_core.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
-                             n_outer_core.isel(theta=slice(yguards)).values)
-            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
-                             n_outer_core.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + xguards),
+                                     theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
+                    n_outer_core.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + xguards),
+                                     theta=slice(jys11 + 1, jys11 + 1 + yguards)).values,
+                    n_outer_core.isel(theta=slice(-yguards, None)).values)
 
         n_outer_intersep = n.bout.from_region('outer_intersep', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_outer_intersep.attrs['region']
+        del n_outer_intersep.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                       theta=slice(jys12 + 1, jys22 + 1)),
+                n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                 theta=slice(jys12 + 1, jys22 + 1)),
                 n_outer_intersep.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
-                             n_outer_intersep.isel(theta=slice(yguards)).values)
-            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
-                             n_outer_intersep.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                     theta=slice(jys21 + 1 - yguards, jys21 + 1)).values,
+                    n_outer_intersep.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                     theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
+                    n_outer_intersep.isel(theta=slice(-yguards, None)).values)
 
         n_outer_sol = n.bout.from_region('outer_SOL', with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_outer_sol.attrs['region']
+        del n_outer_sol.attrs['regions']
         xrt.assert_identical(
-                n.isel(x=slice(ixs2 - xguards, None), theta=slice(jys12 + 1, jys22 + 1)),
+                n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                 theta=slice(jys12 + 1, jys22 + 1)),
                 n_outer_sol.isel(
                     theta=slice(yguards, -yguards if yguards != 0 else None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
-                             n_outer_sol.isel(theta=slice(yguards)).values)
-            npt.assert_equal(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
-                             n_outer_sol.isel(theta=slice(-yguards, None)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                     theta=slice(jys12 + 1 - yguards, jys12 + 1)).values,
+                    n_outer_sol.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                     theta=slice(jys22 + 1, jys22 + 1 + yguards)).values,
+                    n_outer_sol.isel(theta=slice(-yguards, None)).values)
 
         n_lower_outer_PFR = n.bout.from_region('lower_outer_PFR',
                                                with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_lower_outer_PFR.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys22 + 1, None)),
+        del n_lower_outer_PFR.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 + xguards),
+                                              theta=slice(jys22 + 1, None)),
                              n_lower_outer_PFR.isel(theta=slice(yguards, None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 + xguards),
-                                    theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
-                             n_lower_outer_PFR.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 + xguards),
+                                     theta=slice(jys11 + 1 - yguards, jys11 + 1)).values,
+                    n_lower_outer_PFR.isel(theta=slice(yguards)).values)
 
         n_lower_outer_intersep = n.bout.from_region('lower_outer_intersep',
                                                     with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_lower_outer_intersep.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys22 + 1, None)),
+        del n_lower_outer_intersep.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                              theta=slice(jys22 + 1, None)),
                              n_lower_outer_intersep.isel(theta=slice(yguards, None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(n.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
-                                    theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
-                             n_lower_outer_intersep.isel(theta=slice(yguards)).values)
+            npt.assert_equal(
+                    n_noregions.isel(x=slice(ixs1 - xguards, ixs2 + xguards),
+                                     theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
+                    n_lower_outer_intersep.isel(theta=slice(yguards)).values)
 
         n_lower_outer_SOL = n.bout.from_region('lower_outer_SOL',
                                                with_guards=with_guards)
 
         # Remove attributes that are expected to be different
-        del n_lower_outer_SOL.attrs['region']
-        xrt.assert_identical(n.isel(x=slice(ixs2 - xguards, None),
-                                    theta=slice(jys22 + 1, None)),
+        del n_lower_outer_SOL.attrs['regions']
+        xrt.assert_identical(n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                              theta=slice(jys22 + 1, None)),
                              n_lower_outer_SOL.isel(theta=slice(yguards, None)))
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
-                    n.isel(x=slice(ixs2 - xguards, None),
-                           theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
+                    n_noregions.isel(x=slice(ixs2 - xguards, None),
+                                     theta=slice(jys22 + 1 - yguards, jys22 + 1)).values,
                     n_lower_outer_SOL.isel(theta=slice(yguards)).values)


### PR DESCRIPTION
Two features, with commits mixed up because it seems like more trouble than it's worth to un-mix them.

Allow `BoutDataArray`s returned by `from_region()` to be used more like regular `BoutDataArray`s - e.g. plotted, etc. Requires making a sensible `"regions"` attribute (list containing just the selected region) of the returned single-region `BoutDataArray` instead of using a separate `"region"` attribute.

Method to drop the y-boundary cells. This is convenient when there are two targets because the 'upper' target is complicated to cut out as it's not just at the edges of the array.

Note: only about 300 lines of actual code changed, the rest are knock-on changes to tests, mostly getting rid of uses of `"region"` attribute.

~~WIP: should now merge #132 first.~~