### PR TITLE
Add default values for bout_tdim, bout_xdim, bout_ydim, bout_zdim, so that they always exist

### DIFF
--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -209,12 +209,18 @@ def _set_default_toroidal_coordinates(coordinates, ds):
         coordinates = {}
 
     # Replace any values that have not been passed in with defaults
-    coordinates["t"] = coordinates.get("t", ds.metadata.get("bout_tdim", "t"))
-    coordinates["x"] = coordinates.get(
-        "x", ds.metadata.get("bout_xdim", "psi_poloidal")
+    coordinates["t"] = coordinates.get("t", ds.metadata["bout_tdim"])
+
+    default_x = (
+        ds.metadata["bout_xdim"] if ds.metadata["bout_xdim"] != "x" else "psi_poloidal"
     )
-    coordinates["y"] = coordinates.get("y", ds.metadata.get("bout_ydim", "theta"))
-    coordinates["z"] = coordinates.get("z", ds.metadata.get("bout_zdim", "zeta"))
+    coordinates["x"] = coordinates.get("x", default_x)
+
+    default_y = ds.metadata["bout_ydim"] if ds.metadata["bout_ydim"] != "y" else "theta"
+    coordinates["y"] = coordinates.get("y", default_y)
+
+    default_z = ds.metadata["bout_zdim"] if ds.metadata["bout_zdim"] != "z" else "zeta"
+    coordinates["z"] = coordinates.get("z", default_z)
 
     return coordinates
 

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -65,6 +65,13 @@ def _separate_metadata(ds):
     metadata_vals = [ds[var].values.item() for var in scalar_vars]
     metadata = dict(zip(scalar_vars, metadata_vals))
 
+    # Add default values for dimensions to metadata. These may be modified later by
+    # apply_geometry()
+    metadata["bout_tdim"] = "t"
+    metadata["bout_xdim"] = "x"
+    metadata["bout_ydim"] = "y"
+    metadata["bout_zdim"] = "z"
+
     return ds.drop_vars(scalar_vars), metadata
 
 


### PR DESCRIPTION
Some methods need `metadata["bout_ydim"]`, etc., and it can be useful to have these set even when no geometry is applied.