### PR TITLE
y-guard cells of regions wrap around global array if necessary

### DIFF
--- a/xbout/region.py
+++ b/xbout/region.py
@@ -267,8 +267,8 @@ class Region:
         ystop = self.yupper_ind + myg
         if ystart >= self.global_ny:
             # wrap around to beginning of global array
-            ystart -= self.global_ny
-            ystop -= self.global_ny
+            ystart = ystart - self.global_ny
+            ystop = ystop - self.global_ny
         return {
             self.xcoord: slice(xinner, xouter),
             self.ycoord: slice(ystart, ystop),

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -62,6 +62,8 @@ class Region:
         self.connection_outer_x = connection_outer_x
         self.connection_lower_y = connection_lower_y
         self.connection_upper_y = connection_upper_y
+        self.global_nx = ds.sizes[ds.metadata["bout_xdim"]]
+        self.global_ny = ds.sizes[ds.metadata["bout_ydim"]]
 
         if ds is not None:
             # self.nx, self.ny should not include boundary points.
@@ -224,9 +226,21 @@ class Region:
         xouter = self.xouter_ind
         if self.connection_outer_x is not None:
             xouter += mxg
+
+        ystart = self.ylower_ind - myg
+        ystop = self.ylower_ind
+        if ystart < 0:
+            # Make sure negative indices wrap around correctly
+            if ystop == 0:
+                ystop = None
+            elif ystop > 0:
+                raise ValueError(
+                    f"'start={ystart}' of lower guards slice is negative, but "
+                    f"'stop={ystop}' is positive. Should not be possible."
+                )
         return {
             self.xcoord: slice(xinner, xouter),
-            self.ycoord: slice(self.ylower_ind - myg, self.ylower_ind),
+            self.ycoord: slice(ystart, ystop),
         }
 
     def get_upper_guards_slices(self, *, myg, mxg=0):
@@ -247,9 +261,17 @@ class Region:
         xouter = self.xouter_ind
         if self.connection_outer_x is not None:
             xouter += mxg
+
+        # wrap around to the beginning of the grid if necessary
+        ystart = self.yupper_ind
+        ystop = self.yupper_ind + myg
+        if ystart >= self.global_ny:
+            # wrap around to beginning of global array
+            ystart -= self.global_ny
+            ystop -= self.global_ny
         return {
             self.xcoord: slice(xinner, xouter),
-            self.ycoord: slice(self.yupper_ind, self.yupper_ind + myg),
+            self.ycoord: slice(ystart, ystop),
         }
 
     def __eq__(self, other):
@@ -1240,15 +1262,6 @@ def _concat_lower_guards(da, da_global, mxg, myg):
         # continuous so that interpolation works correctly near the boundaries.
         slices = region.get_lower_guards_slices(mxg=mxg, myg=myg)
 
-        if slices[ycoord].start < 0:
-            # For core-only or limiter topologies, the lower-y slice may be out of the
-            # global array bounds
-            raise ValueError(
-                "Trying to fill a slice which is not present in the global array, "
-                "so do not have coordinate values for it. Try setting "
-                "keep_yboundaries=True when calling open_boutdataset."
-            )
-
         new_xcoord = da_global[xcoord].isel(**{xcoord: slices[xcoord]})
         new_ycoord = da_global[ycoord].isel(**{ycoord: slices[ycoord]})
 
@@ -1301,15 +1314,6 @@ def _concat_upper_guards(da, da_global, mxg, myg):
         # neighbouring region, not communicated ones. Ensures the coordinates are
         # continuous so that interpolation works correctly near the boundaries.
         slices = region.get_upper_guards_slices(mxg=mxg, myg=myg)
-
-        if slices[ycoord].stop > da_global.sizes[ycoord]:
-            # For core-only or limiter topologies, the upper-y slice may be out of the
-            # global array bounds
-            raise ValueError(
-                "Trying to fill a slice which is not present in the global array, "
-                "so do not have coordinate values for it. Try setting "
-                "keep_yboundaries=True when calling open_boutdataset."
-            )
 
         new_xcoord = da_global[xcoord].isel(**{xcoord: slices[xcoord]})
         new_ycoord = da_global[ycoord].isel(**{ycoord: slices[ycoord]})

--- a/xbout/tests/test_plot.py
+++ b/xbout/tests/test_plot.py
@@ -134,3 +134,59 @@ class TestPlot:
 
         n.bout.from_region("lower_outer_SOL", with_guards=with_guards).bout.contourf()
         plt.close()
+
+    @pytest.mark.parametrize(params_guards, params_guards_values)
+    @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
+    @pytest.mark.parametrize(
+        "with_guards",
+        [
+            0,
+            pytest.param(1, marks=pytest.mark.long),
+            pytest.param(2, marks=pytest.mark.long),
+        ],
+    )
+    def test_region_limiter(
+        self,
+        bout_xyt_example_files,
+        guards,
+        keep_xboundaries,
+        keep_yboundaries,
+        with_guards,
+    ):
+        # Note using more than MXG x-direction points and MYG y-direction points per
+        # output file ensures tests for whether boundary cells are present do not fail
+        # when using minimal numbers of processors
+        dataset_list, grid_ds = bout_xyt_example_files(
+            None,
+            lengths=(2, 5, 4, 3),
+            nxpe=1,
+            nype=1,
+            nt=1,
+            guards=guards,
+            grid="grid",
+            topology="limiter",
+        )
+
+        ds = open_boutdataset(
+            datapath=dataset_list,
+            gridfilepath=grid_ds,
+            geometry="toroidal",
+            keep_xboundaries=keep_xboundaries,
+            keep_yboundaries=keep_yboundaries,
+        )
+
+        ds["R"] = ds["R"].copy(deep=True)
+        ds["R"].data[:, :] = np.linspace(0.0, 1.0, ds.sizes["x"])[:, np.newaxis]
+        ds["Z"] = ds["Z"].copy(deep=True)
+        ds["Z"].data[:, :] = np.linspace(0.0, 1.0, ds.sizes["theta"])[np.newaxis, :]
+
+        n = ds["n"].isel(t=-1, zeta=0)
+
+        n.bout.contour()
+        plt.close()
+
+        n.bout.contourf()
+        plt.close()
+
+        n.bout.pcolormesh()
+        plt.close()

--- a/xbout/tests/test_plot.py
+++ b/xbout/tests/test_plot.py
@@ -62,6 +62,15 @@ class TestPlot:
 
         n = ds["n"].isel(t=-1, zeta=0)
 
+        n.bout.contour()
+        plt.close()
+
+        n.bout.contourf()
+        plt.close()
+
+        n.bout.pcolormesh()
+        plt.close()
+
         n.bout.from_region("lower_inner_PFR", with_guards=with_guards).bout.pcolormesh()
         plt.close()
 

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -54,12 +54,6 @@ class TestRegion:
 
         n = ds["n"]
 
-        if guards["y"] > 0 and not keep_yboundaries:
-            # expect exception for core topology due to not having neighbour cells to get
-            # coordinate values from
-            with pytest.raises(ValueError):
-                n_core = n.bout.from_region("core")
-            return
         n_core = n.bout.from_region("core")
 
         # Remove attributes that are expected to be different
@@ -73,7 +67,9 @@ class TestRegion:
             ybndry = 0
         xrt.assert_identical(
             n.isel(theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
-            n_core.isel(theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
+            n_core.isel(
+                theta=slice(guards["y"], -guards["y"] if guards["y"] != 0 else None)
+            ),
         )
 
     @pytest.mark.long
@@ -186,15 +182,6 @@ class TestRegion:
             ),
         )
 
-        if guards["y"] > 0 and not keep_yboundaries:
-            # expect exception for core region due to not having neighbour cells to get
-            # coordinate values from
-            with pytest.raises(ValueError):
-                if test_dataset:
-                    ds_core = ds.bout.from_region("core")
-                else:
-                    n_core = n.bout.from_region("core")
-            return
         if test_dataset:
             ds_core = ds.bout.from_region("core")
             n_core = ds_core["n"]
@@ -208,7 +195,9 @@ class TestRegion:
                 x=slice(ixs + mxg),
                 theta=slice(ybndry, -ybndry if ybndry != 0 else None),
             ),
-            n_core.isel(theta=slice(ybndry, -ybndry if ybndry != 0 else None)),
+            n_core.isel(
+                theta=slice(guards["y"], -guards["y"] if guards["y"] != 0 else None)
+            ),
         )
 
     @pytest.mark.long


### PR DESCRIPTION
If the global indices of the y-guard cells of a region are negative or greater than or equal to the y-size of the global array, then correct them to wrap around to the other end of the global array correctly. Helps with selecting regions in all-core or limited geometries.