### PR TITLE
Fixes for attributes of coordinates

### DIFF
--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -88,8 +88,11 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
 
     if (tcoord not in updated_ds.coords) and (tcoord in updated_ds.dims):
         # Create the time coordinate from t_array
-        updated_ds = updated_ds.rename({'t_array': tcoord})
-        updated_ds = updated_ds.set_coords(tcoord)
+        # Slightly odd looking way to create coordinate ensures 'index variable' is
+        # created, which using set_coords() does not (possible xarray bug?
+        # https://github.com/pydata/xarray/issues/4417
+        updated_ds[tcoord] = updated_ds["t_array"]
+        updated_ds = updated_ds.drop_vars("t_array")
 
     if xcoord not in updated_ds.coords:
         # Make index 'x' a coordinate, useful for handling global indexing

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -84,7 +84,7 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
     ycoord = updated_ds.metadata.get('bout_ydim', 'y')
     zcoord = updated_ds.metadata.get('bout_zdim', 'z')
 
-    if (tcoord not in ds.coords) and (tcoord in ds.dims):
+    if (tcoord not in updated_ds.coords) and (tcoord in updated_ds.dims):
         # Create the time coordinate from t_array
         updated_ds = updated_ds.rename({'t_array': tcoord})
         updated_ds = updated_ds.set_coords(tcoord)

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -71,6 +71,8 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
         else:
             updated_ds = add_geometry_coords(ds)
 
+    del ds
+
     # Add global 1D coordinates
     # ######################
     # Note the global coordinates used here are defined so that they are zero at

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -957,6 +957,9 @@ def _concat_upper_guards(da, da_global, mxg, myg):
 
 
 def _from_region(ds_or_da, name, with_guards):
+    # ensure we do not modify the input
+    ds_or_da = ds_or_da.copy(deep=True)
+
     region = ds_or_da.regions[name]
     xcoord = ds_or_da.metadata['bout_xdim']
     ycoord = ds_or_da.metadata['bout_ydim']
@@ -972,10 +975,8 @@ def _from_region(ds_or_da, name, with_guards):
             mxg = with_guards
             myg = with_guards
 
-    result = ds_or_da.isel(region.get_slices())
+    result = ds_or_da.isel(region.get_slices()).copy()
 
-    # Make sure attrs are unique before we change them
-    result.attrs = copy(result.attrs)
     # The returned result has only one region
     single_region = deepcopy(region)
     result.attrs['regions'] = {name: single_region}

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -728,7 +728,14 @@ def _concat_inner_guards(da, da_global, mxg):
         slices = region.get_inner_guards_slices(mxg=mxg)
         new_xcoord = da_global[xcoord].isel(**{xcoord: slices[xcoord]})
         new_ycoord = da_global[ycoord].isel(**{ycoord: slices[ycoord]})
-        da_inner = da_inner.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
+
+        # can't use commented out version, uncommented one works around xarray bug
+        # removing attrs
+        # https://github.com/pydata/xarray/issues/4415
+        # https://github.com/pydata/xarray/issues/4393
+        # da_inner = da_inner.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
+        da_inner[xcoord].data[...] = new_xcoord.data
+        da_inner[ycoord].data[...] = new_ycoord.data
 
     save_regions = da.regions
     da = xr.concat((da_inner, da), xcoord, join='exact')
@@ -812,7 +819,14 @@ def _concat_outer_guards(da, da_global, mxg):
         slices = region.get_outer_guards_slices(mxg=mxg)
         new_xcoord = da_global[xcoord].isel(**{xcoord: slices[xcoord]})
         new_ycoord = da_global[ycoord].isel(**{ycoord: slices[ycoord]})
-        da_outer = da_outer.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
+
+        # can't use commented out version, uncommented one works around xarray bug
+        # removing attrs
+        # https://github.com/pydata/xarray/issues/4415
+        # https://github.com/pydata/xarray/issues/4393
+        # da_outer = da_outer.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
+        da_outer[xcoord].data[...] = new_xcoord.data
+        da_outer[ycoord].data[...] = new_ycoord.data
 
     save_regions = da.regions
     da = xr.concat((da, da_outer), xcoord, join='exact')
@@ -865,7 +879,14 @@ def _concat_lower_guards(da, da_global, mxg, myg):
 
         new_xcoord = da_global[xcoord].isel(**{xcoord: slices[xcoord]})
         new_ycoord = da_global[ycoord].isel(**{ycoord: slices[ycoord]})
-        da_lower = da_lower.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
+
+        # can't use commented out version, uncommented one works around xarray bug
+        # removing attrs
+        # https://github.com/pydata/xarray/issues/4415
+        # https://github.com/pydata/xarray/issues/4393
+        # da_lower = da_lower.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
+        da_lower[xcoord].data[...] = new_xcoord.data
+        da_lower[ycoord].data[...] = new_ycoord.data
 
     save_regions = da.regions
     da = xr.concat((da_lower, da), ycoord, join='exact')
@@ -918,7 +939,14 @@ def _concat_upper_guards(da, da_global, mxg, myg):
 
         new_xcoord = da_global[xcoord].isel(**{xcoord: slices[xcoord]})
         new_ycoord = da_global[ycoord].isel(**{ycoord: slices[ycoord]})
-        da_upper = da_upper.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
+
+        # can't use commented out version, uncommented one works around xarray bug
+        # removing attrs
+        # https://github.com/pydata/xarray/issues/4415
+        # https://github.com/pydata/xarray/issues/4393
+        # da_upper = da_upper.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
+        da_upper[xcoord].data[...] = new_xcoord.data
+        da_upper[ycoord].data[...] = new_ycoord.data
 
     save_regions = da.regions
     da = xr.concat((da, da_upper), ycoord, join='exact')


### PR DESCRIPTION
A bug in xarray (https://github.com/pydata/xarray/issues/2180#issuecomment-391932929, https://github.com/pydata/xarray/issues/4393, https://github.com/pydata/xarray/issues/4415) can result in attributes being deleted from coordinates when a new DataArray is added to a Dataset. This PR adds workarounds for that bug, and also some other fixes to make sure re-loaded Datasets get coordinates identical to the saved Dataset (including attrs).

Also added a work-around for a second weird possible bug in xarray https://github.com/pydata/xarray/issues/4417.