### PR TITLE
Interpolate from unstructured

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -642,7 +642,10 @@ class BoutDataArrayAccessor:
         # boundaries[1] is the inner boundary if it exists
         if len(boundaries) > 1:
             path = matplotlib.path.Path(boundaries[1], closed=True, readonly=True)
-            is_contained = path.contains_points(points)
+            is_contained = path.contains_points(points.reshape([-1, 2]))
+            is_contained = is_contained.reshape(
+                coord_arrays[0].shape + (1,)*len(remaining_dims)
+            )
             result = np.where(is_contained, fill_value, result)
 
         if len(boundaries) > 2:

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -13,7 +13,7 @@ from .plotting.animate import animate_poloidal, animate_pcolormesh, animate_line
 from .plotting import plotfuncs
 from .plotting.utils import _create_norm
 from .region import _from_region
-from .utils import _update_metadata_increased_resolution
+from .utils import _update_metadata_increased_resolution, _get_bounding_surfaces
 
 
 @register_dataarray_accessor('bout')
@@ -413,6 +413,28 @@ class BoutDataArrayAccessor:
         else:
             # Extract the DataArray to return
             return result[self.data.name]
+
+    def get_bounding_surfaces(self, coords=("R", "Z")):
+        """
+        Get bounding surfaces.
+        Surfaces are returned as arrays of points describing a polygon, assuming the
+        third spatial dimension is a symmetry direction.
+
+        Parameters
+        ----------
+        coords : (str, str), default ("R", "Z")
+            Pair of names of coordinates whose values are used to give the positions of
+            the points in the result
+
+        Returns
+        -------
+        result : list of DataArrays
+            Each DataArray in the list contains points on a boundary, with size
+            (<number of points in the bounding polygon>, 2). Points wind clockwise around
+            the outside domain, and anti-clockwise around the inside (if there is an
+            inner boundary).
+        """
+        return _get_bounding_surfaces(self.data, coords)
 
     def animate2D(self, animate_over='t', x=None, y=None, animate=True, fps=10,
                   save_as=None, ax=None, poloidal_plot=False, logscale=None, **kwargs):

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -593,8 +593,10 @@ class BoutDataArrayAccessor:
             }
 
             coord_arrays = tuple(
-                np.meshgrid(*[values for values in kwargs.values()],
-                indexing="ij")
+                np.meshgrid(
+                    *[values for values in kwargs.values()],
+                    indexing="ij"
+                )
             )
 
             new_output_dims = [d for d in kwargs]
@@ -607,7 +609,7 @@ class BoutDataArrayAccessor:
             coord_arrays = tuple(kwargs.values())
 
             lengths = [len(c) for c in coord_arrays]
-            if np.any([l != lengths[0] for l in lengths[1:]]):
+            if np.any([x != lengths[0] for x in lengths[1:]]):
                 raise ValueError(
                     f"When structured_output=False, all the arrays of output coordinate"
                     f"values must have the same length. Got lengths "

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -232,7 +232,15 @@ class BoutDatasetAccessor:
 
         return ds
 
-    def interpolate_from_unstructured(self, variables, *, fill_value=np.nan, **kwargs):
+    def interpolate_from_unstructured(
+        self,
+        variables,
+        *,
+        fill_value=np.nan,
+        structured_output=True,
+        unstructured_dim_name="unstructured_dim",
+        **kwargs
+    ):
         """Interpolate Dataset onto new grids of some existing coordinates
 
         Parameters
@@ -245,6 +253,13 @@ class BoutDatasetAccessor:
             1d array giving the values of that coordinate on the output grid
         fill_value : float
             fill_value passed through to scipy.interpolation.griddata
+        structured_output : bool, default True
+            If True, treat output coordinates values as a structured grid.
+            If False, output coordinate values must all have the same length and are not
+            broadcast together.
+        unstructured_dim_name : str, default "unstructured_dim"
+            Name used for the dimension in the output that replaces the dimensions of
+            the interpolated coordinates. Only used if structured_output=False.
 
         Returns
         -------
@@ -274,7 +289,10 @@ class BoutDatasetAccessor:
             if np.all([c in self.data[v].coords for c in kwargs]):
                 ds = ds.merge(
                     self.data[v].bout.interpolate_from_unstructured(
-                        fill_value=fill_value, **kwargs
+                        fill_value=fill_value,
+                        structured_output=structured_output,
+                        unstructured_dim_name=unstructured_dim_name,
+                        **kwargs
                     ).to_dataset()
                 )
             elif explicit_variables_arg and v in variables:

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -21,6 +21,7 @@ from .geometries import apply_geometry
 from .plotting.animate import animate_poloidal, animate_pcolormesh, animate_line
 from .plotting.utils import _create_norm
 from .region import _from_region
+from .utils import _get_bounding_surfaces
 
 
 @xr.register_dataset_accessor('bout')
@@ -263,6 +264,28 @@ class BoutDatasetAccessor:
         result = apply_geometry(result, self.data.geometry)
 
         return result
+
+    def get_bounding_surfaces(self, coords=("R", "Z")):
+        """
+        Get bounding surfaces.
+        Surfaces are returned as arrays of points describing a polygon, assuming the
+        third spatial dimension is a symmetry direction.
+
+        Parameters
+        ----------
+        coords : (str, str), default ("R", "Z")
+            Pair of names of coordinates whose values are used to give the positions of
+            the points in the result
+
+        Returns
+        -------
+        result : list of DataArrays
+            Each DataArray in the list contains points on a boundary, with size
+            (<number of points in the bounding polygon>, 2). Points wind clockwise around
+            the outside domain, and anti-clockwise around the inside (if there is an
+            inner boundary).
+        """
+        return _get_bounding_surfaces(self.data, coords)
 
     def save(self, savepath='./boutdata.nc', filetype='NETCDF4',
              variables=None, save_dtype=None, separate_vars=False, pre_load=False):

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -600,7 +600,9 @@ class TestBoutDatasetMethods:
         n_rect = n.bout.interpolate_from_unstructured(R=R_rect, Z=Z_rect)
 
         # check BoutDataset and BoutDataArray versions are consistent
-        n_rect_from_ds = ds.bout.interpolate_from_unstructured(..., R=R_rect, Z=Z_rect)["n"]
+        n_rect_from_ds = ds.bout.interpolate_from_unstructured(
+            ..., R=R_rect, Z=Z_rect
+        )["n"]
         npt.assert_allclose(n_rect, n_rect_from_ds)
 
         # check non-NaN values are correct

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from itertools import chain
 
 import numpy as np
+import xarray as xr
 
 
 def _set_attrs_on_all_vars(ds, key, attr_data, copy=False):
@@ -93,3 +94,333 @@ def _update_metadata_increased_resolution(da, n):
         _add_attrs_to_var(da, coord)
 
     return da
+
+
+# Utility methods for _get_bounding_surfaces()
+##############################################
+
+_bounding_surface_checks={}
+
+
+def _check_upper_y(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
+    region = list(ds_region.regions.values())[0]
+    xcoord = ds_region.metadata["bout_xdim"]
+    ycoord = ds_region.metadata["bout_ydim"]
+
+    if region.connection_upper_y is None:
+        xinner = (
+            xbndry - 1
+            if region.connection_inner_x is None and xbndry > 0
+            else None
+        )
+        xouter = (
+            -xbndry - 1
+            if region.connection_outer_x is None and xbndry > 0
+            else None
+        )
+
+        # Reverse order of points to go clockwise around region
+        boundary_slice = {xcoord: slice(xinner, xouter, -1), ycoord: -1 - ybndry}
+        new_boundary_points = np.stack(
+            [
+                ds_region[Rcoord].isel(boundary_slice).values,
+                ds_region[Zcoord].isel(boundary_slice).values,
+            ],
+            axis=-1,
+        )
+
+        boundary_points = np.concatenate(
+            [boundary_points, new_boundary_points]
+        )
+
+        return boundary_points, region.connection_inner_x, "inner_x"
+    else:
+        return None
+_bounding_surface_checks["upper_y"] = _check_upper_y
+
+
+def _check_inner_x(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
+    region = list(ds_region.regions.values())[0]
+    xcoord = ds_region.metadata["bout_xdim"]
+    ycoord = ds_region.metadata["bout_ydim"]
+
+    if region.connection_inner_x is None:
+        ylower = (
+            ybndry - 1
+            if region.connection_lower_y is None and ybndry > 0
+            else None
+        )
+        yupper = (
+            -ybndry - 1
+            if region.connection_upper_y is None and ybndry > 0
+            else None
+        )
+
+        # Reverse order of points to go clockwise around region
+        boundary_slice = {xcoord: xbndry, ycoord: slice(yupper, ylower, -1)}
+        new_boundary_points = np.stack(
+            [
+                ds_region[Rcoord].isel(boundary_slice).values,
+                ds_region[Zcoord].isel(boundary_slice).values,
+            ],
+            axis=-1,
+        )
+
+        boundary_points = np.concatenate(
+            [boundary_points, new_boundary_points]
+        )
+
+        return boundary_points, region.connection_lower_y, "lower_y"
+    else:
+        return None
+_bounding_surface_checks["inner_x"] = _check_inner_x
+
+
+def _check_lower_y(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
+    region = list(ds_region.regions.values())[0]
+    xcoord = ds_region.metadata["bout_xdim"]
+    ycoord = ds_region.metadata["bout_ydim"]
+
+    if region.connection_lower_y is None:
+        xinner = xbndry if region.connection_inner_x is None else None
+        xouter = (
+            -xbndry
+            if region.connection_outer_x is None and xbndry > 0
+            else None
+        )
+
+        boundary_slice = {xcoord: slice(xinner, xouter), ycoord: ybndry}
+        new_boundary_points = np.stack(
+            [
+                ds_region[Rcoord].isel(boundary_slice).values,
+                ds_region[Zcoord].isel(boundary_slice).values,
+            ],
+            axis=-1,
+        )
+
+        boundary_points = np.concatenate(
+            [boundary_points, new_boundary_points]
+        )
+
+        return boundary_points, region.connection_outer_x, "outer_x"
+    else:
+        return None
+_bounding_surface_checks["lower_y"] = _check_lower_y
+
+
+def _check_outer_x(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
+    region = list(ds_region.regions.values())[0]
+    xcoord = ds_region.metadata["bout_xdim"]
+    ycoord = ds_region.metadata["bout_ydim"]
+
+    if region.connection_outer_x is None:
+        ylower = ybndry if region.connection_lower_y is None else None
+        yupper = (
+            -ybndry
+            if region.connection_upper_y is None and ybndry > 0
+            else None
+        )
+
+        boundary_slice = {xcoord: -1 - xbndry, ycoord: slice(ylower, yupper)}
+        new_boundary_points = np.stack(
+            [
+                ds_region[Rcoord].isel(boundary_slice).values,
+                ds_region[Zcoord].isel(boundary_slice).values,
+            ],
+            axis=-1,
+        )
+
+        boundary_points = np.concatenate(
+            [boundary_points, new_boundary_points]
+        )
+
+        return boundary_points, region.connection_upper_y, "upper_y"
+    else:
+        return None
+_bounding_surface_checks["outer_x"] = _check_outer_x
+
+
+def _follow_boundary(ds, start_region, start_direction, xbndry, ybndry, Rcoord, Zcoord):
+    # Define lists of boundaries to cycle through, depending on which direction we
+    # entered the region in
+    check_order = {
+        "upper_y": ["outer_x", "upper_y", "inner_x", "lower_y"],
+        "inner_x": ["upper_y", "inner_x", "lower_y", "outer_x"],
+        "lower_y": ["inner_x", "lower_y", "outer_x", "upper_y"],
+        "outer_x": ["lower_y", "outer_x", "upper_y", "inner_x"],
+    }
+
+    this_region = start_region
+    direction = start_direction
+    visited_regions = []
+    boundary_points = np.empty([0, 2])
+    while True:
+        # Follow around the boundary from start_region
+
+        visited_regions.append(this_region)
+
+        ds_region = ds.bout.from_region(this_region, with_guards=0)
+        region = ds.regions[this_region]
+
+        # Get all boundary points from this region, and decide which region to go to next
+        this_region = None
+
+        for boundary in check_order[direction]:
+            result = _bounding_surface_checks[boundary](
+                ds_region,
+                boundary_points,
+                xbndry,
+                ybndry,
+                Rcoord,
+                Zcoord,
+            )
+            if result is not None:
+                boundary_points, this_region, direction = result
+            else:
+                # Only add the boundary now if it's connected to the boundary we are
+                # following
+                break
+
+        if this_region is None:
+            raise ValueError(f"this_region={this_region} has no boundaries")
+        elif this_region == start_region:
+            break
+
+    return boundary_points, visited_regions
+
+def _get_bounding_surfaces(ds, coords):
+    """
+    Get boundary surfaces from a Dataset or DataArray
+
+    Makes some assumptions about possible topologies that are true for currently
+    supported single-null/double-null tokamaks, but might not be for very general
+    topologies:
+    - If there are y-boundaries, there is a region with both a lower-y boundary and an
+      outer-x boundary.
+
+    Outer boundary goes clockwise, inner boundary (if present) goes anti-clockwise.
+
+    Note the 'boundary points' are the grid points adjacent to the boundary, not the grid
+    boundary half way between grid point and boundary point. Boundary cells are not
+    always present, so tricky to implement something 'better'.
+
+    Returns
+    -------
+    tuple of (N,2) float arrays of vertices on the boundaries
+    """
+
+    # coords do not have to be R and Z, but usually will be.
+    Rcoord, Zcoord = coords
+
+    # Get number of boundary cells
+    if ds.metadata["keep_xboundaries"]:
+        xbndry = ds.metadata["MXG"]
+    else:
+        xbndry = 0
+    if ds.metadata["keep_yboundaries"]:
+        ybndry = ds.metadata["MYG"]
+    else:
+        ybndry = 0
+
+    xcoord = ds.metadata["bout_xdim"]
+    ycoord = ds.metadata["bout_ydim"]
+
+    # First find the outer boundary
+    start_region = None
+    for name, region in ds.regions.items():
+        if region.connection_lower_y is None and region.connection_outer_x is None:
+            start_region = name
+            break
+    if start_region is None:
+        # No y-boundary region found, presumably is core-only simulation. Start on any
+        # region with an outer-x boundary
+        for name, region in ds.regions.items():
+            if region.connection_outer_x is None:
+                start_region = name
+    if start_region is None:
+        raise ValueError(
+            "Failed to find bounding surfaces - no region with outer boundary found"
+        )
+
+    # First region has outer-x boundary, but we only visit start_region once, so need to
+    # add all boundaries in it the first time.
+    region = ds.regions[start_region]
+    if region.connection_upper_y is None:
+        start_direction = "inner_x"
+    elif region.connection_inner_x is None and region.connection_lower_y is None:
+        start_direction = "lower_y"
+    elif region.connection_lower_y is None:
+        start_direction = "outer_x"
+    else:
+        start_direction = "upper_y"
+
+    boundary, checked_regions = _follow_boundary(
+        ds, start_region, start_direction, xbndry, ybndry, Rcoord, Zcoord,
+    )
+    boundaries = [boundary]
+
+    # Look for an inner boundary
+    ############################
+    remaining_regions = set(ds.regions) - set(checked_regions)
+    start_region = None
+    if not remaining_regions:
+        # Check for separate inner-x boundary on any of the already visited regions.
+        # If inner-x boundary was part of the outer boundary (e.g. for SOL-only
+        # simulation) then any region without y-boundaries will be visited twice,
+        # otherwise any region that has an inner-x boundary and no y-boundary must be on
+        # a separate inner boundary
+        for r in checked_regions:
+            if (
+                ds.regions[r].connection_inner_x is None
+                and ds.regions[r].connection_lower_y is not None
+                and ds.regions[r].connection_upper_y is not None
+                and checked_regions.count(r) < 2
+            ):
+                start_region = r
+                break
+    else:
+        for r in remaining_regions:
+            if (
+                ds.regions[r].connection_inner_x is None
+                and ds.regions[r].connection_lower_y is not None
+                and ds.regions[r].connection_upper_y is not None
+            ):
+                start_region = r
+                break
+
+    if start_region is not None:
+        # Inner boundary found
+        # Inner boundary should have only an inner_x boundary, so set start_direction to
+        # check that first
+        start_direction = "lower_y"
+
+        boundary, more_checked_regions = _follow_boundary(
+            ds, start_region, start_direction, xbndry, ybndry, Rcoord, Zcoord
+        )
+        boundaries.append(boundary)
+        checked_regions += more_checked_regions
+
+        remaining_regions = set(ds.regions) - set(checked_regions)
+
+    # If there are any remaining regions, they should not have any boundaries
+    for r in remaining_regions:
+        region = ds.regions[r]
+        if (
+            region.connection_lower_y is None
+            or region.connection_outer_x is None
+            or region.connection_upper_y is None
+            or region.connection_inner_x is None
+        ):
+            raise ValueError(
+                f"Region '{r}' has a boundary, but was missed when getting boundary "
+                f"points"
+            )
+
+    # Pack the result into a DataArray
+    result = [xr.DataArray(
+        boundary,
+        dims=("boundary", "coord"),
+        coords={"coord": [Rcoord, Zcoord]},
+    ) for boundary in boundaries]
+
+    return result

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -99,7 +99,7 @@ def _update_metadata_increased_resolution(da, n):
 # Utility methods for _get_bounding_surfaces()
 ##############################################
 
-_bounding_surface_checks={}
+_bounding_surface_checks = {}
 
 
 def _check_upper_y(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
@@ -136,6 +136,8 @@ def _check_upper_y(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
         return boundary_points, region.connection_inner_x, "inner_x"
     else:
         return None
+
+
 _bounding_surface_checks["upper_y"] = _check_upper_y
 
 
@@ -173,6 +175,8 @@ def _check_inner_x(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
         return boundary_points, region.connection_lower_y, "lower_y"
     else:
         return None
+
+
 _bounding_surface_checks["inner_x"] = _check_inner_x
 
 
@@ -205,6 +209,8 @@ def _check_lower_y(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
         return boundary_points, region.connection_outer_x, "outer_x"
     else:
         return None
+
+
 _bounding_surface_checks["lower_y"] = _check_lower_y
 
 
@@ -237,6 +243,8 @@ def _check_outer_x(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
         return boundary_points, region.connection_upper_y, "upper_y"
     else:
         return None
+
+
 _bounding_surface_checks["outer_x"] = _check_outer_x
 
 
@@ -287,6 +295,7 @@ def _follow_boundary(ds, start_region, start_direction, xbndry, ybndry, Rcoord, 
             break
 
     return boundary_points, visited_regions
+
 
 def _get_bounding_surfaces(ds, coords):
     """


### PR DESCRIPTION
Adds a method to interpolate data from the BOUT++ grid onto a different structured or unstructured grid. The structured grid can be useful to get Cartesian output, e.g. for cross-code comparison or 3d visualisation. Unstructured output can be useful e.g. for interpolating to the measurement positions of some diagnostic.

~~Should be merged after #130.~~