### PR TITLE
to_field_aligned() and from_field_aligned() methods for BoutDataset

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -92,6 +92,41 @@ class BoutDatasetAccessor:
                 self.data[aligned_name] = self.data[name].bout.to_field_aligned()
             return self.data[aligned_name]
 
+    def to_field_aligned(self):
+        """
+        Create a new Dataset with all 3d variables transformed to field-aligned
+        coordinates, which are shifted with respect to the base coordinates by an angle
+        zShift
+        """
+        result = self.data.copy()
+
+        for v in chain(result, result.coords):
+            da = result[v]
+            # Need to transform any z-dependent variables or coordinates
+            if (result.metadata["bout_zdim"] in da.dims) and (
+                da.attrs.get("direction_y", None) == "Standard"
+            ):
+                result[v] = da.bout.to_field_aligned()
+
+        return result
+
+    def from_field_aligned(self):
+        """
+        Create a new Dataset with all 3d variables transformed to non-field-aligned
+        coordinates
+        """
+        result = self.data.copy()
+
+        for v in chain(result, result.coords):
+            da = result[v]
+            # Need to transform any 3d variables or coordinates
+            if (result.metadata["bout_zdim"] in da.dims) and (
+                da.attrs.get("direction_y", None) == "Aligned"
+            ):
+                result[v] = da.bout.from_field_aligned()
+
+        return result
+
     def from_region(self, name, with_guards=None):
         """
         Get a logically-rectangular section of data from a certain region.

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -494,9 +494,9 @@ class TestBoutDataArrayMethods:
                 # Check shifting non-staggered field fails without zShift
                 ds["T"].bout.from_field_aligned()
 
-        n_stag_al = ds["n"].bout.from_field_aligned()
+        n_stag_nal = ds["n"].bout.from_field_aligned()
 
-        npt.assert_equal(n_stag_al.values, n_nal.values)
+        npt.assert_equal(n_stag_nal.values, n_nal.values)
 
     @pytest.mark.long
     def test_interpolate_parallel_region_core(self, bout_xyt_example_files):

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -126,6 +126,9 @@ class TestBoutDataArrayMethods:
 
         n.attrs["direction_y"] = "Standard"
         n_al = n.bout.to_field_aligned()
+
+        assert n_al.direction_y == "Aligned"
+
         for t in range(ds.sizes["t"]):
             for z in range(nz):
                 npt.assert_allclose(
@@ -228,6 +231,9 @@ class TestBoutDataArrayMethods:
 
         n.attrs["direction_y"] = "Standard"
         n_al = n.bout.to_field_aligned()
+
+        assert n_al.direction_y == "Aligned"
+
         for t in range(ds.sizes["t"]):
             for z in range(nz):
                 npt.assert_allclose(
@@ -331,6 +337,9 @@ class TestBoutDataArrayMethods:
 
         n.attrs["direction_y"] = "Aligned"
         n_nal = n.bout.from_field_aligned()
+
+        assert n_nal.direction_y == "Standard"
+
         for t in range(ds.sizes["t"]):
             for z in range(nz):
                 npt.assert_allclose(
@@ -426,6 +435,8 @@ class TestBoutDataArrayMethods:
 
         n_al = n.bout.to_field_aligned().copy(deep=True)
 
+        assert n_al.direction_y == "Aligned"
+
         # make 'n' staggered
         ds["n"].attrs["cell_location"] = stag_location
 
@@ -477,6 +488,8 @@ class TestBoutDataArrayMethods:
         ds["T"].attrs["direction_y"] = "Aligned"
 
         n_nal = n.bout.from_field_aligned().copy(deep=True)
+
+        assert n_nal.direction_y == "Standard"
 
         # make 'n' staggered
         ds["n"].attrs["cell_location"] = stag_location

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -308,7 +308,9 @@ class TestBoutDatasetMethods:
         # The above loop required the call to .load(), but that turned the data into a
         # numpy array. Now convert back to dask
         n = n.chunk({"t": 1})
+        ds = ds.chunk({"t": 1})
         assert isinstance(n.data, dask.array.Array)
+        assert isinstance(ds["n"].data, dask.array.Array)
 
         n.attrs["direction_y"] = "Standard"
         ds["n"] = n

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -3,6 +3,8 @@ import pytest
 import numpy.testing as npt
 from xarray import Dataset, DataArray, concat, open_dataset, open_mfdataset
 import xarray.testing as xrt
+
+import dask.array
 import numpy as np
 from pathlib import Path
 
@@ -159,6 +161,461 @@ class TestBoutDatasetMethods:
             # don't need to delete MYG again
 
         xrt.assert_equal(ds, ds_no_yboundaries)
+
+    @pytest.mark.parametrize(
+        "nz",
+        [
+            pytest.param(6, marks=pytest.mark.long),
+            7,
+            pytest.param(8, marks=pytest.mark.long),
+            pytest.param(9, marks=pytest.mark.long),
+        ],
+    )
+    def test_to_field_aligned(self, bout_xyt_example_files, nz):
+        dataset_list = bout_xyt_example_files(
+            None, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
+        )
+        with pytest.warns(UserWarning):
+            ds = open_boutdataset(
+                datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+            )
+
+        ds["psixy"] = ds["x"]
+        ds["Rxy"] = ds["x"]
+        ds["Zxy"] = ds["y"]
+
+        ds = apply_geometry(ds, "toroidal")
+
+        # set up test variable
+        n = ds["n"].load()
+        zShift = ds["zShift"].load()
+        for t in range(ds.sizes["t"]):
+            for x in range(ds.sizes["x"]):
+                for y in range(ds.sizes["theta"]):
+                    zShift[x, y] = (
+                        (x * ds.sizes["theta"] + y) * 2.0 * np.pi / ds.sizes["zeta"]
+                    )
+                    for z in range(nz):
+                        n[t, x, y, z] = 1000.0 * t + 100.0 * x + 10.0 * y + z
+
+        n.attrs["direction_y"] = "Standard"
+        ds["n"] = n
+
+        assert ds["n"].direction_y == "Standard"
+
+        # Create field-aligned Dataset
+        ds_al = ds.bout.to_field_aligned()
+
+        n_al = ds_al["n"]
+
+        assert n_al.direction_y == "Aligned"
+
+        for t in range(ds.sizes["t"]):
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 0, 0, z].values,
+                    1000.0 * t + z % nz,
+                    rtol=1.0e-15,
+                    atol=5.0e-16,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 0, 1, z].values,
+                    1000.0 * t + 10.0 * 1.0 + (z + 1) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 0, 2, z].values,
+                    1000.0 * t + 10.0 * 2.0 + (z + 2) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 0, 3, z].values,
+                    1000.0 * t + 10.0 * 3.0 + (z + 3) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 1, 0, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 0.0 + (z + 4) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 1, 1, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 1.0 + (z + 5) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 1, 2, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 2.0 + (z + 6) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 1, 3, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 3.0 + (z + 7) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+    def test_to_field_aligned_dask(self, bout_xyt_example_files):
+
+        nz = 6
+
+        dataset_list = bout_xyt_example_files(
+            None, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
+        )
+        with pytest.warns(UserWarning):
+            ds = open_boutdataset(
+                datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+            )
+
+        ds["psixy"] = ds["x"]
+        ds["Rxy"] = ds["x"]
+        ds["Zxy"] = ds["y"]
+
+        ds = apply_geometry(ds, "toroidal")
+
+        # set up test variable
+        n = ds["n"].load()
+        zShift = ds["zShift"].load()
+        for t in range(ds.sizes["t"]):
+            for x in range(ds.sizes["x"]):
+                for y in range(ds.sizes["theta"]):
+                    zShift[x, y] = (
+                        (x * ds.sizes["theta"] + y) * 2.0 * np.pi / ds.sizes["zeta"]
+                    )
+                    for z in range(nz):
+                        n[t, x, y, z] = 1000.0 * t + 100.0 * x + 10.0 * y + z
+
+        # The above loop required the call to .load(), but that turned the data into a
+        # numpy array. Now convert back to dask
+        n = n.chunk({"t": 1})
+        assert isinstance(n.data, dask.array.Array)
+
+        n.attrs["direction_y"] = "Standard"
+        ds["n"] = n
+
+        assert ds["n"].direction_y == "Standard"
+
+        # Create field-aligned Dataset
+        ds_al = ds.bout.to_field_aligned()
+
+        n_al = ds_al["n"]
+
+        assert n_al.direction_y == "Aligned"
+
+        for t in range(ds.sizes["t"]):
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 0, 0, z].values,
+                    1000.0 * t + z % nz,
+                    rtol=1.0e-15,
+                    atol=5.0e-16,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 0, 1, z].values,
+                    1000.0 * t + 10.0 * 1.0 + (z + 1) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 0, 2, z].values,
+                    1000.0 * t + 10.0 * 2.0 + (z + 2) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 0, 3, z].values,
+                    1000.0 * t + 10.0 * 3.0 + (z + 3) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 1, 0, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 0.0 + (z + 4) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 1, 1, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 1.0 + (z + 5) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 1, 2, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 2.0 + (z + 6) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_al[t, 1, 3, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 3.0 + (z + 7) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+    @pytest.mark.parametrize(
+        "nz",
+        [
+            pytest.param(6, marks=pytest.mark.long),
+            7,
+            pytest.param(8, marks=pytest.mark.long),
+            pytest.param(9, marks=pytest.mark.long),
+        ],
+    )
+    def test_from_field_aligned(self, bout_xyt_example_files, nz):
+        dataset_list = bout_xyt_example_files(
+            None, lengths=(3, 3, 4, nz), nxpe=1, nype=1, nt=1
+        )
+        with pytest.warns(UserWarning):
+            ds = open_boutdataset(
+                datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+            )
+
+        ds["psixy"] = ds["x"]
+        ds["Rxy"] = ds["x"]
+        ds["Zxy"] = ds["y"]
+
+        ds = apply_geometry(ds, "toroidal")
+
+        # set up test variable
+        n = ds["n"].load()
+        zShift = ds["zShift"].load()
+        for t in range(ds.sizes["t"]):
+            for x in range(ds.sizes["x"]):
+                for y in range(ds.sizes["theta"]):
+                    zShift[x, y] = (
+                        (x * ds.sizes["theta"] + y) * 2.0 * np.pi / ds.sizes["zeta"]
+                    )
+                    for z in range(ds.sizes["zeta"]):
+                        n[t, x, y, z] = 1000.0 * t + 100.0 * x + 10.0 * y + z
+
+        n.attrs["direction_y"] = "Aligned"
+        ds["n"] = n
+
+        assert ds["n"].direction_y == "Aligned"
+
+        # Create non-field-aligned Dataset
+        ds_nal = ds.bout.from_field_aligned()
+
+        n_nal = ds_nal["n"]
+
+        assert n_nal.direction_y == "Standard"
+
+        for t in range(ds.sizes["t"]):
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_nal[t, 0, 0, z].values,
+                    1000.0 * t + z % nz,
+                    rtol=1.0e-15,
+                    atol=5.0e-16,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_nal[t, 0, 1, z].values,
+                    1000.0 * t + 10.0 * 1.0 + (z - 1) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_nal[t, 0, 2, z].values,
+                    1000.0 * t + 10.0 * 2.0 + (z - 2) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_nal[t, 0, 3, z].values,
+                    1000.0 * t + 10.0 * 3.0 + (z - 3) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_nal[t, 1, 0, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 0.0 + (z - 4) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_nal[t, 1, 1, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 1.0 + (z - 5) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_nal[t, 1, 2, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 2.0 + (z - 6) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+            for z in range(nz):
+                npt.assert_allclose(
+                    n_nal[t, 1, 3, z].values,
+                    1000.0 * t + 100.0 * 1 + 10.0 * 3.0 + (z - 7) % nz,
+                    rtol=1.0e-15,
+                    atol=0.0,
+                )  # noqa: E501
+
+    @pytest.mark.parametrize("stag_location", ["CELL_XLOW", "CELL_YLOW", "CELL_ZLOW"])
+    def test_to_field_aligned_staggered(self, bout_xyt_example_files, stag_location):
+        dataset_list = bout_xyt_example_files(
+            None, lengths=(3, 3, 4, 8), nxpe=1, nype=1, nt=1
+        )
+        with pytest.warns(UserWarning):
+            ds = open_boutdataset(
+                datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+            )
+
+        ds["psixy"] = ds["x"]
+        ds["Rxy"] = ds["x"]
+        ds["Zxy"] = ds["y"]
+
+        ds = apply_geometry(ds, "toroidal")
+
+        # set up test variable
+        n = ds["n"].load()
+        zShift = ds["zShift"].load()
+        for t in range(ds.sizes["t"]):
+            for x in range(ds.sizes["x"]):
+                for y in range(ds.sizes["theta"]):
+                    zShift[x, y] = (
+                        (x * ds.sizes["theta"] + y) * 2.0 * np.pi / ds.sizes["zeta"]
+                    )
+                    for z in range(ds.sizes["zeta"]):
+                        n[t, x, y, z] = 1000.0 * t + 100.0 * x + 10.0 * y + z
+
+        ds["n"] = n
+
+        assert ds["n"].direction_y == "Standard"
+
+        # Create field-aligned Dataset
+        ds_al = ds.bout.to_field_aligned()
+
+        n_al = ds_al["n"].copy(deep=True)
+
+        assert n_al.direction_y == "Aligned"
+
+        # make 'n' staggered
+        ds["n"].attrs["cell_location"] = stag_location
+
+        if stag_location != "CELL_ZLOW":
+            with pytest.raises(ValueError):
+                # Check exception raised when needed zShift_CELL_*LOW is not present
+                ds.bout.to_field_aligned()
+            ds["zShift_" + stag_location] = zShift
+            ds["zShift_" + stag_location].attrs["cell_location"] = stag_location
+            ds = ds.set_coords("zShift_" + stag_location)
+
+        # New field-aligned Dataset
+        ds_al = ds.bout.to_field_aligned()
+
+        n_stag_al = ds_al["n"]
+
+        assert n_stag_al.direction_y == "Aligned"
+
+        npt.assert_equal(n_stag_al.values, n_al.values)
+
+    @pytest.mark.parametrize("stag_location", ["CELL_XLOW", "CELL_YLOW", "CELL_ZLOW"])
+    def test_from_field_aligned_staggered(self, bout_xyt_example_files, stag_location):
+        dataset_list = bout_xyt_example_files(
+            None, lengths=(3, 3, 4, 8), nxpe=1, nype=1, nt=1
+        )
+        with pytest.warns(UserWarning):
+            ds = open_boutdataset(
+                datapath=dataset_list, inputfilepath=None, keep_xboundaries=False
+            )
+
+        ds["psixy"] = ds["x"]
+        ds["Rxy"] = ds["x"]
+        ds["Zxy"] = ds["y"]
+
+        ds = apply_geometry(ds, "toroidal")
+
+        # set up test variable
+        n = ds["n"].load()
+        zShift = ds["zShift"].load()
+        for t in range(ds.sizes["t"]):
+            for x in range(ds.sizes["x"]):
+                for y in range(ds.sizes["theta"]):
+                    zShift[x, y] = (
+                        (x * ds.sizes["theta"] + y) * 2.0 * np.pi / ds.sizes["zeta"]
+                    )
+                    for z in range(ds.sizes["zeta"]):
+                        n[t, x, y, z] = 1000.0 * t + 100.0 * x + 10.0 * y + z
+        n.attrs["direction_y"] = "Aligned"
+        ds["n"] = n
+        ds["T"].attrs["direction_y"] = "Aligned"
+
+        # Make non-field-aligned Dataset
+        ds_nal = ds.bout.from_field_aligned()
+
+        n_nal = ds_nal["n"].copy(deep=True)
+
+        assert n_nal.direction_y == "Standard"
+
+        # make 'n' staggered
+        ds["n"].attrs["cell_location"] = stag_location
+
+        if stag_location != "CELL_ZLOW":
+            with pytest.raises(ValueError):
+                # Check exception raised when needed zShift_CELL_*LOW is not present
+                ds["n"].bout.from_field_aligned()
+            ds["zShift_" + stag_location] = zShift
+            ds["zShift_" + stag_location].attrs["cell_location"] = stag_location
+            ds = ds.set_coords("zShift_" + stag_location)
+
+        # New non-field-aligned Dataset
+        ds_nal = ds.bout.from_field_aligned()
+
+        n_stag_nal = ds_nal["n"]
+
+        assert n_stag_nal.direction_y == "Standard"
+
+        npt.assert_equal(n_stag_nal.values, n_nal.values)
 
     def test_set_parallel_interpolation_factor(self):
         ds = Dataset()


### PR DESCRIPTION
These methods return a new Dataset with all z-dependent variables transformed to or from field-aligned coordinates (if a variable is already aligned or not-aligned respectively it is left unchanged). 

Fixes #177.