### PR TITLE
Fix multiple-coordinate-values error for core-only/limiter cases

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -7,4 +7,4 @@ pycodestyle:
     max-line-length: 88  # Default is 79 in PEP8
     ignore:
       - E203 # whitespace before ':' has inconsistency between pycodestyle and black, so ignore
-
+      - W503 # line break before binary operator has inconsistency between pycodestyle and black, so ignore

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -110,14 +110,14 @@ class TestRegion:
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
-    @pytest.mark.parametrize("test_dataset", [False, True])
+    @pytest.mark.parametrize("region_guards", [0, 1])
     def test_region_limiter(
         self,
         bout_xyt_example_files,
         guards,
         keep_xboundaries,
         keep_yboundaries,
-        test_dataset,
+        region_guards,
     ):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
@@ -160,43 +160,39 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_noregions.attrs["regions"]
 
-        if test_dataset:
-            ds_sol = ds.bout.from_region("SOL")
-            n_sol = ds_sol["n"]
-        else:
-            n_sol = n.bout.from_region("SOL")
+        n_sol = n.bout.from_region("SOL", with_guards=region_guards)
 
         # Remove attributes that are expected to be different
         # Corners may be different because core region 'communicates' in y
         del n_sol.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs, None)), n_sol.isel(x=slice(mxg, None))
+            n_noregions.isel(x=slice(ixs, None)),
+            n_sol.isel(x=slice(region_guards, None)),
         )
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs - mxg, ixs),
+                x=slice(ixs - region_guards, ixs),
                 theta=slice(ybndry, -ybndry if ybndry != 0 else None),
             ),
             n_sol.isel(
-                x=slice(mxg), theta=slice(ybndry, -ybndry if ybndry != 0 else None)
+                x=slice(region_guards),
+                theta=slice(ybndry, -ybndry if ybndry != 0 else None),
             ),
         )
 
-        if test_dataset:
-            ds_core = ds.bout.from_region("core")
-            n_core = ds_core["n"]
-        else:
-            n_core = n.bout.from_region("core")
+        n_core = n.bout.from_region("core", with_guards=region_guards)
 
         # Remove attributes that are expected to be different
         del n_core.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs + mxg),
+                x=slice(ixs + region_guards),
                 theta=slice(ybndry, -ybndry if ybndry != 0 else None),
             ),
             n_core.isel(
-                theta=slice(guards["y"], -guards["y"] if guards["y"] != 0 else None)
+                theta=slice(
+                    region_guards, -region_guards if region_guards != 0 else None
+                )
             ),
         )
 


### PR DESCRIPTION
When values of the theta coordinate for the guard cells were taken from the other side of the branch cut for core-only or limiter cases, they did not join continuously onto the main grid's theta values. Work around this by adding an offset calculated from a linear extrapolation from the grid values (which is exact for constant grid spacing, which is usually the case for the y-direction).