### PR TITLE
Correct conda installation instruction with '-c conda-forge'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install --user xbout
 
 With conda:
 ```bash
-conda install xbout
+conda install -c conda-forge xbout
 ```
 
 You can test your installation of `xBOUT` by running `pytest --pyargs xbout`.


### PR DESCRIPTION
Previous version only worked if you had already configured `conda` to always use the `conda-forge` channel.