### PR TITLE
Fix formatting of Options in BoutDataset.__str__()

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -59,7 +59,7 @@ class BoutDatasetAccessor:
             + "Metadata:\n{}\n".format(styled(self.metadata))
         )
         if self.options:
-            text += "Options:\n{}".format(styled(self.options))
+            text += "Options:\n{}".format(self.options)
         return text
 
     # def __repr__(self):


### PR DESCRIPTION
BoutOptionsFile provides a `__str()__` method with decent formatting, which also breaks `prettyformat`, so remove the call to `styled()` around `self.options` in `BoutDataset.__str__()`.