### PR TITLE
Make save_dtype to BoutDataset.save() work

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -463,6 +463,8 @@ class BoutDatasetAccessor:
 
         if save_dtype is not None:
             encoding = {v: {"dtype": save_dtype} for v in to_save}
+        else:
+            encoding = None
 
         if separate_vars:
             # Save each major variable to a different netCDF file

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -495,11 +495,15 @@ class BoutDatasetAccessor:
                 path = Path(savepath)
                 var_savepath = str(path.parent / path.stem) + '_' \
                                + str(major_var) + path.suffix
+                if encoding is not None:
+                    var_encoding = {major_var: encoding[major_var]}
+                else:
+                    var_encoding = None
                 print('Saving ' + major_var + ' data...')
                 with ProgressBar():
                     single_var_ds.to_netcdf(path=str(var_savepath),
                                             format=filetype, compute=True,
-                                            encoding={major_var: encoding[major_var]})
+                                            encoding=var_encoding)
 
                 # Force memory deallocation to limit RAM usage
                 single_var_ds.close()

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -774,7 +774,7 @@ class TestSave:
         savepath = str(Path(path).parent) + '/temp_boutdata.nc'
         original.bout.save(
             savepath=savepath,
-            save_dtype=np.dtype(save_dtype),
+            save_dtype=save_dtype,
             separate_vars=separate_vars
         )
 

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -746,7 +746,7 @@ class TestSave:
                    )
 
         # Save it to a netCDF file
-        savepath = str(Path(path).parent) + 'temp_boutdata.nc'
+        savepath = str(Path(path).parent) + '/temp_boutdata.nc'
         original.bout.save(savepath=savepath)
 
         # Load it again
@@ -767,7 +767,7 @@ class TestSave:
         original = open_boutdataset(datapath=path, inputfilepath=None)
 
         # Save it to a netCDF file
-        savepath = str(Path(path).parent) + 'temp_boutdata.nc'
+        savepath = str(Path(path).parent) + '/temp_boutdata.nc'
         original.bout.save(savepath=savepath, save_dtype=np.dtype(save_dtype))
 
         # Load it again using bare xarray

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -754,13 +754,12 @@ class TestSave:
 
         xrt.assert_identical(original.load(), recovered.load())
 
-    @pytest.mark.skip("saving and loading as float32 does not work")
     @pytest.mark.parametrize("save_dtype", [np.float64, np.float32])
     def test_save_dtype(self, tmpdir_factory, bout_xyt_example_files, save_dtype):
 
         # Create data
         path = bout_xyt_example_files(
-            tmpdir_factory, nxpe=1, nype=1, nt=1, write_to_grid=True
+            tmpdir_factory, nxpe=1, nype=1, nt=1, write_to_disk=True
         )
 
         # Load it as a boutdataset


### PR DESCRIPTION
We can change the datatype of the output file successfully by passing an `encoding` argument to `xr.Dataset.to_netcdf()`.

Also un-skips and updates the test for `save_dtype` functionality.