### PR TITLE
animation updates

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
         pip-packages:
           - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
         pip-packages:
           - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
         pip-packages:
           - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.1 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: true
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boutdata>=0.1.2
 dask[array]>=2.10.0
 natsort>=5.5.0
 matplotlib>=3.1.1
-animatplot>=0.4.1
+animatplot>=0.4.2
 netcdf4>=1.4.0
 Pillow>=6.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ xarray>=0.16.0
 boutdata>=0.1.2
 dask[array]>=2.10.0
 natsort>=5.5.0
-matplotlib>=3.1.1
+matplotlib>=3.1.1,!=3.3.0,!=3.3.1,!=3.3.2
 animatplot>=0.4.2
 netcdf4>=1.4.0
 Pillow>=6.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     boutdata>=0.1.2
     dask[array]>=2.10.0
     natsort>=5.5.0
-    matplotlib>=3.1.1
+    matplotlib>=3.1.1,!=3.3.0,!=3.3.1,!=3.3.2
     animatplot>=0.4.2
     netcdf4>=1.4.0
     Pillow>=6.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     dask[array]>=2.10.0
     natsort>=5.5.0
     matplotlib>=3.1.1
-    animatplot>=0.4.1
+    animatplot>=0.4.2
     netcdf4>=1.4.0
     Pillow>=6.1.0
     importlib-metadata; python_version < "3.8"

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -506,7 +506,7 @@ class BoutDataArrayAccessor:
         animate : bool, optional
             If set to false, do not create the animation, just return the block or blocks
         axis_coords : None, str, dict
-            Coordinates to use for axis labelling.  Only affects time coordinate.
+            Coordinates to use for axis labelling.
             - None: Use the dimension coordinate for each axis, if it exists.
             - "index": Use the integer index values.
             - dict: keys are dimension names, values set axis_coords for each axis
@@ -514,6 +514,7 @@ class BoutDataArrayAccessor:
               coordinate (which must have the dimension given by 'key'), or a 1d
               numpy array, dask array or DataArray whose length matches the length of
               the dimension given by 'key'.
+            Only affects time coordinate for plots with poloidal_plot=True.
         fps : int, optional
             Frames per second of resulting gif
         save_as : True or str, optional
@@ -613,7 +614,7 @@ class BoutDataArrayAccessor:
         animate_over : str, optional
             Dimension over which to animate, defaults to the time dimension
         axis_coords : None, str, dict
-            Coordinates to use for axis labelling.  Only affects time coordinate.
+            Coordinates to use for axis labelling.
             - None: Use the dimension coordinate for each axis, if it exists.
             - "index": Use the integer index values.
             - dict: keys are dimension names, values set axis_coords for each axis

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -474,7 +474,7 @@ class BoutDataArrayAccessor:
 
     def animate2D(
         self,
-        animate_over="t",
+        animate_over=None,
         x=None,
         y=None,
         animate=True,
@@ -496,7 +496,7 @@ class BoutDataArrayAccessor:
         Parameters
         ----------
         animate_over : str, optional
-            Dimension over which to animate
+            Dimension over which to animate, defaults to the time dimension
         x : str, optional
             Dimension to use on the x axis, default is None - then use the first spatial
             dimension of the data
@@ -593,7 +593,7 @@ class BoutDataArrayAccessor:
 
     def animate1D(
         self,
-        animate_over="t",
+        animate_over=None,
         animate=True,
         axis_coords=None,
         fps=10,
@@ -611,7 +611,7 @@ class BoutDataArrayAccessor:
         Parameters
         ----------
         animate_over : str, optional
-            Dimension over which to animate
+            Dimension over which to animate, defaults to the time dimension
         axis_coords : None, str, dict
             Coordinates to use for axis labelling.  Only affects time coordinate.
             - None: Use the dimension coordinate for each axis, if it exists.

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -478,6 +478,7 @@ class BoutDataArrayAccessor:
         x=None,
         y=None,
         animate=True,
+        axis_coords=None,
         fps=10,
         save_as=None,
         ax=None,
@@ -504,6 +505,15 @@ class BoutDataArrayAccessor:
             dimension of the data
         animate : bool, optional
             If set to false, do not create the animation, just return the block or blocks
+        axis_coords : None, str, dict
+            Coordinates to use for axis labelling.  Only affects time coordinate.
+            - None: Use the dimension coordinate for each axis, if it exists.
+            - "index": Use the integer index values.
+            - dict: keys are dimension names, values set axis_coords for each axis
+              separately. Values can be: None, "index", the name of a 1d variable or
+              coordinate (which must have the dimension given by 'key'), or a 1d
+              numpy array, dask array or DataArray whose length matches the length of
+              the dimension given by 'key'.
         fps : int, optional
             Frames per second of resulting gif
         save_as : True or str, optional
@@ -550,6 +560,7 @@ class BoutDataArrayAccessor:
                     data,
                     animate_over=animate_over,
                     animate=animate,
+                    axis_coords=axis_coords,
                     fps=fps,
                     save_as=save_as,
                     ax=ax,
@@ -567,6 +578,7 @@ class BoutDataArrayAccessor:
                     x=x,
                     y=y,
                     animate=animate,
+                    axis_coords=axis_coords,
                     fps=fps,
                     save_as=save_as,
                     ax=ax,
@@ -583,6 +595,7 @@ class BoutDataArrayAccessor:
         self,
         animate_over="t",
         animate=True,
+        axis_coords=None,
         fps=10,
         save_as=None,
         sep_pos=None,
@@ -599,6 +612,15 @@ class BoutDataArrayAccessor:
         ----------
         animate_over : str, optional
             Dimension over which to animate
+        axis_coords : None, str, dict
+            Coordinates to use for axis labelling.  Only affects time coordinate.
+            - None: Use the dimension coordinate for each axis, if it exists.
+            - "index": Use the integer index values.
+            - dict: keys are dimension names, values set axis_coords for each axis
+              separately. Values can be: None, "index", the name of a 1d variable or
+              coordinate (which must have the dimension given by 'key'), or a 1d
+              numpy array, dask array or DataArray whose length matches the length of
+              the dimension given by 'key'.
         fps : int, optional
             Frames per second of resulting gif
         save_as : True or str, optional
@@ -627,6 +649,7 @@ class BoutDataArrayAccessor:
             line_block = animate_line(
                 data=data,
                 animate_over=animate_over,
+                axis_coords=axis_coords,
                 sep_pos=sep_pos,
                 animate=animate,
                 fps=fps,

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -532,6 +532,9 @@ class BoutDataArrayAccessor:
             threshold of a symmetric logarithmic scale as
             linthresh=min(abs(vmin),abs(vmax))*logscale, defaults to 1e-5 if True is
             passed.
+        aspect : str or None, optional
+            Argument to set_aspect(). Defaults to "equal" for poloidal plots and "equal"
+            for others.
         kwargs : dict, optional
             Additional keyword arguments are passed on to the plotting function
             (animatplot.blocks.Pcolormesh).
@@ -633,6 +636,8 @@ class BoutDataArrayAccessor:
         ax : Axes, optional
             A matplotlib axes instance to plot to. If None, create a new
             figure and axes, and plot to that
+        aspect : str or None, optional
+            Argument to set_aspect(), defaults to "auto"
         kwargs : dict, optional
             Additional keyword arguments are passed on to the plotting function
             (animatplot.blocks.Line).

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -533,7 +533,7 @@ class BoutDataArrayAccessor:
             linthresh=min(abs(vmin),abs(vmax))*logscale, defaults to 1e-5 if True is
             passed.
         aspect : str or None, optional
-            Argument to set_aspect(). Defaults to "equal" for poloidal plots and "equal"
+            Argument to set_aspect(). Defaults to "equal" for poloidal plots and "auto"
             for others.
         kwargs : dict, optional
             Additional keyword arguments are passed on to the plotting function

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -691,7 +691,8 @@ class BoutDatasetAccessor:
             Custom titles for each plot. Pass None in the sequence to use the default for
             a certain variable
         aspect : str or None, or sequence of str or None, optional
-            Argument to set_aspect() for each plot
+            Argument to set_aspect() for each plot. Defaults to "equal" for poloidal
+            plots and "auto" for others.
         extend : str or None, optional
             Passed to fig.colorbar()
         controls : bool, optional
@@ -816,13 +817,6 @@ class BoutDatasetAccessor:
                 ndims = len(data.dims)
                 ax.set_title(data.name)
 
-            if this_aspect is None:
-                if ndims == 3:
-                    this_aspect = "equal"
-                else:
-                    this_aspect = "auto"
-            ax.set_aspect(this_aspect)
-
             if ndims == 2:
                 if not is_list(v):
                     blocks.append(
@@ -832,6 +826,7 @@ class BoutDatasetAccessor:
                             animate_over=animate_over,
                             animate=False,
                             axis_coords=this_axis_coords,
+                            aspect=this_aspect,
                             **kwargs,
                         )
                     )
@@ -844,6 +839,7 @@ class BoutDatasetAccessor:
                                 animate_over=animate_over,
                                 animate=False,
                                 axis_coords=this_axis_coords,
+                                aspect=this_aspect,
                                 label=w.name,
                                 **kwargs,
                             )
@@ -891,6 +887,7 @@ class BoutDatasetAccessor:
                             vmin=this_vmin,
                             vmax=this_vmax,
                             norm=norm,
+                            aspect=this_aspect,
                             extend=this_extend,
                             **kwargs,
                         )

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -630,7 +630,7 @@ class BoutDatasetAccessor:
         vmax=None,
         logscale=None,
         titles=None,
-        aspect="equal",
+        aspect=None,
         extend=None,
         controls=True,
         tight_layout=True,
@@ -790,8 +790,6 @@ class BoutDatasetAccessor:
             divider = make_axes_locatable(ax)
             cax = divider.append_axes("right", size="5%", pad=0.1)
 
-            ax.set_aspect(this_aspect)
-
             if is_list(v):
                 for i in range(len(v)):
                     if isinstance(v[i], str):
@@ -817,6 +815,13 @@ class BoutDatasetAccessor:
                 data = v.bout.data
                 ndims = len(data.dims)
                 ax.set_title(data.name)
+
+            if this_aspect is None:
+                if ndims == 3:
+                    this_aspect = "equal"
+                else:
+                    this_aspect = "auto"
+            ax.set_aspect(this_aspect)
 
             if ndims == 2:
                 if not is_list(v):

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -18,7 +18,12 @@ import numpy as np
 from dask.diagnostics import ProgressBar
 
 from .geometries import apply_geometry
-from .plotting.animate import animate_poloidal, animate_pcolormesh, animate_line
+from .plotting.animate import (
+    animate_poloidal,
+    animate_pcolormesh,
+    animate_line,
+    _parse_coord_option,
+)
 from .plotting.utils import _create_norm
 from .region import _from_region
 from .utils import _get_bounding_surfaces, _split_into_restarts
@@ -618,6 +623,7 @@ class BoutDatasetAccessor:
         nrows=None,
         ncols=None,
         poloidal_plot=False,
+        axis_coords=None,
         subplots_adjust=None,
         vmin=None,
         vmax=None,
@@ -653,6 +659,20 @@ class BoutDatasetAccessor:
         poloidal_plot : bool or sequence of bool, optional
             If set to True, make all 2D animations in the poloidal plane instead of using
             grid coordinates, per variable if sequence is given
+        axis_coords : None, str, dict or list of None, str or dict
+            Coordinates to use for axis labelling.
+            - None: Use the dimension coordinate for each axis, if it exists.
+            - "index": Use the integer index values.
+            - dict: keys are dimension names, values set axis_coords for each axis
+              separately. Values can be: None, "index", the name of a 1d variable or
+              coordinate (which must have the dimension given by 'key'), or a 1d
+              numpy array, dask array or DataArray whose length matches the length of
+              the dimension given by 'key'.
+            Only affects time coordinate for plots with poloidal_plot=True.
+            If a list is passed, it must have the same length as 'variables' and gives
+            the axis_coords setting for each plot individually.
+            The setting to use for the 'animate_over' coordinate can be passed in one or
+            more dict values, but must be the same in all dicts if given more than once.
         subplots_adjust : dict, optional
             Arguments passed to fig.subplots_adjust()()
         vmin : float or sequence of floats
@@ -726,6 +746,7 @@ class BoutDatasetAccessor:
         titles = _expand_list_arg(titles, "titles")
         aspect = _expand_list_arg(aspect, "aspect")
         extend = _expand_list_arg(extend, "extend")
+        axis_coords = _expand_list_arg(axis_coords, "axis_coords")
 
         blocks = []
 
@@ -737,13 +758,23 @@ class BoutDatasetAccessor:
             )
 
         for subplot_args in zip(
-            variables, axes, poloidal_plot, vmin, vmax, logscale, titles, aspect, extend
+            variables,
+            axes,
+            poloidal_plot,
+            axis_coords,
+            vmin,
+            vmax,
+            logscale,
+            titles,
+            aspect,
+            extend,
         ):
 
             (
                 v,
                 ax,
                 this_poloidal_plot,
+                this_axis_coords,
                 this_vmin,
                 this_vmax,
                 this_logscale,
@@ -791,6 +822,7 @@ class BoutDatasetAccessor:
                             ax=ax,
                             animate_over=animate_over,
                             animate=False,
+                            axis_coords=this_axis_coords,
                             **kwargs,
                         )
                     )
@@ -802,6 +834,7 @@ class BoutDatasetAccessor:
                                 ax=ax,
                                 animate_over=animate_over,
                                 animate=False,
+                                axis_coords=this_axis_coords,
                                 label=w.name,
                                 **kwargs,
                             )
@@ -827,6 +860,7 @@ class BoutDatasetAccessor:
                         cax=cax,
                         animate_over=animate_over,
                         animate=False,
+                        axis_coords=this_axis_coords,
                         vmin=this_vmin,
                         vmax=this_vmax,
                         norm=norm,
@@ -844,6 +878,7 @@ class BoutDatasetAccessor:
                             cax=cax,
                             animate_over=animate_over,
                             animate=False,
+                            axis_coords=this_axis_coords,
                             vmin=this_vmin,
                             vmax=this_vmax,
                             norm=norm,
@@ -863,7 +898,26 @@ class BoutDatasetAccessor:
                 # Replace default title with user-specified one
                 ax.set_title(this_title)
 
-        timeline = amp.Timeline(np.arange(v.sizes[animate_over]), fps=fps)
+        if np.all([a == "index" for a in axis_coords]):
+            time_opt = "index"
+        elif np.any([isinstance(a, dict) and animate_over in a for a in axis_coords]):
+            given_values = [
+                a[animate_over]
+                for a in axis_coords
+                if isinstance(a, dict) and animate_over in a
+            ]
+            time_opt = given_values[0]
+            if len(given_values) > 1 and not np.all(
+                [v == time_opt for v in given_values[1:]]
+            ):
+                raise ValueError(
+                    f"Inconsistent axis_coords values given for animate_over "
+                    f"coordinate ({animate_over}). Got {given_values}."
+                )
+        else:
+            time_opt = None
+        time_values, time_label = _parse_coord_option(animate_over, time_opt, self.data)
+        timeline = amp.Timeline(time_values, fps=fps)
         anim = amp.Animation(blocks, timeline)
 
         if tight_layout:
@@ -878,7 +932,7 @@ class BoutDatasetAccessor:
             fig.tight_layout(**tight_layout)
 
         if controls:
-            anim.controls(timeline_slider_args={"text": animate_over})
+            anim.controls(timeline_slider_args={"text": time_label})
 
         if save_as is not None:
             anim.save(save_as + ".gif", writer=PillowWriter(fps=fps))

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -22,6 +22,7 @@ from .plotting.animate import (
     animate_poloidal,
     animate_pcolormesh,
     animate_line,
+    _normalise_time_coord,
     _parse_coord_option,
 )
 from .plotting.utils import _create_norm
@@ -917,7 +918,9 @@ class BoutDatasetAccessor:
         else:
             time_opt = None
         time_values, time_label = _parse_coord_option(animate_over, time_opt, self.data)
-        timeline = amp.Timeline(time_values, fps=fps)
+        time_values, time_suffix = _normalise_time_coord(time_values)
+
+        timeline = amp.Timeline(time_values, fps=fps, units=time_suffix)
         anim = amp.Animation(blocks, timeline)
 
         if tight_layout:

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -617,7 +617,7 @@ class BoutDatasetAccessor:
     def animate_list(
         self,
         variables,
-        animate_over="t",
+        animate_over=None,
         save_as=None,
         show=False,
         fps=10,
@@ -646,7 +646,7 @@ class BoutDatasetAccessor:
             allow more flexible plots, e.g. with different variables being
             plotted against different axes.
         animate_over : str, optional
-            Dimension over which to animate
+            Dimension over which to animate, defaults to the time dimension
         save_as : str, optional
             If passed, a gif is created with this filename
         show : bool, optional
@@ -703,6 +703,9 @@ class BoutDatasetAccessor:
         **kwargs : dict, optional
             Additional keyword arguments are passed on to each animation function
         """
+
+        if animate_over is None:
+            animate_over = self.metadata.get("bout_tdim", "t")
 
         nvars = len(variables)
 

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -32,7 +32,7 @@ def _parse_coord_option(coord, axis_coords, da):
         else:
             label = coord
         if "units" in c.attrs:
-            label += f" [{c.units}]"
+            label = label + f" [{c.units}]"
         return c, label
     elif option_value == "index":
         return np.arange(da.sizes[coord]), f"{coord} index"
@@ -43,7 +43,7 @@ def _parse_coord_option(coord, axis_coords, da):
         else:
             label = option_value
         if "units" in c.attrs:
-            label += f" [{c.units}]"
+            label = label + f" [{c.units}]"
         return c, label
     else:
         return option_value, None

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -113,7 +113,7 @@ def animate_poloidal(
     cmap : matplotlib.colors.Colormap instance, optional
         Colors to use for the plot
     axis_coords : None, str, dict
-        Coordinates to use for axis labelling.  Only affects time coordinate.
+        Coordinates to use for axis labelling. Only affects time coordinate.
         - None: Use the dimension coordinate for each axis, if it exists.
         - "index": Use the integer index values.
         - dict: keys are dimension names, values set axis_coords for each axis
@@ -298,7 +298,7 @@ def animate_pcolormesh(
     animate : bool, optional
         If set to false, do not create the animation, just return the block
     axis_coords : None, str, dict
-        Coordinates to use for axis labelling.  Only affects time coordinate.
+        Coordinates to use for axis labelling.
         - None: Use the dimension coordinate for each axis, if it exists.
         - "index": Use the integer index values.
         - dict: keys are dimension names, values set axis_coords for each axis
@@ -477,7 +477,7 @@ def animate_line(
     animate : bool, optional
         If set to false, do not create the animation, just return the block
     axis_coords : None, str, dict
-        Coordinates to use for axis labelling.  Only affects time coordinate.
+        Coordinates to use for axis labelling.
         - None: Use the dimension coordinate for each axis, if it exists.
         - "index": Use the integer index values.
         - dict: keys are dimension names, values set axis_coords for each axis

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -84,7 +84,7 @@ def animate_poloidal(
     save_as=None,
     fps=10,
     controls=True,
-    aspect="equal",
+    aspect=None,
     extend=None,
     **kwargs,
 ):
@@ -136,7 +136,7 @@ def animate_poloidal(
     controls : bool, optional
         If False, do not add the timeline and pause button to the animation
     aspect : str or None, optional
-        Argument to set_aspect()
+        Argument to set_aspect(), defaults to "equal"
     extend : str or None, optional
         Passed to fig.colorbar()
     **kwargs : optional
@@ -151,6 +151,9 @@ def animate_poloidal(
 
     if animate_over is None:
         animate_over = da.metadata.get("bout_tdim", "t")
+
+    if aspect is None:
+        aspect = "equal"
 
     # TODO generalise this
     x = kwargs.pop("x", "R")
@@ -273,6 +276,7 @@ def animate_pcolormesh(
     save_as=None,
     ax=None,
     cax=None,
+    aspect=None,
     extend=None,
     controls=True,
     **kwargs,
@@ -326,6 +330,8 @@ def animate_pcolormesh(
     cax : Axes, optional
         Matplotlib axes instance where the colorbar will be plotted. If None, the default
         position created by matplotlab.figure.Figure.colorbar() will be used.
+    aspect : str or None, optional
+        Argument to set_aspect(), defaults to "auto"
     extend : str or None, optional
         Passed to fig.colorbar()
     controls : bool, optional
@@ -337,6 +343,9 @@ def animate_pcolormesh(
 
     if animate_over is None:
         animate_over = data.metadata.get("bout_tdim", "t")
+
+    if aspect is None:
+        aspect = "auto"
 
     variable = data.name
 
@@ -397,6 +406,8 @@ def animate_pcolormesh(
 
     if not ax:
         fig, ax = plt.subplots()
+
+    ax.set_aspect(aspect)
 
     # Note: animatplot's Pcolormesh gave strange outputs without passing
     # explicitly x- and y-value arrays, although in principle these should not
@@ -461,6 +472,7 @@ def animate_line(
     save_as=None,
     sep_pos=None,
     ax=None,
+    aspect=None,
     controls=True,
     **kwargs,
 ):
@@ -502,6 +514,8 @@ def animate_line(
     ax : Axes, optional
         A matplotlib axes instance to plot to. If None, create a new
         figure and axes, and plot to that
+    aspect : str or None, optional
+        Argument to set_aspect(), defaults to "auto"
     controls : bool, optional
         If False, do not add the timeline and pause button to the animation
     kwargs : dict, optional
@@ -511,6 +525,9 @@ def animate_line(
 
     if animate_over is None:
         animate_over = data.metadata.get("bout_tdim", "t")
+
+    if aspect is None:
+        aspect = "auto"
 
     variable = data.name
 
@@ -537,6 +554,8 @@ def animate_line(
 
     if not ax:
         fig, ax = plt.subplots()
+
+    ax.set_aspect(aspect)
 
     # set range of plot
     ax.set_ylim([vmin, vmax])

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -584,7 +584,7 @@ def animate_line(
     else:
         y_label = variable
     if "units" in data.attrs:
-        y_label += f" [{data.units}]"
+        y_label = y_label + f" [{data.units}]"
     ax.set_ylabel(y_label)
 
     # Plot separatrix

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -196,7 +196,14 @@ def animate_poloidal(
     sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap)
     sm.set_array([])
     cmap = sm.get_cmap()
-    fig.colorbar(sm, ax=ax, cax=cax, extend=extend)
+    cbar = fig.colorbar(sm, ax=ax, cax=cax, extend=extend)
+    if "long_name" in data.attrs:
+        cbar_label = data.long_name
+    else:
+        cbar_label = variable
+    if "units" in data.attrs:
+        cbar_label += f" [{data.units}]"
+    cbar.ax.set_ylabel(cbar_label)
 
     ax.set_aspect(aspect)
 

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -72,7 +72,7 @@ def animate_poloidal(
     *,
     ax=None,
     cax=None,
-    animate_over="t",
+    animate_over=None,
     separatrix=True,
     targets=True,
     add_limiter_hatching=True,
@@ -102,6 +102,8 @@ def animate_poloidal(
     cax : Axes, optional
         Matplotlib axes instance where the colorbar will be plotted. If None, the default
         position created by matplotlab.figure.Figure.colorbar() will be used.
+    animate_over : str, optional
+        Dimension over which to animate, defaults to the time dimension
     separatrix : bool, optional
         Add dashed lines showing separatrices
     targets : bool, optional
@@ -146,6 +148,9 @@ def animate_poloidal(
     blocks
         List of animatplot.blocks.Pcolormesh instances
     """
+
+    if animate_over is None:
+        animate_over = da.metadata.get("bout_tdim", "t")
 
     # TODO generalise this
     x = kwargs.pop("x", "R")
@@ -256,7 +261,7 @@ def animate_poloidal(
 
 def animate_pcolormesh(
     data,
-    animate_over="t",
+    animate_over=None,
     x=None,
     y=None,
     animate=True,
@@ -283,7 +288,7 @@ def animate_pcolormesh(
     ----------
     data : xarray.DataArray
     animate_over : str, optional
-        Dimension over which to animate
+        Dimension over which to animate, defaults to the time dimension
     x : str, optional
         Dimension to use on the x axis, default is None - then use the first spatial
         dimension of the data
@@ -329,6 +334,9 @@ def animate_pcolormesh(
         Additional keyword arguments are passed on to the animation function
         animatplot.blocks.Pcolormesh
     """
+
+    if animate_over is None:
+        animate_over = data.metadata.get("bout_tdim", "t")
 
     variable = data.name
 
@@ -444,7 +452,7 @@ def animate_pcolormesh(
 
 def animate_line(
     data,
-    animate_over="t",
+    animate_over=None,
     animate=True,
     axis_coords=None,
     vmin=None,
@@ -465,7 +473,7 @@ def animate_line(
     ----------
     data : xarray.DataArray
     animate_over : str, optional
-        Dimension over which to animate
+        Dimension over which to animate, defaults to the time dimension
     animate : bool, optional
         If set to false, do not create the animation, just return the block
     axis_coords : None, str, dict
@@ -500,6 +508,9 @@ def animate_line(
         Additional keyword arguments are passed on to the plotting function
         animatplot.blocks.Line
     """
+
+    if animate_over is None:
+        animate_over = data.metadata.get("bout_tdim", "t")
 
     variable = data.name
 

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -49,6 +49,24 @@ def _parse_coord_option(coord, axis_coords, da):
         return option_value, None
 
 
+def _normalise_time_coord(time_values):
+    """
+    amp.Timeline() does not do a good job of displaying time values that are very small
+    (they get rounded to zero). This function scales the time values by a power of 10 to
+    get nice values and modifies the units by the scale factor.
+    """
+    tmax = time_values.max()
+    if tmax < 1.0e-2 or tmax > 1.0e6:
+        scale_pow = int(np.floor(np.log10(tmax)))
+        scale_factor = 10 ** scale_pow
+        time_values = time_values / scale_factor
+        suffix = f"e{scale_pow}"
+    else:
+        suffix = ""
+
+    return time_values, suffix
+
+
 def animate_poloidal(
     da,
     *,
@@ -220,8 +238,9 @@ def animate_poloidal(
 
     if animate:
         t_values, t_label = _parse_coord_option(animate_over, axis_coords, da)
+        t_values, t_suffix = _normalise_time_coord(t_values)
 
-        timeline = amp.Timeline(t_values, fps=fps)
+        timeline = amp.Timeline(t_values, fps=fps, units=t_suffix)
         anim = amp.Animation(blocks, timeline)
 
         if controls:
@@ -392,7 +411,9 @@ def animate_pcolormesh(
 
     if animate:
         t_values, t_label = _parse_coord_option(animate_over, axis_coords, data)
-        timeline = amp.Timeline(t_values, fps=fps)
+        t_values, t_suffix = _normalise_time_coord(t_values)
+
+        timeline = amp.Timeline(t_values, fps=fps, units=t_suffix)
         anim = amp.Animation([pcolormesh_block], timeline)
 
     cbar = plt.colorbar(pcolormesh_block.quad, ax=ax, cax=cax, extend=extend)
@@ -513,7 +534,9 @@ def animate_line(
 
     if animate:
         t_values, t_label = _parse_coord_option(animate_over, axis_coords, data)
-        timeline = amp.Timeline(t_values, fps=fps)
+        t_values, t_suffix = _normalise_time_coord(t_values)
+
+        timeline = amp.Timeline(t_values, fps=fps, units=t_suffix)
         anim = amp.Animation([line_block], timeline)
 
     # Add title and axis labels

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -396,7 +396,13 @@ def animate_pcolormesh(
         anim = amp.Animation([pcolormesh_block], timeline)
 
     cbar = plt.colorbar(pcolormesh_block.quad, ax=ax, cax=cax, extend=extend)
-    cbar.ax.set_ylabel(variable)
+    if "long_name" in data.attrs:
+        cbar_label = data.long_name
+    else:
+        cbar_label = variable
+    if "units" in data.attrs:
+        cbar_label += f" [{data.units}]"
+    cbar.ax.set_ylabel(cbar_label)
 
     # Add title and axis labels
     ax.set_title(variable)
@@ -513,7 +519,13 @@ def animate_line(
     # Add title and axis labels
     ax.set_title(variable)
     ax.set_xlabel(x_label)
-    ax.set_ylabel(variable)
+    if "long_name" in data.attrs:
+        y_label = data.long_name
+    else:
+        y_label = variable
+    if "units" in data.attrs:
+        y_label += f" [{data.units}]"
+    ax.set_ylabel(y_label)
 
     # Plot separatrix
     if sep_pos:

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -9,6 +9,16 @@ from .utils import _decompose_regions, _is_core_only, plot_separatrices, plot_ta
 from matplotlib.animation import PillowWriter
 
 
+if (
+    "pcolor.shading" in matplotlib.rcParams
+    and matplotlib.rcParams["pcolor.shading"] == "flat"
+):
+    # "flat" was the old matplotlib default which discarded the last row and column if
+    # X, Y and Z were all equal in size. The new "auto" should be better. Need to set
+    # this explicitly because "flat" is the default during a deprecation cycle.
+    matplotlib.rcParams["pcolor.shading"] = "auto"
+
+
 def animate_poloidal(
     da,
     *,

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -197,12 +197,12 @@ def animate_poloidal(
     sm.set_array([])
     cmap = sm.get_cmap()
     cbar = fig.colorbar(sm, ax=ax, cax=cax, extend=extend)
-    if "long_name" in data.attrs:
-        cbar_label = data.long_name
+    if "long_name" in da.attrs:
+        cbar_label = da.long_name
     else:
-        cbar_label = variable
-    if "units" in data.attrs:
-        cbar_label += f" [{data.units}]"
+        cbar_label = da.name
+    if "units" in da.attrs:
+        cbar_label += f" [{da.units}]"
     cbar.ax.set_ylabel(cbar_label)
 
     ax.set_aspect(aspect)

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -14,6 +14,16 @@ from .utils import (
 )
 
 
+if (
+    "pcolor.shading" in matplotlib.rcParams
+    and matplotlib.rcParams["pcolor.shading"] == "flat"
+):
+    # "flat" was the old matplotlib default which discarded the last row and column if
+    # X, Y and Z were all equal in size. The new "auto" should be better. Need to set
+    # this explicitly because "flat" is the default during a deprecation cycle.
+    matplotlib.rcParams["pcolor.shading"] = "auto"
+
+
 def regions(da, ax=None, **kwargs):
     """
     Plots each logical plotting region as a different color for debugging.


### PR DESCRIPTION
* Now that matplotlib-3.3.3 is released (which fixes a bug causing animations to freeze), we can use `shading="nearest"` for pcolormesh by default
  * require that the matplotlib version is not 3.3.0, 3.3.1 or 3.3.2.
* animatplot-0.4.2 is released, which fixes a pcolormesh bug with `shading="nearest"` or `shading="gouraud"`
  * require animatplot-0.4.2
* some small improvements to animations:
  * use coordinates (when available) rather than dimensions for animation labels, with an optional argument to choose the coordinate, or use the integer index values instead.
  * give units in labels for animated variables
  * use the value of `metadata["bout_tdim"]` as the default for `animate_over` arguments, rather than hard-coded `"t"`
  * better defaults for `aspect` argument - `"equal"` for poloidal plots, but `"auto"` for everything else.

Closes #150