### PR TITLE
List of Datasets argument to open_boutdataset()

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -531,8 +531,6 @@ def _arrange_for_concatenation(filepaths, nxpe=1, nype=1):
 
     # Create list of lists of filepaths, so that xarray knows how they should
     # be concatenated by xarray.open_mfdataset()
-    # Only possible with this Pull Request to xarray
-    # https://github.com/pydata/xarray/pull/2553
     paths = iter(filepaths)
     paths_grid = [[[next(paths) for x in range(nxpe)]
                                 for y in range(nype)]
@@ -573,8 +571,6 @@ def _trim(ds, *, guards, keep_boundaries, nxpe, nype):
 
     if any(keep_boundaries.values()):
         # Work out if this particular dataset contains any boundary cells
-        # Relies on a change to xarray so datasets always have source encoding
-        # See xarray GH issue #2550
         lower_boundaries, upper_boundaries = _infer_contains_boundaries(
             ds, nxpe, nype)
     else:

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -1,6 +1,7 @@
 from copy import copy
 from warnings import warn
 from pathlib import Path
+from py._path.local import LocalPath
 from functools import partial
 from itertools import chain
 
@@ -51,13 +52,17 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
 
     Parameters
     ----------
-    datapath : str, optional
+    datapath : str or (list or tuple of xr.Dataset), optional
         Path to the data to open. Can point to either a set of one or more dump
         files, or a single grid file.
 
         To specify multiple dump files you must enter the path to them as a
         single glob, e.g. './BOUT.dmp.*.nc', or for multiple consecutive runs
         in different directories (in order) then './run*/BOUT.dmp.*.nc'.
+
+        If a list or tuple of xr.Dataset is passed, they will be combined with
+        xr.combine_nested() instead of loading data from disk (intended for unit
+        testing).
     chunks : dict, optional
     inputfilepath : str, optional
     geometry : str, optional
@@ -105,8 +110,11 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
         chunks = {}
 
     if pre_squashed:
-        ds = xr.open_mfdataset(datapath, chunks=chunks, combine='nested',
-                               concat_dim=None, **kwargs)
+        if isinstance(datapath, (str, Path, LocalPath)):
+            ds = xr.open_mfdataset(datapath, chunks=chunks, combine='nested',
+                                   concat_dim=None, **kwargs)
+        else:
+            ds = xr.combine_nested(datapath)
     else:
         # Determine if file is a grid file or data dump files
         if _is_dump_files(datapath):
@@ -360,6 +368,17 @@ def _is_dump_files(datapath):
     grid file. Else assume we have one or more dump files.
     """
 
+    if not isinstance(datapath, (str, Path, LocalPath)):
+        if isinstance(datapath, xr.Dataset):
+            # Has time dimension, so is not a grid Dataset
+            return "t" in datapath.dims
+        elif len(datapath) > 1:
+            # List with multiple Datasets, so is not a grid Dataset
+            return True
+        else:
+            # Single element list of Datasets, or nested list of Datasets
+            return _is_dump_files(datapath[0])
+
     filepaths, filetype = _expand_filepaths(datapath)
 
     if len(filepaths) == 1:
@@ -377,22 +396,50 @@ def _auto_open_mfboutdataset(datapath, chunks=None, info=True,
     if chunks is None:
         chunks = {}
 
-    filepaths, filetype = _expand_filepaths(datapath)
+    if isinstance(datapath, (str, Path, LocalPath)):
+        filepaths, filetype = _expand_filepaths(datapath)
 
-    # Open just one file to read processor splitting
-    nxpe, nype, mxg, myg, mxsub, mysub = _read_splitting(filepaths[0], info)
+        # Open just one file to read processor splitting
+        nxpe, nype, mxg, myg, mxsub, mysub = _read_splitting(filepaths[0], info)
 
-    paths_grid, concat_dims = _arrange_for_concatenation(filepaths, nxpe, nype)
+        _preprocess = partial(_trim, guards={'x': mxg, 'y': myg},
+                              keep_boundaries={'x': keep_xboundaries,
+                                               'y': keep_yboundaries},
+                              nxpe=nxpe, nype=nype)
 
-    _preprocess = partial(_trim, guards={'x': mxg, 'y': myg},
-                          keep_boundaries={'x': keep_xboundaries,
-                                           'y': keep_yboundaries},
-                          nxpe=nxpe, nype=nype)
+        paths_grid, concat_dims = _arrange_for_concatenation(filepaths, nxpe, nype)
 
-    ds = xr.open_mfdataset(paths_grid, concat_dim=concat_dims, combine='nested',
-                           data_vars=_BOUT_TIME_DEPENDENT_META_VARS,
-                           preprocess=_preprocess, engine=filetype,
-                           chunks=chunks, join='exact', **kwargs)
+        ds = xr.open_mfdataset(paths_grid, concat_dim=concat_dims, combine='nested',
+                               data_vars=_BOUT_TIME_DEPENDENT_META_VARS,
+                               preprocess=_preprocess, engine=filetype,
+                               chunks=chunks, join='exact', **kwargs)
+    else:
+        # datapath was nested list of Datasets
+
+        if isinstance(datapath, xr.Dataset):
+            # normalise as one-element list
+            datapath = [datapath]
+
+        mxg = int(datapath[0]["MXG"])
+        myg = int(datapath[0]["MYG"])
+        nxpe = int(datapath[0]["NXPE"])
+        nype = int(datapath[0]["NYPE"])
+
+        _preprocess = partial(_trim, guards={'x': mxg, 'y': myg},
+                              keep_boundaries={'x': keep_xboundaries,
+                                               'y': keep_yboundaries},
+                              nxpe=nxpe, nype=nype)
+
+        datapath = [_preprocess(x) for x in datapath]
+
+        ds_grid, concat_dims = _arrange_for_concatenation(datapath, nxpe, nype)
+
+        ds = xr.combine_nested(
+            ds_grid,
+            concat_dim=concat_dims,
+            data_vars=_BOUT_TIME_DEPENDENT_META_VARS,
+            join="exact"
+        )
 
     # Remove any duplicate time values from concatenation
     _, unique_indices = unique(ds['t_array'], return_index=True)
@@ -675,8 +722,11 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2):
     for dim in unrecognised_chunk_dims:
         del grid_chunks[dim]
 
-    gridfilepath = Path(datapath)
-    grid = xr.open_dataset(gridfilepath, engine=_check_filetype(gridfilepath))
+    if isinstance(datapath, (str, Path, LocalPath)):
+        gridfilepath = Path(datapath)
+        grid = xr.open_dataset(gridfilepath, engine=_check_filetype(gridfilepath))
+    else:
+        grid = datapath
 
     # TODO find out what 'yup_xsplit' etc are in the doublenull storm file John gave me
     # For now drop any variables with extra dimensions

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -17,8 +17,10 @@ from xbout.geometries import apply_geometry
 class TestBoutDataArrayMethods:
 
     def test_to_dataset(self, tmpdir_factory, bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, nxpe=3, nype=4, nt=1)
-        ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
+        dataset_list = bout_xyt_example_files(tmpdir_factory, nxpe=3, nype=4, nt=1)
+        ds = open_boutdataset(
+            datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+        )
         da = ds['n']
 
         new_ds = da.bout.to_dataset()
@@ -31,9 +33,12 @@ class TestBoutDataArrayMethods:
                                     pytest.param(8, marks=pytest.mark.long),
                                     pytest.param(9, marks=pytest.mark.long)])
     def test_to_field_aligned(self, tmpdir_factory, bout_xyt_example_files, nz):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1,
-                                      nype=1, nt=1)
-        ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
+        dataset_list = bout_xyt_example_files(
+            tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
+        )
+        ds = open_boutdataset(
+            datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+        )
 
         ds['psixy'] = ds['x']
         ds['Rxy'] = ds['x']
@@ -82,9 +87,12 @@ class TestBoutDataArrayMethods:
 
         nz = 6
 
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1,
-                                      nype=1, nt=1)
-        ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
+        dataset_list = bout_xyt_example_files(
+            tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
+        )
+        ds = open_boutdataset(
+            datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+        )
 
         ds['psixy'] = ds['x']
         ds['Rxy'] = ds['x']
@@ -139,9 +147,12 @@ class TestBoutDataArrayMethods:
                                     pytest.param(8, marks=pytest.mark.long),
                                     pytest.param(9, marks=pytest.mark.long)])
     def test_from_field_aligned(self, tmpdir_factory, bout_xyt_example_files, nz):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1,
-                                      nype=1, nt=1)
-        ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
+        dataset_list = bout_xyt_example_files(
+            tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
+        )
+        ds = open_boutdataset(
+            datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+        )
 
         ds['psixy'] = ds['x']
         ds['Rxy'] = ds['x']
@@ -189,9 +200,12 @@ class TestBoutDataArrayMethods:
     @pytest.mark.parametrize('stag_location', ['CELL_XLOW', 'CELL_YLOW', 'CELL_ZLOW'])
     def test_to_field_aligned_staggered(self, tmpdir_factory, bout_xyt_example_files,
                                         stag_location):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 8), nxpe=1,
-                                      nype=1, nt=1)
-        ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
+        dataset_list = bout_xyt_example_files(
+            tmpdir_factory, lengths=(3, 3, 4, 8), nxpe=1, nype=1, nt=1
+        )
+        ds = open_boutdataset(
+            datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+        )
 
         ds['psixy'] = ds['x']
         ds['Rxy'] = ds['x']
@@ -234,9 +248,12 @@ class TestBoutDataArrayMethods:
     @pytest.mark.parametrize('stag_location', ['CELL_XLOW', 'CELL_YLOW', 'CELL_ZLOW'])
     def test_from_field_aligned_staggered(self, tmpdir_factory, bout_xyt_example_files,
                                           stag_location):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(3, 3, 4, 8), nxpe=1,
-                                      nype=1, nt=1)
-        ds = open_boutdataset(datapath=path, inputfilepath=None, keep_xboundaries=False)
+        dataset_list = bout_xyt_example_files(
+            tmpdir_factory, lengths=(3, 3, 4, 8), nxpe=1, nype=1, nt=1
+        )
+        ds = open_boutdataset(
+            datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+        )
 
         ds['psixy'] = ds['x']
         ds['Rxy'] = ds['x']
@@ -281,13 +298,23 @@ class TestBoutDataArrayMethods:
     @pytest.mark.long
     def test_interpolate_parallel_region_core(self, tmpdir_factory,
                                               bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=1, nt=1, grid='grid', guards={'y': 2},
-                                      topology='core')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 16, 3),
+            nxpe=1,
+            nype=1,
+            nt=1,
+            grid='grid',
+            guards={'y': 2},
+            topology='core'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_yboundaries=True)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_yboundaries=True
+        )
 
         n = ds['n']
 
@@ -321,13 +348,23 @@ class TestBoutDataArrayMethods:
     def test_interpolate_parallel_region_core_change_n(self, tmpdir_factory,
                                                        bout_xyt_example_files,
                                                        res_factor):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=1, nt=1, grid='grid', guards={'y': 2},
-                                      topology='core')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 16, 3),
+            nxpe=1,
+            nype=1,
+            nt=1,
+            grid='grid',
+            guards={'y': 2},
+            topology='core'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_yboundaries=True)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_yboundaries=True
+        )
 
         n = ds['n']
 
@@ -358,13 +395,23 @@ class TestBoutDataArrayMethods:
     @pytest.mark.long
     def test_interpolate_parallel_region_sol(self, tmpdir_factory,
                                              bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=1, nt=1, grid='grid', guards={'y': 2},
-                                      topology='sol')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 16, 3),
+            nxpe=1,
+            nype=1,
+            nt=1,
+            grid='grid',
+            guards={'y': 2},
+            topology='sol'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_yboundaries=True)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_yboundaries=True
+        )
 
         n = ds['n']
 
@@ -393,13 +440,23 @@ class TestBoutDataArrayMethods:
 
     def test_interpolate_parallel_region_singlenull(self, tmpdir_factory,
                                                     bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=3, nt=1, grid='grid', guards={'y': 2},
-                                      topology='single-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 16, 3),
+            nxpe=1,
+            nype=3,
+            nt=1,
+            grid='grid',
+            guards={'y': 2},
+            topology='single-null'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_yboundaries=True)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_yboundaries=True
+        )
 
         n = ds['n']
 
@@ -444,13 +501,23 @@ class TestBoutDataArrayMethods:
             npt.assert_allclose(n_highres.values, expected.values, rtol=0., atol=1.e-2)
 
     def test_interpolate_parallel(self, tmpdir_factory, bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=3, nt=1, grid='grid', guards={'y': 2},
-                                      topology='single-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 16, 3),
+            nxpe=1,
+            nype=3,
+            nt=1,
+            grid='grid',
+            guards={'y': 2},
+            topology='single-null'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_yboundaries=True)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_yboundaries=True
+        )
 
         n = ds['n']
 
@@ -484,13 +551,23 @@ class TestBoutDataArrayMethods:
                             rtol=0., atol=1.1e-2)
 
     def test_interpolate_parallel_sol(self, tmpdir_factory, bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=1, nt=1, grid='grid', guards={'y': 2},
-                                      topology='sol')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 16, 3),
+            nxpe=1,
+            nype=1,
+            nt=1,
+            grid='grid',
+            guards={'y': 2},
+            topology='sol'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_yboundaries=True)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_yboundaries=True
+        )
 
         n = ds['n']
 
@@ -525,13 +602,23 @@ class TestBoutDataArrayMethods:
 
     def test_interpolate_parallel_toroidal_points(self, tmpdir_factory,
                                                   bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=3, nt=1, grid='grid', guards={'y': 2},
-                                      topology='single-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 16, 3),
+            nxpe=1,
+            nype=3,
+            nt=1,
+            grid='grid',
+            guards={'y': 2},
+            topology='single-null'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_yboundaries=True)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_yboundaries=True
+        )
 
         n_highres = ds['n'].bout.interpolate_parallel()
 
@@ -541,13 +628,23 @@ class TestBoutDataArrayMethods:
 
     def test_interpolate_parallel_toroidal_points_list(self, tmpdir_factory,
                                                        bout_xyt_example_files):
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 16, 3), nxpe=1,
-                                      nype=3, nt=1, grid='grid', guards={'y': 2},
-                                      topology='single-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 16, 3),
+            nxpe=1,
+            nype=3,
+            nt=1,
+            grid='grid',
+            guards={'y': 2},
+            topology='single-null'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_yboundaries=True)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_yboundaries=True
+        )
 
         n_highres = ds['n'].bout.interpolate_parallel()
 

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -16,8 +16,8 @@ from xbout.geometries import apply_geometry
 
 class TestBoutDataArrayMethods:
 
-    def test_to_dataset(self, tmpdir_factory, bout_xyt_example_files):
-        dataset_list = bout_xyt_example_files(tmpdir_factory, nxpe=3, nype=4, nt=1)
+    def test_to_dataset(self, bout_xyt_example_files):
+        dataset_list = bout_xyt_example_files(None, nxpe=3, nype=4, nt=1)
         ds = open_boutdataset(
             datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
         )
@@ -32,9 +32,9 @@ class TestBoutDataArrayMethods:
                                     7,
                                     pytest.param(8, marks=pytest.mark.long),
                                     pytest.param(9, marks=pytest.mark.long)])
-    def test_to_field_aligned(self, tmpdir_factory, bout_xyt_example_files, nz):
+    def test_to_field_aligned(self, bout_xyt_example_files, nz):
         dataset_list = bout_xyt_example_files(
-            tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
+            None, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
         )
         ds = open_boutdataset(
             datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
@@ -83,12 +83,12 @@ class TestBoutDataArrayMethods:
             for z in range(nz):
                 npt.assert_allclose(n_al[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z + 7) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
-    def test_to_field_aligned_dask(self, tmpdir_factory, bout_xyt_example_files):
+    def test_to_field_aligned_dask(self, bout_xyt_example_files):
 
         nz = 6
 
         dataset_list = bout_xyt_example_files(
-            tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
+            None, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
         )
         ds = open_boutdataset(
             datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
@@ -146,9 +146,9 @@ class TestBoutDataArrayMethods:
                                     7,
                                     pytest.param(8, marks=pytest.mark.long),
                                     pytest.param(9, marks=pytest.mark.long)])
-    def test_from_field_aligned(self, tmpdir_factory, bout_xyt_example_files, nz):
+    def test_from_field_aligned(self, bout_xyt_example_files, nz):
         dataset_list = bout_xyt_example_files(
-            tmpdir_factory, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
+            None, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
         )
         ds = open_boutdataset(
             datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
@@ -198,10 +198,10 @@ class TestBoutDataArrayMethods:
                 npt.assert_allclose(n_nal[t, 1, 3, z].values, 1000.*t + 100.*1 + 10.*3. + (z - 7) % nz, rtol=1.e-15, atol=0.)  # noqa: E501
 
     @pytest.mark.parametrize('stag_location', ['CELL_XLOW', 'CELL_YLOW', 'CELL_ZLOW'])
-    def test_to_field_aligned_staggered(self, tmpdir_factory, bout_xyt_example_files,
+    def test_to_field_aligned_staggered(self, bout_xyt_example_files,
                                         stag_location):
         dataset_list = bout_xyt_example_files(
-            tmpdir_factory, lengths=(3, 3, 4, 8), nxpe=1, nype=1, nt=1
+            None, lengths=(3, 3, 4, 8), nxpe=1, nype=1, nt=1
         )
         ds = open_boutdataset(
             datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
@@ -246,10 +246,10 @@ class TestBoutDataArrayMethods:
         npt.assert_equal(n_stag_al.values, n_al.values)
 
     @pytest.mark.parametrize('stag_location', ['CELL_XLOW', 'CELL_YLOW', 'CELL_ZLOW'])
-    def test_from_field_aligned_staggered(self, tmpdir_factory, bout_xyt_example_files,
+    def test_from_field_aligned_staggered(self, bout_xyt_example_files,
                                           stag_location):
         dataset_list = bout_xyt_example_files(
-            tmpdir_factory, lengths=(3, 3, 4, 8), nxpe=1, nype=1, nt=1
+            None, lengths=(3, 3, 4, 8), nxpe=1, nype=1, nt=1
         )
         ds = open_boutdataset(
             datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
@@ -296,10 +296,9 @@ class TestBoutDataArrayMethods:
         npt.assert_equal(n_stag_al.values, n_nal.values)
 
     @pytest.mark.long
-    def test_interpolate_parallel_region_core(self, tmpdir_factory,
-                                              bout_xyt_example_files):
+    def test_interpolate_parallel_region_core(self, bout_xyt_example_files):
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 16, 3),
             nxpe=1,
             nype=1,
@@ -345,11 +344,11 @@ class TestBoutDataArrayMethods:
                                             3,
                                             pytest.param(7, marks=pytest.mark.long),
                                             pytest.param(18, marks=pytest.mark.long)])
-    def test_interpolate_parallel_region_core_change_n(self, tmpdir_factory,
-                                                       bout_xyt_example_files,
-                                                       res_factor):
+    def test_interpolate_parallel_region_core_change_n(
+        self, bout_xyt_example_files, res_factor
+    ):
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 16, 3),
             nxpe=1,
             nype=1,
@@ -393,10 +392,9 @@ class TestBoutDataArrayMethods:
         npt.assert_allclose(n_highres.values, expected.values, rtol=0., atol=1.e-2)
 
     @pytest.mark.long
-    def test_interpolate_parallel_region_sol(self, tmpdir_factory,
-                                             bout_xyt_example_files):
+    def test_interpolate_parallel_region_sol(self, bout_xyt_example_files):
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 16, 3),
             nxpe=1,
             nype=1,
@@ -438,10 +436,9 @@ class TestBoutDataArrayMethods:
 
         npt.assert_allclose(n_highres.values, expected.values, rtol=0., atol=1.e-2)
 
-    def test_interpolate_parallel_region_singlenull(self, tmpdir_factory,
-                                                    bout_xyt_example_files):
+    def test_interpolate_parallel_region_singlenull(self, bout_xyt_example_files):
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 16, 3),
             nxpe=1,
             nype=3,
@@ -500,9 +497,9 @@ class TestBoutDataArrayMethods:
 
             npt.assert_allclose(n_highres.values, expected.values, rtol=0., atol=1.e-2)
 
-    def test_interpolate_parallel(self, tmpdir_factory, bout_xyt_example_files):
+    def test_interpolate_parallel(self, bout_xyt_example_files):
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 16, 3),
             nxpe=1,
             nype=3,
@@ -550,9 +547,9 @@ class TestBoutDataArrayMethods:
         npt.assert_allclose(n_highres.values, expected.values,
                             rtol=0., atol=1.1e-2)
 
-    def test_interpolate_parallel_sol(self, tmpdir_factory, bout_xyt_example_files):
+    def test_interpolate_parallel_sol(self, bout_xyt_example_files):
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 16, 3),
             nxpe=1,
             nype=1,
@@ -600,10 +597,9 @@ class TestBoutDataArrayMethods:
         npt.assert_allclose(n_highres.values, expected.values,
                             rtol=0., atol=1.1e-2)
 
-    def test_interpolate_parallel_toroidal_points(self, tmpdir_factory,
-                                                  bout_xyt_example_files):
+    def test_interpolate_parallel_toroidal_points(self, bout_xyt_example_files):
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 16, 3),
             nxpe=1,
             nype=3,
@@ -626,10 +622,9 @@ class TestBoutDataArrayMethods:
 
         xrt.assert_identical(n_highres_truncated, n_highres.isel(zeta=[0, 2]))
 
-    def test_interpolate_parallel_toroidal_points_list(self, tmpdir_factory,
-                                                       bout_xyt_example_files):
+    def test_interpolate_parallel_toroidal_points_list(self, bout_xyt_example_files):
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 16, 3),
             nxpe=1,
             nype=3,

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -23,18 +23,18 @@ class TestBoutDatasetIsXarrayDataset:
     (With the accessor approach these should pass trivially now.)
     """
 
-    def test_concat(self, tmpdir_factory, bout_xyt_example_files):
-        dataset_list1 = bout_xyt_example_files(tmpdir_factory, nxpe=3, nype=4, nt=1)
+    def test_concat(self, bout_xyt_example_files):
+        dataset_list1 = bout_xyt_example_files(None, nxpe=3, nype=4, nt=1)
         bd1 = open_boutdataset(datapath=dataset_list1, inputfilepath=None,
                                keep_xboundaries=False)
-        dataset_list2 = bout_xyt_example_files(tmpdir_factory, nxpe=3, nype=4, nt=1)
+        dataset_list2 = bout_xyt_example_files(None, nxpe=3, nype=4, nt=1)
         bd2 = open_boutdataset(datapath=dataset_list2, inputfilepath=None,
                                keep_xboundaries=False)
         result = concat([bd1, bd2], dim='run')
         assert result.dims == {**bd1.dims, 'run': 2}
 
-    def test_isel(self, tmpdir_factory, bout_xyt_example_files):
-        dataset_list = bout_xyt_example_files(tmpdir_factory, nxpe=1, nype=1, nt=1)
+    def test_isel(self, bout_xyt_example_files):
+        dataset_list = bout_xyt_example_files(None, nxpe=1, nype=1, nt=1)
         bd = open_boutdataset(datapath=dataset_list, inputfilepath=None,
                               keep_xboundaries=False)
         actual = bd.isel(x=slice(None,None,2))
@@ -44,8 +44,8 @@ class TestBoutDatasetIsXarrayDataset:
 
 class TestBoutDatasetMethods:
     @pytest.mark.skip
-    def test_test_method(self, tmpdir_factory, bout_xyt_example_files):
-        dataset_list = bout_xyt_example_files(tmpdir_factory, nxpe=1, nype=1, nt=1)
+    def test_test_method(self, bout_xyt_example_files):
+        dataset_list = bout_xyt_example_files(None, nxpe=1, nype=1, nt=1)
         ds = open_boutdataset(datapath=dataset_list, inputfilepath=None)
         #ds = collect(path=path)
         #bd = BoutAccessor(ds)
@@ -60,8 +60,8 @@ class TestBoutDatasetMethods:
 
         print(ds.bout.extra_data)
 
-    def test_get_field_aligned(self, tmpdir_factory, bout_xyt_example_files):
-        dataset_list = bout_xyt_example_files(tmpdir_factory, nxpe=3, nype=4, nt=1)
+    def test_get_field_aligned(self, bout_xyt_example_files):
+        dataset_list = bout_xyt_example_files(None, nxpe=3, nype=4, nt=1)
         ds = open_boutdataset(
             datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
         )
@@ -108,7 +108,7 @@ class TestBoutDatasetMethods:
     @pytest.mark.parametrize(
         "vars_to_interpolate", [('n', 'T'), pytest.param(..., marks=pytest.mark.long)]
     )
-    def test_interpolate_parallel(self, tmpdir_factory, bout_xyt_example_files,
+    def test_interpolate_parallel(self, bout_xyt_example_files,
                                   guards, keep_xboundaries, keep_yboundaries,
                                   vars_to_interpolate):
         # This test checks that the regions created in the new high-resolution Dataset by
@@ -119,7 +119,7 @@ class TestBoutDatasetMethods:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        dataset_list, grid_ds = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
+        dataset_list, grid_ds = bout_xyt_example_files(None, lengths=(2, 3, 4, 3), nxpe=3,
                                       nype=6, nt=1, guards=guards, grid='grid',
                                       topology='disconnected-double-null')
 
@@ -442,11 +442,10 @@ class TestBoutDatasetMethods:
                                         theta=slice(jys22 + 1 - myg, jys22 + 1)).values,
                                  v_lower_outer_SOL.isel(theta=slice(myg)).values)
 
-    def test_interpolate_parallel_all_variables_arg(self, tmpdir_factory,
-                                                    bout_xyt_example_files):
+    def test_interpolate_parallel_all_variables_arg(self, bout_xyt_example_files):
         # Check that passing 'variables=...' to interpolate_parallel() does actually
         # interpolate all the variables
-        dataset_list, grid_ds = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=1,
+        dataset_list, grid_ds = bout_xyt_example_files(None, lengths=(2, 3, 4, 3), nxpe=1,
                                       nype=1, nt=1, grid='grid', topology='sol')
 
         ds = open_boutdataset(
@@ -473,8 +472,8 @@ class TestLoadInputFile:
         # TODO Check it contains the same text
 
     @pytest.mark.skip
-    def test_load_options_in_dataset(self, tmpdir_factory, bout_xyt_example_files):
-        dataset_list = bout_xyt_example_files(tmpdir_factory, nxpe=1, nype=1, nt=1)
+    def test_load_options_in_dataset(self, bout_xyt_example_files):
+        dataset_list = bout_xyt_example_files(None, nxpe=1, nype=1, nt=1)
         ds = open_boutdataset(
             datapath=dataset_list, inputfilepath=EXAMPLE_OPTIONS_FILE_PATH
         )

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -119,9 +119,16 @@ class TestBoutDatasetMethods:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        dataset_list, grid_ds = bout_xyt_example_files(None, lengths=(2, 3, 4, 3), nxpe=3,
-                                      nype=6, nt=1, guards=guards, grid='grid',
-                                      topology='disconnected-double-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            None,
+            lengths=(2, 3, 4, 3),
+            nxpe=3,
+            nype=6,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='disconnected-double-null'
+        )
 
         ds = open_boutdataset(
             datapath=dataset_list,
@@ -445,8 +452,15 @@ class TestBoutDatasetMethods:
     def test_interpolate_parallel_all_variables_arg(self, bout_xyt_example_files):
         # Check that passing 'variables=...' to interpolate_parallel() does actually
         # interpolate all the variables
-        dataset_list, grid_ds = bout_xyt_example_files(None, lengths=(2, 3, 4, 3), nxpe=1,
-                                      nype=1, nt=1, grid='grid', topology='sol')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            None,
+            lengths=(2, 3, 4, 3),
+            nxpe=1,
+            nype=1,
+            nt=1,
+            grid='grid',
+            topology='sol'
+        )
 
         ds = open_boutdataset(
             datapath=dataset_list, gridfilepath=grid_ds, geometry='toroidal'

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -277,11 +277,7 @@ def create_bout_ds_list(prefix, lengths=(6, 2, 4, 7), nxpe=4, nype=2, nt=1, guar
                                 xproc=i, yproc=j, guards=guards, topology=topology)
             ds_list.append(ds)
 
-    # Sort this in order of num to remove any BOUT-specific structure
-    ds_list_sorted = [ds for filename, ds in sorted(zip(file_list, ds_list))]
-    file_list_sorted = [filename for filename, ds in sorted(zip(file_list, ds_list))]
-
-    return ds_list_sorted, file_list_sorted
+    return ds_list, file_list
 
 
 def create_bout_ds(syn_data_type='random', lengths=(6, 2, 4, 7), num=0, nxpe=1, nype=1,

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -226,6 +226,8 @@ def _bout_xyt_example_files(tmpdir_factory, prefix='BOUT.dmp', lengths=(6, 2, 4,
             return ds_list
         else:
             return ds_list, grid_ds
+    elif tmpdir_factory is None:
+        raise ValueError("tmpdir_factory required when write_to_disk=False")
 
     save_dir = tmpdir_factory.mktemp("data")
 
@@ -527,8 +529,8 @@ class TestStripMetadata():
 
 # TODO also test loading multiple files which have guard cells
 class TestOpen:
-    def test_single_file(self, tmpdir_factory, bout_xyt_example_files):
-        dataset = bout_xyt_example_files(tmpdir_factory, nxpe=1, nype=1, nt=1)
+    def test_single_file(self, bout_xyt_example_files):
+        dataset = bout_xyt_example_files(None, nxpe=1, nype=1, nt=1)
         actual = open_boutdataset(datapath=dataset, keep_xboundaries=False)
         expected = create_bout_ds()
         xrt.assert_equal(actual.load(),
@@ -536,9 +538,9 @@ class TestOpen:
                                        + _BOUT_TIME_DEPENDENT_META_VARS,
                                        errors='ignore'))
 
-    def test_squashed_file(self, tmpdir_factory, bout_xyt_example_files):
+    def test_squashed_file(self, bout_xyt_example_files):
         dataset = bout_xyt_example_files(
-            tmpdir_factory, nxpe=4, nype=3, nt=1, squashed=True
+            None, nxpe=4, nype=3, nt=1, squashed=True
         )
         actual = open_boutdataset(datapath=dataset, keep_xboundaries=False)
         expected = create_bout_ds()
@@ -547,9 +549,9 @@ class TestOpen:
                                        + _BOUT_TIME_DEPENDENT_META_VARS,
                                        errors='ignore'))
 
-    def test_combine_along_x(self, tmpdir_factory, bout_xyt_example_files):
+    def test_combine_along_x(self, bout_xyt_example_files):
         dataset_list = bout_xyt_example_files(
-            tmpdir_factory, nxpe=4, nype=1, nt=1, syn_data_type='stepped'
+            None, nxpe=4, nype=1, nt=1, syn_data_type='stepped'
         )
         actual = open_boutdataset(datapath=dataset_list, keep_xboundaries=False)
 
@@ -560,9 +562,9 @@ class TestOpen:
                          expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES,
                                        errors='ignore'))
 
-    def test_combine_along_y(self, tmpdir_factory, bout_xyt_example_files):
+    def test_combine_along_y(self, bout_xyt_example_files):
         dataset_list = bout_xyt_example_files(
-            tmpdir_factory, nxpe=1, nype=3, nt=1, syn_data_type='stepped'
+            None, nxpe=1, nype=3, nt=1, syn_data_type='stepped'
         )
         actual = open_boutdataset(datapath=dataset_list, keep_xboundaries=False)
 
@@ -577,9 +579,9 @@ class TestOpen:
     def test_combine_along_t(self):
         ...
 
-    def test_combine_along_xy(self, tmpdir_factory, bout_xyt_example_files):
+    def test_combine_along_xy(self, bout_xyt_example_files):
         dataset_list = bout_xyt_example_files(
-            tmpdir_factory, nxpe=4, nype=3, nt=1, syn_data_type='stepped'
+            None, nxpe=4, nype=3, nt=1, syn_data_type='stepped'
         )
         actual = open_boutdataset(datapath=dataset_list, keep_xboundaries=False)
 

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -26,11 +26,11 @@ class TestRegion:
     @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
-    def test_region_core(self, tmpdir_factory, bout_xyt_example_files, guards,
+    def test_region_core(self, bout_xyt_example_files, guards,
                          keep_xboundaries, keep_yboundaries):
         # Note need to use more than (3*MXG,3*MYG) points per output file
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 4, 3),
             nxpe=3,
             nype=4,
@@ -72,11 +72,11 @@ class TestRegion:
     @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
-    def test_region_sol(self, tmpdir_factory, bout_xyt_example_files, guards,
+    def test_region_sol(self, bout_xyt_example_files, guards,
                         keep_xboundaries, keep_yboundaries):
         # Note need to use more than (3*MXG,3*MYG) points per output file
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 4, 3),
             nxpe=3,
             nype=4,
@@ -104,13 +104,13 @@ class TestRegion:
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
-    def test_region_limiter(self, tmpdir_factory, bout_xyt_example_files, guards,
+    def test_region_limiter(self, bout_xyt_example_files, guards,
                             keep_xboundaries, keep_yboundaries):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 4, 3),
             nxpe=3,
             nype=4,
@@ -173,13 +173,13 @@ class TestRegion:
     @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
-    def test_region_xpoint(self, tmpdir_factory, bout_xyt_example_files, guards,
+    def test_region_xpoint(self, bout_xyt_example_files, guards,
                            keep_xboundaries, keep_yboundaries):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 4, 3),
             nxpe=3,
             nype=4,
@@ -333,13 +333,13 @@ class TestRegion:
     @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
-    def test_region_singlenull(self, tmpdir_factory, bout_xyt_example_files, guards,
+    def test_region_singlenull(self, bout_xyt_example_files, guards,
                                keep_xboundaries, keep_yboundaries):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 4, 3),
             nxpe=3,
             nype=4,
@@ -465,13 +465,13 @@ class TestRegion:
     @pytest.mark.long
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
-    def test_region_connecteddoublenull(self, tmpdir_factory, bout_xyt_example_files,
+    def test_region_connecteddoublenull(self, bout_xyt_example_files,
                                         guards, keep_xboundaries, keep_yboundaries):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 4, 3),
             nxpe=3,
             nype=6,
@@ -696,13 +696,13 @@ class TestRegion:
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
-    def test_region_disconnecteddoublenull(self, tmpdir_factory, bout_xyt_example_files,
+    def test_region_disconnecteddoublenull(self, bout_xyt_example_files,
                                            guards, keep_xboundaries, keep_yboundaries):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 4, 3),
             nxpe=3,
             nype=6,
@@ -1029,13 +1029,13 @@ class TestRegion:
     @pytest.mark.parametrize('with_guards',
                              [0, {'x': 1}, {'theta': 1}, {'x': 1, 'theta': 1}, 1])
     def test_region_disconnecteddoublenull_get_one_guard(
-            self, tmpdir_factory, bout_xyt_example_files, guards, keep_xboundaries,
+            self, bout_xyt_example_files, guards, keep_xboundaries,
             keep_yboundaries, with_guards):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
         dataset_list, grid_ds = bout_xyt_example_files(
-            tmpdir_factory,
+            None,
             lengths=(2, 3, 4, 3),
             nxpe=3,
             nype=6,

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -29,14 +29,24 @@ class TestRegion:
     def test_region_core(self, tmpdir_factory, bout_xyt_example_files, guards,
                          keep_xboundaries, keep_yboundaries):
         # Note need to use more than (3*MXG,3*MYG) points per output file
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
-                                      nype=4, nt=1, guards=guards, grid='grid',
-                                      topology='core')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 4, 3),
+            nxpe=3,
+            nype=4,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='core'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
-                              keep_yboundaries=keep_yboundaries)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_xboundaries=keep_xboundaries,
+            keep_yboundaries=keep_yboundaries
+        )
 
         n = ds['n']
 
@@ -65,14 +75,24 @@ class TestRegion:
     def test_region_sol(self, tmpdir_factory, bout_xyt_example_files, guards,
                         keep_xboundaries, keep_yboundaries):
         # Note need to use more than (3*MXG,3*MYG) points per output file
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
-                                      nype=4, nt=1, guards=guards, grid='grid',
-                                      topology='sol')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 4, 3),
+            nxpe=3,
+            nype=4,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='sol'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
-                              keep_yboundaries=keep_yboundaries)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_xboundaries=keep_xboundaries,
+            keep_yboundaries=keep_yboundaries
+        )
 
         n = ds['n']
 
@@ -89,14 +109,24 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
-                                      nype=4, nt=1, guards=guards, grid='grid',
-                                      topology='limiter')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 4, 3),
+            nxpe=3,
+            nype=4,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='limiter'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
-                              keep_yboundaries=keep_yboundaries)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_xboundaries=keep_xboundaries,
+            keep_yboundaries=keep_yboundaries
+        )
 
         mxg = guards['x']
 
@@ -148,14 +178,24 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
-                                      nype=4, nt=1, guards=guards, grid='grid',
-                                      topology='xpoint')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 4, 3),
+            nxpe=3,
+            nype=4,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='xpoint'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
-                              keep_yboundaries=keep_yboundaries)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_xboundaries=keep_xboundaries,
+            keep_yboundaries=keep_yboundaries
+        )
 
         mxg = guards['x']
         myg = guards['y']
@@ -298,14 +338,24 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
-                                      nype=4, nt=1, guards=guards, grid='grid',
-                                      topology='single-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 4, 3),
+            nxpe=3,
+            nype=4,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='single-null'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
-                              keep_yboundaries=keep_yboundaries)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_xboundaries=keep_xboundaries,
+            keep_yboundaries=keep_yboundaries
+        )
 
         mxg = guards['x']
         myg = guards['y']
@@ -420,14 +470,24 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
-                                      nype=6, nt=1, guards=guards, grid='grid',
-                                      topology='connected-double-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 4, 3),
+            nxpe=3,
+            nype=6,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='connected-double-null'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
-                              keep_yboundaries=keep_yboundaries)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_xboundaries=keep_xboundaries,
+            keep_yboundaries=keep_yboundaries
+        )
 
         mxg = guards['x']
         myg = guards['y']
@@ -641,14 +701,24 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
-                                      nype=6, nt=1, guards=guards, grid='grid',
-                                      topology='disconnected-double-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 4, 3),
+            nxpe=3,
+            nype=6,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='disconnected-double-null'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
-                              keep_yboundaries=keep_yboundaries)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_xboundaries=keep_xboundaries,
+            keep_yboundaries=keep_yboundaries
+        )
 
         mxg = guards['x']
         myg = guards['y']
@@ -964,14 +1034,24 @@ class TestRegion:
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
         # when using minimal numbers of processors
-        path = bout_xyt_example_files(tmpdir_factory, lengths=(2, 3, 4, 3), nxpe=3,
-                                      nype=6, nt=1, guards=guards, grid='grid',
-                                      topology='disconnected-double-null')
+        dataset_list, grid_ds = bout_xyt_example_files(
+            tmpdir_factory,
+            lengths=(2, 3, 4, 3),
+            nxpe=3,
+            nype=6,
+            nt=1,
+            guards=guards,
+            grid='grid',
+            topology='disconnected-double-null'
+        )
 
-        ds = open_boutdataset(datapath=path,
-                              gridfilepath=Path(path).parent.joinpath('grid.nc'),
-                              geometry='toroidal', keep_xboundaries=keep_xboundaries,
-                              keep_yboundaries=keep_yboundaries)
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry='toroidal',
+            keep_xboundaries=keep_xboundaries,
+            keep_yboundaries=keep_yboundaries
+        )
 
         mxg = guards['x']
         myg = guards['y']


### PR DESCRIPTION
Allow `open_boutdataset()` to optionally take a list of existing `Dataset`s instead of a filename-glob. Useful for unit tests which no longer have to create files on disk and then read them. Speeds up the unit tests, which is useful so we can add more tests in other PRs without making Travis time out. A few unit tests do still read and write files, so this functionality is still tested.