### PR TITLE
Better values for jyseps2_2 in test data

### DIFF
--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -483,7 +483,7 @@ def create_bout_ds(
         ds["jyseps1_1"] = -1
         ds["jyseps2_1"] = ny // 2 - 1
         ds["jyseps1_2"] = ny // 2 - 1
-        ds["jyseps2_2"] = ny
+        ds["jyseps2_2"] = ny - 1
         ds["ny_inner"] = ny // 2
     elif topology == "sol":
         ds["ixseps1"] = 0
@@ -491,7 +491,7 @@ def create_bout_ds(
         ds["jyseps1_1"] = -1
         ds["jyseps2_1"] = ny // 2 - 1
         ds["jyseps1_2"] = ny // 2 - 1
-        ds["jyseps2_2"] = ny
+        ds["jyseps2_2"] = ny - 1
         ds["ny_inner"] = ny // 2
     elif topology == "limiter":
         ds["ixseps1"] = nx // 2
@@ -499,7 +499,7 @@ def create_bout_ds(
         ds["jyseps1_1"] = -1
         ds["jyseps2_1"] = ny // 2 - 1
         ds["jyseps1_2"] = ny // 2 - 1
-        ds["jyseps2_2"] = ny
+        ds["jyseps2_2"] = ny - 1
         ds["ny_inner"] = ny // 2
     elif topology == "xpoint":
         if nype < 4:


### PR DESCRIPTION
In core, sol or limiter configurations, BOUT++ would set `jyseps2_2=ny-1`, rather than `ny` which was previously used in `test_load.py`. The difference should not be important for anything at the moment, but might possibly hide a bug in future if not updated.