### PR TITLE
Create 1d coordinates from spacing taken from non-boundary values

### DIFF
--- a/xbout/tests/test_geometries.py
+++ b/xbout/tests/test_geometries.py
@@ -29,7 +29,15 @@ class TestGeometryRegistration:
 
         original = Dataset()
         original["dy"] = DataArray(np.ones((3, 4)), dims=("x", "y"))
-        original.attrs["metadata"] = {}
+        metadata = {
+            "bout_xdim": "x",
+            "bout_ydim": "y",
+            "bout_zdim": "z",
+            "keep_xboundaries": True,
+            "keep_yboundaries": True,
+        }
+        original.attrs["metadata"] = metadata
+        original["dy"].attrs["metadata"] = metadata
         updated = apply_geometry(ds=original, geometry_name="Schwarzschild")
         assert_equal(updated["event_horizon"], DataArray(4.0))
 

--- a/xbout/tests/test_utils.py
+++ b/xbout/tests/test_utils.py
@@ -111,6 +111,13 @@ class TestUtils:
     )
     def test__1d_coord_from_spacing_da(self, origin_at):
         da = xr.DataArray(0.2 * np.ones(10), dims="testdim")
+        da.attrs["metadata"] = {
+            "bout_xdim": "x",
+            "bout_ydim": "y",
+            "bout_zdim": "z",
+            "keep_xboundaries": True,
+            "keep_yboundaries": True,
+        }
 
         if origin_at == "expectfail":
             with pytest.raises(ValueError):

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -154,8 +154,18 @@ def _1d_coord_from_spacing(spacing, dim, ds=None, *, origin_at=None):
                 f"create coordinate"
             )
 
+        point_to_use = {
+            spacing.metadata["bout_xdim"]: spacing.metadata.get("MXG", 0)
+            if spacing.metadata["keep_xboundaries"]
+            else 0,
+            spacing.metadata["bout_ydim"]: spacing.metadata.get("MYG", 0)
+            if spacing.metadata["keep_yboundaries"]
+            else 0,
+            spacing.metadata["bout_zdim"]: spacing.metadata.get("MZG", 0),
+        }
+
         # make spacing 1d
-        spacing = spacing.isel({d: 0 for d in other_dims})
+        spacing = spacing.isel({d: point_to_use[d] for d in other_dims})
 
         # xarray stores coordinates as numpy (not dask) arrays anyway, so use .values
         # here to evaluate the task-graph (if there is one)


### PR DESCRIPTION
Corner boundary cells may contain NaN, so when creating 1d coordinates, select a slice of the `spacing` from the first non-boundary points to avoid any NaNs.

Fixes #187.