### PR TITLE
Methods to calculate coordinate derivatives

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -476,6 +476,12 @@ class BoutDataArrayAccessor:
         result = (da.shift({xcoord: -1}) - da.shift({xcoord: 1})) / (2.0 * dx)
 
         result.name = f"d({da.name})/dx"
+        if "standard_name" in result.attrs:
+            result.standard_name = f"d({result.standard_name})/dx"
+        if "long_name" in result.attrs:
+            result.long_name = f"x-derivative of {result.long_name}"
+        if "units" in result.attrs:
+            result.units = ""
 
         return result
 
@@ -553,7 +559,6 @@ class BoutDataArrayAccessor:
             raise ValueError(f'Unrecognised cell location "{da.cell_location}"')
 
         result = (da.shift({ycoord: -1}) - da.shift({ycoord: 1})) / (2.0 * dy)
-        result.name = f"d({da.name})/dy"
 
         # Remove any y-guard cells
         region_object = da.regions[region]
@@ -570,6 +575,14 @@ class BoutDataArrayAccessor:
         if not aligned_input:
             # Want output in non-aligned coordinates
             result = result.bout.from_field_aligned()
+
+        result.name = f"d({da.name})/dy"
+        if "standard_name" in result.attrs:
+            result.standard_name = f"d({result.standard_name})/dy"
+        if "long_name" in result.attrs:
+            result.long_name = f"y-derivative of {result.long_name}"
+        if "units" in result.attrs:
+            result.units = ""
 
         return result
 
@@ -589,7 +602,15 @@ class BoutDataArrayAccessor:
             da.roll({zcoord: -1}, roll_coords=False)
             - da.roll({zcoord: 1}, roll_coords=False)
         ) / (2.0 * da.metadata["dz"])
+
         result.name = f"d({da.name})/dz"
+        if "standard_name" in result.attrs:
+            result.standard_name = f"d({result.standard_name})/dz"
+        if "long_name" in result.attrs:
+            result.long_name = f"z-derivative of {result.long_name}"
+        if "units" in result.attrs:
+            result.units = ""
+
         return result
 
     def get_bounding_surfaces(self, coords=("R", "Z")):

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -454,6 +454,25 @@ class BoutDataArrayAccessor:
             # Extract the DataArray to return
             return result[self.data.name]
 
+    def ddz(self):
+        """
+        Special method for calculating a derivative in the "bout_zdim"
+        direction (toroidal, z-direction), needed because xarray's
+        differentiate method doesn't have an option to handle a periodic
+        dimension (as of xarray-0.17.0).
+
+        This method uses a second-order accurate central finite difference method to
+        calculate the derivative.
+        """
+        da = self.data
+        zcoord = da.metadata["bout_zdim"]
+        result = (
+            da.roll({zcoord: -1}, roll_coords=False)
+            - da.roll({zcoord: 1}, roll_coords=False)
+        ) / (2.0 * da.metadata["dz"])
+        result.name = f"d({da.name})/dz"
+        return result
+
     def get_bounding_surfaces(self, coords=("R", "Z")):
         """
         Get bounding surfaces.

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -490,7 +490,7 @@ class BoutDataArrayAccessor:
         Special method for calculating a derivative in the "bout_ydim"
         direction (parallel, y-direction), needed because we need to (a) do the
         calculation region-by-region to take account of the branch cuts in the
-        y-direction and (b)transform to a field-aligned grid to take parallel
+        y-direction and (b) transform to a field-aligned grid to take parallel
         derivatives.
 
         This method uses a second-order accurate central finite difference

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -352,20 +352,11 @@ class BoutDataArrayAccessor:
 
         da = _update_metadata_increased_resolution(da, n)
 
-        # Add dy to da as a coordinate. This will only be temporary, once we have
-        # combined the regions together, we will demote dy to a regular variable
+        # Modify dy to be consistent with the higher resolution grid
         dy_array = xr.DataArray(
             np.full([da.sizes[xcoord], da.sizes[ycoord]], dy), dims=[xcoord, ycoord]
         )
-        # need a view of da with only x- and y-dimensions, unfortunately no neat way to
-        # do this with isel
-        da_2d = da
-        if tcoord in da.sizes:
-            da_2d = da_2d.isel(**{tcoord: 0}, drop=True)
-        if zcoord in da.sizes:
-            da_2d = da_2d.isel(**{zcoord: 0}, drop=True)
-        dy_array = da_2d.copy(data=dy_array)
-        da = da.assign_coords(dy=dy_array)
+        da["dy"] = da["dy"].copy(data=dy_array)
 
         # Remove regions which have incorrect information for the high-resolution grid.
         # New regions will be generated when creating a new Dataset in

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -303,6 +303,8 @@ class BoutDataArrayAccessor:
         ycoord = da.metadata["bout_ydim"]
         zcoord = da.metadata["bout_zdim"]
 
+        da = da.bout.from_region(region.name, with_guards={xcoord: 0, ycoord: 2})
+
         if zcoord in da.dims and da.direction_y != "Aligned":
             aligned_input = False
             da = da.bout.to_field_aligned()
@@ -312,7 +314,6 @@ class BoutDataArrayAccessor:
         if n is None:
             n = self.fine_interpolation_factor
 
-        da = da.bout.from_region(region.name, with_guards={xcoord: 0, ycoord: 2})
         da = da.chunk({ycoord: None})
 
         ny_fine = n * region.ny

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -214,16 +214,6 @@ class BoutDatasetAccessor:
         if isinstance(variables, tuple):
             variables = list(variables)
 
-        if "dy" in variables:
-            # dy is treated specially, as it is converted to a coordinate, and then
-            # converted back again below, so must not call
-            # interpolate_parallel('dy').
-            variables.remove("dy")
-
-        # Add extra variables needed to make this a valid Dataset
-        if "dx" not in variables:
-            variables.append("dx")
-
         # Need to start with a Dataset with attrs as merge() drops the attrs of the
         # passed-in argument.
         # Make sure the first variable has all dimensions so we don't lose any
@@ -266,11 +256,6 @@ class BoutDatasetAccessor:
             elif ycoord not in da.dims:
                 ds[var] = da
             # Can't interpolate a variable that depends on y but not x, so just skip
-
-        # dy needs to be compatible with the new poloidal coordinate
-        # dy was created as a coordinate in BoutDataArray.interpolate_parallel, here just
-        # need to demote back to a regular variable.
-        ds = ds.reset_coords("dy")
 
         # Apply geometry
         ds = apply_geometry(ds, ds.geometry)

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -5,7 +5,12 @@ import xarray as xr
 import numpy as np
 
 from .region import Region, _create_regions_toroidal
-from .utils import _add_attrs_to_var, _set_attrs_on_all_vars, _1d_coord_from_spacing
+from .utils import (
+    _add_attrs_to_var,
+    _set_attrs_on_all_vars,
+    _set_as_coord,
+    _1d_coord_from_spacing,
+)
 
 REGISTERED_GEOMETRIES = {}
 
@@ -167,6 +172,10 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
 
         _add_attrs_to_var(updated_ds, zcoord)
 
+    # Add dx and dy as coordinates, so that they are available with BoutDataArrays
+    updated_ds = _set_as_coord(updated_ds, "dx")
+    updated_ds = _set_as_coord(updated_ds, "dy")
+
     return updated_ds
 
 
@@ -304,22 +313,7 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
         ds = ds.set_coords(("Rxy", "Zxy"))
 
     # Add zShift as a coordinate, so that it gets interpolated along with a variable
-    try:
-        ds = ds.set_coords("zShift")
-    except ValueError:
-        pass
-    try:
-        ds = ds.set_coords("zShift_CELL_XLOW")
-    except ValueError:
-        pass
-    try:
-        ds = ds.set_coords("zShift_CELL_YLOW")
-    except ValueError:
-        pass
-    try:
-        ds = ds.set_coords("zShift_CELL_ZLOW")
-    except ValueError:
-        pass
+    ds = _set_as_coord(ds, "zShift")
 
     ds = _create_regions_toroidal(ds)
 

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -937,6 +937,40 @@ class TestBoutDataArrayMethods:
             atol=1.0e-13,
         )
 
+    def test_ddy(self, bout_xyt_example_files):
+
+        ny = 64
+
+        dataset_list, gridfilepath = bout_xyt_example_files(
+            None,
+            lengths=(2, 3, ny, 4),
+            nxpe=1,
+            nype=1,
+            grid="grid",
+        )
+
+        ds = open_boutdataset(
+            datapath=dataset_list, geometry="toroidal", gridfilepath=gridfilepath
+        )
+
+        n = ds["n"]
+
+        t = ds["t"].broadcast_like(n)
+        x = ds["x"].broadcast_like(n)
+        y = ds["theta"].broadcast_like(n)
+        z = ds["zeta"].broadcast_like(n)
+
+        n.values[:] = (np.sin(3.0 * y / ny) * (1.0 + t + x + z)).values
+
+        expected = 3.0 / ny * np.cos(3.0 * y / ny) * (1.0 + t + x + z)
+
+        npt.assert_allclose(
+            n.bout.ddy().isel(theta=slice(1, -1)).values,
+            expected.isel(theta=slice(1, -1)).values,
+            rtol=1.0e-2,
+            atol=1.0e-13,
+        )
+
     def test_ddz(self, bout_xyt_example_files):
         dataset_list = bout_xyt_example_files(
             None,

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -12,6 +12,7 @@ from xarray.core.utils import dict_equiv
 from xbout.tests.test_load import bout_xyt_example_files, create_bout_ds
 from xbout import open_boutdataset
 from xbout.geometries import apply_geometry
+from xbout.utils import _1d_coord_from_spacing
 
 
 class TestBoutDataArrayMethods:
@@ -900,6 +901,41 @@ class TestBoutDataArrayMethods:
         )
 
         xrt.assert_identical(n_highres_truncated, n_highres.isel(zeta=points_list))
+
+    def test_ddx(self, bout_xyt_example_files):
+
+        nx = 64
+
+        dataset_list = bout_xyt_example_files(
+            None,
+            lengths=(2, nx, 4, 3),
+            nxpe=1,
+            nype=1,
+        )
+
+        with pytest.warns(UserWarning):
+            ds = open_boutdataset(
+                datapath=dataset_list,
+            )
+
+        n = ds["n"]
+
+        t = ds["t"].broadcast_like(n)
+        ds["x_1d"] = _1d_coord_from_spacing(ds["dx"], "x")
+        x = ds["x_1d"].broadcast_like(n)
+        y = ds["y"].broadcast_like(n)
+        z = ds["z"].broadcast_like(n)
+
+        n.values[:] = (np.sin(12.0 * x / nx) * (1.0 + t + y + z)).values
+
+        expected = 12.0 / nx * np.cos(12.0 * x / nx) * (1.0 + t + y + z)
+
+        npt.assert_allclose(
+            n.bout.ddx().isel(x=slice(1, -1)).values,
+            expected.isel(x=slice(1, -1)).values,
+            rtol=1.0e-2,
+            atol=1.0e-13,
+        )
 
     def test_ddz(self, bout_xyt_example_files):
         dataset_list = bout_xyt_example_files(

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -900,3 +900,31 @@ class TestBoutDataArrayMethods:
         )
 
         xrt.assert_identical(n_highres_truncated, n_highres.isel(zeta=points_list))
+
+    def test_ddz(self, bout_xyt_example_files):
+        dataset_list = bout_xyt_example_files(
+            None,
+            lengths=(2, 3, 4, 64),
+            nxpe=1,
+            nype=1,
+        )
+
+        with pytest.warns(UserWarning):
+            ds = open_boutdataset(
+                datapath=dataset_list,
+            )
+
+        n = ds["n"]
+
+        t = ds["t"].broadcast_like(n)
+        x = ds["x"].broadcast_like(n)
+        y = ds["y"].broadcast_like(n)
+        z = ds["z"].broadcast_like(n)
+
+        n.values[:] = (np.sin(z) * (1.0 + t + x + y)).values
+
+        expected = np.cos(z) * (1.0 + t + x + y)
+
+        npt.assert_allclose(
+            n.bout.ddz().values, expected.values, rtol=1.0e-2, atol=1.0e-13
+        )

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -1153,8 +1153,6 @@ class TestBoutDatasetMethods:
                 "G3",
                 "J",
                 "Bxy",
-                "dx",
-                "dy",
             )
         )
 

--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -22,6 +22,7 @@ def create_example_grid_file(tmpdir_factory):
     arr = np.arange(6).reshape(2, 3)
     grid = DataArray(data=arr, name="arr", dims=["x", "y"]).to_dataset()
     grid["dy"] = DataArray(np.ones((2, 3)), dims=["x", "y"])
+    grid = grid.set_coords(["dy"])
 
     # Create temporary directory
     save_dir = tmpdir_factory.mktemp("griddata")

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -609,6 +609,7 @@ def create_bout_ds(
 
     ds["dx"] = 0.5 * one
     ds["dy"] = 2.0 * one
+    ds = ds.set_coords(["dx", "dy"])
     ds["dz"] = 2.0 * np.pi / nz
 
     ds["iteration"] = t_length

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -765,3 +765,23 @@ def _get_bounding_surfaces(ds, coords):
     ]
 
     return result
+
+
+def _set_as_coord(ds, name):
+    try:
+        ds = ds.set_coords(name)
+    except ValueError:
+        pass
+    try:
+        ds = ds.set_coords(f"{name}_CELL_XLOW")
+    except ValueError:
+        pass
+    try:
+        ds = ds.set_coords(f"{name}_CELL_YLOW")
+    except ValueError:
+        pass
+    try:
+        ds = ds.set_coords(f"{name}_CELL_ZLOW")
+    except ValueError:
+        pass
+    return ds


### PR DESCRIPTION
Special method for calculating a derivative in the "bout_zdim" direction (toroidal, z-direction), needed because xarray's differentiate method doesn't have an option to handle a periodic dimension (as of xarray-0.17.0). This method uses a second-order accurate central finite difference method to calculate the derivative.

Edit: Also added methods for a derivative in the "bout_xdim" direction, which needs to account for the fact that `dx` is a 2d quantity (may be different between core and PFR regions), and for a derivative in the "bout_ydim" direction, which needs to account for branch cuts and shifting to and from the field-aligned grid. 