### PR TITLE
Fix regions in result of ddy()

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -10,6 +10,7 @@ from scipy.interpolate import griddata as scipy_griddata
 import xarray as xr
 from xarray import register_dataarray_accessor
 
+from .geometries import apply_geometry
 from .plotting.animate import animate_poloidal, animate_pcolormesh, animate_line
 from .plotting import plotfuncs
 from .plotting.utils import _create_norm
@@ -293,6 +294,7 @@ class BoutDataArrayAccessor:
                 return result
             else:
                 # Extract the DataArray to return
+                result = apply_geometry(result, self.data.geometry)
                 return result[self.data.name]
 
         # Select a particular 'region' and interpolate to higher parallel resolution

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -532,6 +532,9 @@ class BoutDataArrayAccessor:
             name = self.data.name
             result = xr.combine_by_coords(parts)[f"d({name})/dy"]
 
+            # regions get mixed up during the split and combine_by_coords, so reset them
+            result.attrs["regions"] = self.data.regions
+
             return result
 
         da = self.data


### PR DESCRIPTION
https://github.com/boutproject/xBOUT/pull/192#issuecomment-824391295 from @Vandoo:
> ddy() gives only dict_keys(['lower_inner_PFR']) in the result.regions.keys(), ddx and ddz are fine.

This PR fixes this bug.

It also includes a similar fix for `BoutDataArray.interpolate_parallel()`. Previously, it was recommended to always use `BoutDataset.interpolate_parallel()` in order to get the regions correct by calling `apply_geometry()` on the result, but now `apply_geometry()` can also be called on the partial Dataset in the BoutDataArray version, making `BoutDataArray.interpolate_parallel()` more useful.