### PR TITLE
Bugfix: Metadata doesn't exist if pre-squashed

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -136,6 +136,10 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
         metadata['keep_yboundaries'] = int(keep_yboundaries)
         ds = _set_attrs_on_all_vars(ds, 'metadata', metadata)
 
+        # Set some default settings that are only used in post-processing by xBOUT, not by
+        # BOUT++
+        ds.bout.fine_interpolation_factor = 8
+
         for var in _BOUT_TIME_DEPENDENT_META_VARS:
             if var in ds:
                 # Assume different processors in x & y have same iteration etc.
@@ -171,10 +175,6 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
 
     if run_name:
         ds.name = run_name
-
-    # Set some default settings that are only used in post-processing by xBOUT, not by
-    # BOUT++
-    ds.bout.fine_interpolation_factor = 8
 
     if info == 'terse':
         print("Read in dataset from {}".format(str(Path(datapath))))

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -136,8 +136,8 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
         metadata['keep_yboundaries'] = int(keep_yboundaries)
         ds = _set_attrs_on_all_vars(ds, 'metadata', metadata)
 
-        # Set some default settings that are only used in post-processing by xBOUT, not by
-        # BOUT++
+        # Set some default settings that are only used in post-processing by xBOUT, not
+        # by BOUT++
         ds.bout.fine_interpolation_factor = 8
 
         for var in _BOUT_TIME_DEPENDENT_META_VARS:


### PR DESCRIPTION
One of the recent commits caused this error when loading pre-squashed files:

```python
    179     # Set some default settings that are only used in post-processing by xBOUT, not by
    180     # BOUT++
--> 181     ds.bout.fine_interpolation_factor = 8
    182 
    183     if info == 'terse':

/marconi_work/FUA34_SOLBOUT4/tnichola/pycode/xBOUT/xbout/boutdataset.py in fine_interpolation_factor(self, n)
    126         """
    127         ds = self.data
--> 128         ds.metadata['fine_interpolation_factor'] = n
    129         for da in ds.data_vars.values():
    130             da.metadata['fine_interpolation_factor'] = n

/marconi_work/FUA34_SOLBOUT4/tnichola/pycode/xarray/xarray/core/common.py in __getattr__(self, name)
    227                     return source[name]
    228         raise AttributeError(
--> 229             "{!r} object has no attribute {!r}".format(type(self).__name__, name)
    230         )
    231 

AttributeError: 'Dataset' object has no attribute 'metadata'
```
This change fixes it.