### PR TITLE
Pass nx, ny, nz to BoutOptions

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -270,7 +270,12 @@ def open_boutdataset(
 def _add_options(ds, inputfilepath):
     if inputfilepath:
         # Use Ben's options class to store all input file options
-        options = BoutOptionsFile(inputfilepath)
+        options = BoutOptionsFile(
+            inputfilepath,
+            nx=ds.metadata["nx"],
+            ny=ds.metadata["ny"],
+            nz=ds.metadata["nz"],
+        )
     else:
         options = None
     ds = _set_attrs_on_all_vars(ds, "options", options)


### PR DESCRIPTION
Avoids possible warning from BoutOptions constructor. Also guarantees we can evaluate expressions in BoutOptions if necessary (although this capability is not xarray-integrated yet, it will just return a numpy array).