### PR TITLE
Merge reload_boutdataset() functionality into open_boutdataset()

### DIFF
--- a/xbout/__init__.py
+++ b/xbout/__init__.py
@@ -1,4 +1,4 @@
-from .load import open_boutdataset, reload_boutdataset, collect
+from .load import open_boutdataset, collect
 
 from . import geometries
 from .geometries import register_geometry, REGISTERED_GEOMETRIES

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -47,26 +47,29 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
     UnregisteredGeometryError
     """
 
-    ds = _set_attrs_on_all_vars(ds, 'geometry', geometry_name)
-
-    try:
-        add_geometry_coords = REGISTERED_GEOMETRIES[geometry_name]
-    except KeyError:
-        message = dedent("""{} is not a registered geometry. Inspect the global
-                         variable REGISTERED_GEOMETRIES to see which geometries
-                         have been registered.""".format(geometry_name))
-        raise UnregisteredGeometryError(message)
-
-    # User-registered functions may accept 'coordinates' and 'grid' arguments, but do not
-    # have to as long as they are not used
-    if coordinates is not None and grid is not None:
-        updated_ds = add_geometry_coords(ds, coordinates=coordinates, grid=grid)
-    elif coordinates is not None:
-        updated_ds = add_geometry_coords(ds, coordinates=coordinates)
-    elif grid is not None:
-        updated_ds = add_geometry_coords(ds, grid=grid)
+    if geometry_name is None:
+        updated_ds = ds
     else:
-        updated_ds = add_geometry_coords(ds)
+        ds = _set_attrs_on_all_vars(ds, 'geometry', geometry_name)
+
+        try:
+            add_geometry_coords = REGISTERED_GEOMETRIES[geometry_name]
+        except KeyError:
+            message = dedent("""{} is not a registered geometry. Inspect the global
+                             variable REGISTERED_GEOMETRIES to see which geometries
+                             have been registered.""".format(geometry_name))
+            raise UnregisteredGeometryError(message)
+
+        # User-registered functions may accept 'coordinates' and 'grid' arguments, but
+        # do not have to as long as they are not used
+        if coordinates is not None and grid is not None:
+            updated_ds = add_geometry_coords(ds, coordinates=coordinates, grid=grid)
+        elif coordinates is not None:
+            updated_ds = add_geometry_coords(ds, coordinates=coordinates)
+        elif grid is not None:
+            updated_ds = add_geometry_coords(ds, grid=grid)
+        else:
+            updated_ds = add_geometry_coords(ds)
 
     # Add global 1D coordinates
     # ######################

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -186,7 +186,7 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
 
 
 def reload_boutdataset(
-    datapath, inputfilepath=None, chunks=None, info=True, pre_squashed=False, **kwargs
+    datapath, inputfilepath=None, chunks=None, info=True, **kwargs
 ):
     """
     Reload a BoutDataset saved by bout.save(), restoring it to the state the original
@@ -202,18 +202,17 @@ def reload_boutdataset(
     chunks : dict, optional
         Passed to `xarray.open_mfdataset` or `xarray.open_dataset`
     info : bool or "terse", optional
-    pre_squashed :  bool, optional
-        Set true when loading from data which was saved as separate variables
-        using ds.bout.save().
     kwargs : optional
         Keyword arguments are passed down to `xarray.open_mfdataset` or
         `xarray.open_dataset`
     """
-    if pre_squashed:
-        ds = xr.open_mfdataset(datapath, chunks=chunks, combine='nested',
-                               concat_dim=None, **kwargs)
-    else:
-        ds = xr.open_dataset(datapath, chunks=chunks, **kwargs)
+    ds = xr.open_mfdataset(
+        datapath,
+        chunks=chunks,
+        combine='by_coords',
+        data_vars='minimal',
+        **kwargs
+    )
 
     def attrs_to_dict(obj, section):
         result = {}

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -160,12 +160,13 @@ def open_boutdataset(datapath='./BOUT.dmp.*.nc', inputfilepath=None,
                               mxg=ds.metadata['MXG'])
         else:
             grid = None
-
-        # Update coordinates to match particular geometry of grid
-        ds = geometries.apply_geometry(ds, geometry, grid=grid)
     else:
+        grid = None
         if info:
-            warn("No geometry type found, no coordinates will be added")
+            warn("No geometry type found, no physical coordinates will be added")
+
+    # Update coordinates to match particular geometry of grid
+    ds = geometries.apply_geometry(ds, geometry, grid=grid)
 
     # TODO read and store git commit hashes from output files
 

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -887,6 +887,8 @@ class TestSaveRestart:
                     x=slice(2 + proc_xind*mxsub, 2 + (proc_xind + 1)*mxsub),
                     y=slice(proc_yind*mysub, (proc_yind + 1)*mysub)
                 ).load()
+                t_array = check_ds["t"]
+                check_ds = check_ds.drop_vars(["t", "x", "y", "z"])
 
                 for v in restart_ds:
                     if v in check_ds:
@@ -895,7 +897,7 @@ class TestSaveRestart:
                         if v == "hist_hi":
                             assert restart_ds[v].values == -1
                         elif v == "tt":
-                            assert restart_ds[v].values == check_ds["t_array"]
+                            assert restart_ds[v].values == t_array
                         else:
                             assert restart_ds[v].values == check_ds.metadata[v]
 
@@ -945,6 +947,8 @@ class TestSaveRestart:
                     x=slice(2 + proc_xind*mxsub, 2 + (proc_xind + 1)*mxsub),
                     y=slice(proc_yind*mysub, (proc_yind + 1)*mysub)
                 ).load()
+                t_array = check_ds["t"]
+                check_ds = check_ds.drop_vars(["t", "x", "y", "z"])
 
                 for v in restart_ds:
                     if v in check_ds:
@@ -955,7 +959,7 @@ class TestSaveRestart:
                         elif v == "hist_hi":
                             assert restart_ds[v].values == -1
                         elif v == "tt":
-                            assert restart_ds[v].values == check_ds["t_array"]
+                            assert restart_ds[v].values == t_array
                         else:
                             assert restart_ds[v].values == check_ds.metadata[v]
 
@@ -1007,6 +1011,8 @@ class TestSaveRestart:
                     x=slice(2 + proc_xind*mxsub, 2 + (proc_xind + 1)*mxsub),
                     y=slice(proc_yind*mysub, (proc_yind + 1)*mysub)
                 ).load()
+                t_array = check_ds["t"]
+                check_ds = check_ds.drop_vars(["t", "x", "y", "z"])
 
                 for v in restart_ds:
                     if v in check_ds:
@@ -1017,7 +1023,7 @@ class TestSaveRestart:
                         elif v == "hist_hi":
                             assert restart_ds[v].values == -1
                         elif v == "tt":
-                            assert restart_ds[v].values == check_ds["t_array"]
+                            assert restart_ds[v].values == t_array
                         else:
                             assert restart_ds[v].values == check_ds.metadata[v]
 

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from xbout.tests.test_load import bout_xyt_example_files, create_bout_ds
 from xbout.tests.test_region import (params_guards, params_guards_values,
                                      params_boundaries, params_boundaries_values)
-from xbout import BoutDatasetAccessor, open_boutdataset, reload_boutdataset
+from xbout import BoutDatasetAccessor, open_boutdataset
 from xbout.geometries import apply_geometry
 from xbout.utils import _set_attrs_on_all_vars
 
@@ -750,7 +750,7 @@ class TestSave:
         original.bout.save(savepath=savepath)
 
         # Load it again
-        recovered = reload_boutdataset(savepath)
+        recovered = open_boutdataset(savepath)
 
         xrt.assert_identical(original.load(), recovered.load())
 
@@ -827,7 +827,7 @@ class TestSave:
 
         # Load it again
         savepath = str(Path(path).parent) + '/temp_boutdata_*.nc'
-        recovered = reload_boutdataset(savepath)
+        recovered = open_boutdataset(savepath)
 
         # Compare
         xrt.assert_identical(recovered, original)
@@ -872,7 +872,7 @@ class TestSave:
 
         # Load it again
         savepath = str(Path(path).parent) + '/temp_boutdata_*.nc'
-        recovered = reload_boutdataset(savepath)
+        recovered = open_boutdataset(savepath)
 
         # Compare
         xrt.assert_identical(recovered, original)

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -795,6 +795,11 @@ class TestSave:
             # Compare equal (not identical because attributes are changed when saving)
             xrt.assert_equal(recovered[var], original[var])
 
+        # test open_boutdataset() on dataset saved with separate_vars=True
+        savepath = str(Path(path).parent) + '/temp_boutdata_*.nc'
+        recovered = open_boutdataset(savepath)
+        xrt.assert_identical(original, recovered)
+
     @pytest.mark.parametrize("geometry", [None, "toroidal"])
     def test_reload_separate_variables(
         self, tmpdir_factory, bout_xyt_example_files, geometry

--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -37,6 +37,7 @@ class TestOpenGrid:
     def test_open_grid(self, create_example_grid_file):
         example_grid = create_example_grid_file
         result = open_boutdataset(datapath=example_grid)
+        result = result.drop_vars(["x", "y"])
         assert_equal(result, open_dataset(example_grid))
         result.close()
 
@@ -53,6 +54,7 @@ class TestOpenGrid:
         with pytest.warns(UserWarning, match="drop all variables containing "
                                              "the dimensions 'w'"):
             result = open_boutdataset(datapath=dodgy_grid_path)
+        result = result.drop_vars(["x", "y"])
         assert_equal(result, example_grid)
         result.close()
 
@@ -76,6 +78,7 @@ class TestOpenGrid:
     def test_open_grid_chunks(self, create_example_grid_file):
         example_grid = create_example_grid_file
         result = open_boutdataset(datapath=example_grid, chunks={'x': 4, 'y': 5})
+        result = result.drop_vars(["x", "y"])
         assert_equal(result, open_dataset(example_grid))
         result.close()
 
@@ -83,5 +86,6 @@ class TestOpenGrid:
         example_grid = create_example_grid_file
         result = open_boutdataset(datapath=example_grid,
                                   chunks={'anonexistantdimension': 5})
+        result = result.drop_vars(["x", "y"])
         assert_equal(result, open_dataset(example_grid))
         result.close()

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -534,6 +534,8 @@ class TestOpen:
         dataset = bout_xyt_example_files(None, nxpe=1, nype=1, nt=1)
         actual = open_boutdataset(datapath=dataset, keep_xboundaries=False)
         expected = create_bout_ds()
+        actual = actual.drop_vars(["x", "y", "z"])
+        expected = expected.set_coords("t_array").rename(t_array="t")
         xrt.assert_equal(actual.load(),
                          expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES
                                        + _BOUT_TIME_DEPENDENT_META_VARS,
@@ -545,6 +547,8 @@ class TestOpen:
         )
         actual = open_boutdataset(datapath=dataset, keep_xboundaries=False)
         expected = create_bout_ds()
+        actual = actual.drop_vars(["x", "y", "z"])
+        expected = expected.set_coords("t_array").rename(t_array="t")
         xrt.assert_equal(actual.load(),
                          expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES
                                        + _BOUT_TIME_DEPENDENT_META_VARS,
@@ -559,6 +563,8 @@ class TestOpen:
         bout_ds = create_bout_ds
         expected = concat([bout_ds(0), bout_ds(1), bout_ds(2), bout_ds(3)], dim='x',
                           data_vars='minimal')
+        actual = actual.drop_vars(["x", "y", "z"])
+        expected = expected.set_coords("t_array").rename(t_array="t")
         xrt.assert_equal(actual.load(),
                          expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES,
                                        errors='ignore'))
@@ -572,6 +578,8 @@ class TestOpen:
         bout_ds = create_bout_ds
         expected = concat([bout_ds(0), bout_ds(1), bout_ds(2)], dim='y',
                           data_vars='minimal')
+        actual = actual.drop_vars(["x", "y", "z"])
+        expected = expected.set_coords("t_array").rename(t_array="t")
         xrt.assert_equal(actual.load(),
                          expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES,
                                        errors='ignore'))
@@ -595,6 +603,8 @@ class TestOpen:
                        data_vars='minimal')
         expected = concat([line1, line2, line3], dim='y',
                           data_vars='minimal')
+        actual = actual.drop_vars(["x", "y", "z"])
+        expected = expected.set_coords("t_array").rename(t_array="t")
         xrt.assert_equal(actual.load(),
                          expected.drop(METADATA_VARS + _BOUT_PER_PROC_VARIABLES,
                                        errors='ignore'))

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -347,10 +347,7 @@ def _split_into_restarts(ds, variables, savepath, nxpe, nype, tind, prefix, over
             restart_ds["hist_hi"] = hist_hi
 
             # tt is the simulation time where the restart happens
-            # t_array variable may have been assigned as a coordinate and renamed as
-            # tcoord
-            t_array = ds.get("t_array", tcoord)
-            restart_ds["tt"] = t_array.values.flatten()[0]
+            restart_ds["tt"] = ds[tcoord].values.flatten()[0]
 
             restart_datasets.append(restart_ds)
 


### PR DESCRIPTION
Removes `reload_boutdataset()`. Instead updates `open_boutdataset()` to automatically detect and reload datasets saved from xBOUT, including those saved with `separate_vars=True`. `pre_squashed` argument is no longer needed so is removed.

Replaces #136.

@TomNicholas maybe overkill for your issue, but I think this solution is nicer! Does it fix the problem for you? If the broken backward compatibility with `pre_squashed` is going to be much effort for you to fix (the re-opened Datasets will be different now, e.g. will include a `metadata` attribute), then we could keep `pre_squashed` with the old behaviour on a deprecation cycle.