### PR TITLE
Support user-defined time dimension with separate_vars option to save()

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -627,7 +627,7 @@ def _find_major_vars(data):
     """
 
     # TODO Use an Ordered Set instead to preserve order of variables in files?
-    tcoord = data.attrs["metadata:bout_tdim"]
+    tcoord = data.attrs.get("metadata:bout_tdim", "t")
     major_vars = set(var for var in data.data_vars
                      if (tcoord in data[var].dims) and data[var].dims != (tcoord, ))
     minor_vars = set(data.data_vars) - set(major_vars)

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -627,7 +627,8 @@ def _find_major_vars(data):
     """
 
     # TODO Use an Ordered Set instead to preserve order of variables in files?
+    tcoord = data.attrs["metadata:bout_tdim"]
     major_vars = set(var for var in data.data_vars
-                     if ('t' in data[var].dims) and data[var].dims != ('t', ))
+                     if (tcoord in data[var].dims) and data[var].dims != (tcoord, ))
     minor_vars = set(data.data_vars) - set(major_vars)
     return list(major_vars), list(minor_vars)


### PR DESCRIPTION
Use `metadata["bout_tdim"]` instead of hard-coded `"t"` in `_get_major_vars()` to support user-changed dimension names.