### PR TITLE
Fix handling of upper disconnected double null

### DIFF
--- a/xbout/region.py
+++ b/xbout/region.py
@@ -331,8 +331,11 @@ def _get_topology(ds):
             return "connected-double-null"
         else:
             raise ValueError("Currently unsupported topology")
-
-    return "disconnected-double-null"
+    elif ixs1 < ixs2:
+        return "lower-disconnected-double-null"
+    else:
+        # ixs1 > ixs2
+        return "upper-disconnected-double-null"
 
 
 def _check_connections(regions):
@@ -374,7 +377,7 @@ def _check_connections(regions):
 topologies = {}
 
 
-def topology_disconnected_double_null(
+def topology_lower_disconnected_double_null(
     *, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, jys22, ny, ybndry
 ):
     regions = {}
@@ -573,7 +576,209 @@ def topology_disconnected_double_null(
     return regions
 
 
-topologies["disconnected-double-null"] = topology_disconnected_double_null
+topologies["lower-disconnected-double-null"] = topology_lower_disconnected_double_null
+
+
+def topology_upper_disconnected_double_null(
+    *, ds, ixs1, ixs2, nx, jys11, jys21, ny_inner, jys12, jys22, ny, ybndry
+):
+    regions = {}
+    regions["lower_inner_PFR"] = Region(
+        name="lower_inner_PFR",
+        ds=ds,
+        xinner_ind=0,
+        xouter_ind=ixs2,
+        ylower_ind=0,
+        yupper_ind=jys11 + 1,
+        connection_outer_x="lower_inner_intersep",
+        connection_upper_y="lower_outer_PFR",
+    )
+    regions["lower_inner_intersep"] = Region(
+        name="lower_inner_intersep",
+        ds=ds,
+        xinner_ind=ixs2,
+        xouter_ind=ixs1,
+        ylower_ind=0,
+        yupper_ind=jys11 + 1,
+        connection_inner_x="lower_inner_PFR",
+        connection_outer_x="lower_inner_SOL",
+        connection_upper_y="lower_outer_intersep",
+    )
+    regions["lower_inner_SOL"] = Region(
+        name="lower_inner_SOL",
+        ds=ds,
+        xinner_ind=ixs1,
+        xouter_ind=nx,
+        ylower_ind=0,
+        yupper_ind=jys11 + 1,
+        connection_inner_x="lower_inner_intersep",
+        connection_upper_y="inner_SOL",
+    )
+    regions["inner_core"] = Region(
+        name="inner_core",
+        ds=ds,
+        xinner_ind=0,
+        xouter_ind=ixs2,
+        ylower_ind=jys11 + 1,
+        yupper_ind=jys21 + 1,
+        connection_outer_x="inner_intersep",
+        connection_lower_y="outer_core",
+        connection_upper_y="outer_core",
+    )
+    regions["inner_intersep"] = Region(
+        name="inner_intersep",
+        ds=ds,
+        xinner_ind=ixs2,
+        xouter_ind=ixs1,
+        ylower_ind=jys11 + 1,
+        yupper_ind=jys21 + 1,
+        connection_inner_x="inner_core",
+        connection_outer_x="inner_SOL",
+        connection_lower_y="outer_intersep",
+        connection_upper_y="upper_inner_intersep",
+    )
+    regions["inner_SOL"] = Region(
+        name="inner_SOL",
+        ds=ds,
+        xinner_ind=ixs1,
+        xouter_ind=nx,
+        ylower_ind=jys11 + 1,
+        yupper_ind=jys21 + 1,
+        connection_inner_x="inner_intersep",
+        connection_lower_y="lower_inner_SOL",
+        connection_upper_y="upper_inner_SOL",
+    )
+    regions["upper_inner_PFR"] = Region(
+        name="upper_inner_PFR",
+        ds=ds,
+        xinner_ind=0,
+        xouter_ind=ixs2,
+        ylower_ind=jys21 + 1,
+        yupper_ind=ny_inner,
+        connection_outer_x="upper_inner_intersep",
+        connection_lower_y="upper_outer_PFR",
+    )
+    regions["upper_inner_intersep"] = Region(
+        name="upper_inner_intersep",
+        ds=ds,
+        xinner_ind=ixs2,
+        xouter_ind=ixs1,
+        ylower_ind=jys21 + 1,
+        yupper_ind=ny_inner,
+        connection_inner_x="upper_inner_PFR",
+        connection_outer_x="upper_inner_SOL",
+        connection_lower_y="inner_intersep",
+    )
+    regions["upper_inner_SOL"] = Region(
+        name="upper_inner_SOL",
+        ds=ds,
+        xinner_ind=ixs1,
+        xouter_ind=nx,
+        ylower_ind=jys21 + 1,
+        yupper_ind=ny_inner,
+        connection_inner_x="upper_inner_intersep",
+        connection_lower_y="inner_SOL",
+    )
+    regions["upper_outer_PFR"] = Region(
+        name="upper_outer_PFR",
+        ds=ds,
+        xinner_ind=0,
+        xouter_ind=ixs2,
+        ylower_ind=ny_inner,
+        yupper_ind=jys12 + 1,
+        connection_outer_x="upper_outer_intersep",
+        connection_upper_y="upper_inner_PFR",
+    )
+    regions["upper_outer_intersep"] = Region(
+        name="upper_outer_intersep",
+        ds=ds,
+        xinner_ind=ixs2,
+        xouter_ind=ixs1,
+        ylower_ind=ny_inner,
+        yupper_ind=jys12 + 1,
+        connection_inner_x="upper_outer_PFR",
+        connection_outer_x="upper_outer_SOL",
+        connection_upper_y="outer_intersep",
+    )
+    regions["upper_outer_SOL"] = Region(
+        name="upper_outer_SOL",
+        ds=ds,
+        xinner_ind=ixs1,
+        xouter_ind=nx,
+        ylower_ind=ny_inner,
+        yupper_ind=jys12 + 1,
+        connection_inner_x="upper_outer_intersep",
+        connection_upper_y="outer_SOL",
+    )
+    regions["outer_core"] = Region(
+        name="outer_core",
+        ds=ds,
+        xinner_ind=0,
+        xouter_ind=ixs2,
+        ylower_ind=jys12 + 1,
+        yupper_ind=jys22 + 1,
+        connection_outer_x="outer_intersep",
+        connection_lower_y="inner_core",
+        connection_upper_y="inner_core",
+    )
+    regions["outer_intersep"] = Region(
+        name="outer_intersep",
+        ds=ds,
+        xinner_ind=ixs2,
+        xouter_ind=ixs1,
+        ylower_ind=jys12 + 1,
+        yupper_ind=jys22 + 1,
+        connection_inner_x="outer_core",
+        connection_outer_x="outer_SOL",
+        connection_lower_y="upper_outer_intersep",
+        connection_upper_y="inner_intersep",
+    )
+    regions["outer_SOL"] = Region(
+        name="outer_SOL",
+        ds=ds,
+        xinner_ind=ixs1,
+        xouter_ind=nx,
+        ylower_ind=jys12 + 1,
+        yupper_ind=jys22 + 1,
+        connection_inner_x="outer_intersep",
+        connection_lower_y="upper_outer_SOL",
+        connection_upper_y="lower_outer_SOL",
+    )
+    regions["lower_outer_PFR"] = Region(
+        name="lower_outer_PFR",
+        ds=ds,
+        xinner_ind=0,
+        xouter_ind=ixs2,
+        ylower_ind=jys22 + 1,
+        yupper_ind=ny,
+        connection_outer_x="lower_outer_intersep",
+        connection_lower_y="lower_inner_PFR",
+    )
+    regions["lower_outer_intersep"] = Region(
+        name="lower_outer_intersep",
+        ds=ds,
+        xinner_ind=ixs2,
+        xouter_ind=ixs1,
+        ylower_ind=jys22 + 1,
+        yupper_ind=ny,
+        connection_inner_x="lower_outer_PFR",
+        connection_outer_x="lower_outer_SOL",
+        connection_lower_y="lower_inner_intersep",
+    )
+    regions["lower_outer_SOL"] = Region(
+        name="lower_outer_SOL",
+        ds=ds,
+        xinner_ind=ixs1,
+        xouter_ind=nx,
+        ylower_ind=jys22 + 1,
+        yupper_ind=ny,
+        connection_inner_x="lower_outer_intersep",
+        connection_lower_y="outer_SOL",
+    )
+    return regions
+
+
+topologies["upper-disconnected-double-null"] = topology_upper_disconnected_double_null
 
 
 def topology_connected_double_null(
@@ -962,7 +1167,6 @@ def _create_regions_toroidal(ds):
     # Make sure all sizes are sensible
     ixs1 = _in_range(ixs1, 0, nx)
     ixs2 = _in_range(ixs2, 0, nx)
-    ixs1, ixs2 = _order_vars(ixs1, ixs2)
     jys11 = _in_range(jys11, 0, ny - 1)
     jys21 = _in_range(jys21, 0, ny - 1)
     jys12 = _in_range(jys12, 0, ny - 1)

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -665,7 +665,7 @@ class TestBoutDatasetMethods:
             nt=1,
             guards=guards,
             grid="grid",
-            topology="disconnected-double-null",
+            topology="lower-disconnected-double-null",
         )
 
         ds = open_boutdataset(
@@ -1572,7 +1572,7 @@ class TestBoutDatasetMethods:
             nype=6,
             nt=1,
             grid="grid",
-            topology="disconnected-double-null",
+            topology="upper-disconnected-double-null",
         )
 
         ds = open_boutdataset(
@@ -1623,7 +1623,7 @@ class TestBoutDatasetMethods:
             nype=6,
             nt=1,
             grid="grid",
-            topology="disconnected-double-null",
+            topology="lower-disconnected-double-null",
         )
 
         ds = open_boutdataset(
@@ -2083,7 +2083,7 @@ class TestSaveRestart:
             nt=1,
             guards={"x": 2, "y": 2},
             lengths=(6, 5, 4, 7),
-            topology="disconnected-double-null",
+            topology="upper-disconnected-double-null",
             write_to_disk=True,
         )
 
@@ -2148,7 +2148,7 @@ class TestSaveRestart:
             nt=1,
             guards={"x": 2, "y": 2},
             lengths=(6, 5, 4, 7),
-            topology="disconnected-double-null",
+            topology="lower-disconnected-double-null",
             write_to_disk=True,
         )
 

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -560,14 +560,33 @@ def create_bout_ds(
         ds["jyseps2_1"] = ny_inner - MYSUB - 1
         ds["jyseps1_2"] = ny_inner + MYSUB - 1
         ds["jyseps2_2"] = ny - MYSUB - 1
-    elif topology == "disconnected-double-null":
+    elif topology == "lower-disconnected-double-null":
         if nype < 6 and not squashed:
             raise ValueError(
-                "Not enough processors for disconnected-double-null "
+                "Not enough processors for lower-disconnected-double-null "
                 f"topology: nype={nype}"
             )
         ds["ixseps1"] = nx // 2
         ds["ixseps2"] = nx // 2 + 4
+        if ds["ixseps2"] >= nx:
+            raise ValueError(
+                "Not enough points in the x-direction. ixseps2="
+                f'{ds["ixseps2"]} > nx={nx}'
+            )
+        ds["jyseps1_1"] = MYSUB - 1
+        ny_inner = 3 * MYSUB
+        ds["ny_inner"] = ny_inner
+        ds["jyseps2_1"] = ny_inner - MYSUB - 1
+        ds["jyseps1_2"] = ny_inner + MYSUB - 1
+        ds["jyseps2_2"] = ny - MYSUB - 1
+    elif topology == "upper-disconnected-double-null":
+        if nype < 6 and not squashed:
+            raise ValueError(
+                "Not enough processors for upper-disconnected-double-null "
+                f"topology: nype={nype}"
+            )
+        ds["ixseps2"] = nx // 2
+        ds["ixseps1"] = nx // 2 + 4
         if ds["ixseps2"] >= nx:
             raise ValueError(
                 "Not enough points in the x-direction. ixseps2="
@@ -776,7 +795,7 @@ class TestOpen:
             lengths=(6, 2, 4, 7),
             guards={"x": 2, "y": 2},
             squashed=True,
-            topology="disconnected-double-null",
+            topology="lower-disconnected-double-null",
         )
         with pytest.warns(UserWarning):
             ds = open_boutdataset(
@@ -811,7 +830,7 @@ class TestOpen:
             guards={"x": 2, "y": 2},
             squashed=True,
             write_to_disk=True,
-            topology="disconnected-double-null",
+            topology="upper-disconnected-double-null",
         )
         with pytest.warns(UserWarning):
             ds = open_boutdataset(

--- a/xbout/tests/test_plot.py
+++ b/xbout/tests/test_plot.py
@@ -25,6 +25,9 @@ class TestPlot:
             pytest.param(2, marks=pytest.mark.long),
         ],
     )
+    @pytest.mark.parametrize(
+        "dnd_type", ["lower-disconnected-double-null", "upper-disconnected-double-null"]
+    )
     def test_region_disconnecteddoublenull(
         self,
         bout_xyt_example_files,
@@ -32,6 +35,7 @@ class TestPlot:
         keep_xboundaries,
         keep_yboundaries,
         with_guards,
+        dnd_type,
     ):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
@@ -44,7 +48,7 @@ class TestPlot:
             nt=1,
             guards=guards,
             grid="grid",
-            topology="disconnected-double-null",
+            topology=dnd_type,
         )
 
         ds = open_boutdataset(

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -864,8 +864,16 @@ class TestRegion:
 
     @pytest.mark.parametrize(params_guards, params_guards_values)
     @pytest.mark.parametrize(params_boundaries, params_boundaries_values)
+    @pytest.mark.parametrize(
+        "dnd_type", ["lower-disconnected-double-null", "upper-disconnected-double-null"]
+    )
     def test_region_disconnecteddoublenull(
-        self, bout_xyt_example_files, guards, keep_xboundaries, keep_yboundaries
+        self,
+        bout_xyt_example_files,
+        guards,
+        keep_xboundaries,
+        keep_yboundaries,
+        dnd_type,
     ):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
@@ -878,7 +886,7 @@ class TestRegion:
             nt=1,
             guards=guards,
             grid="grid",
-            topology="disconnected-double-null",
+            topology=dnd_type,
         )
 
         ds = open_boutdataset(
@@ -901,6 +909,15 @@ class TestRegion:
             ixs2 = ds.metadata["ixseps2"]
         else:
             ixs2 = ds.metadata["ixseps2"] - guards["x"]
+
+        if dnd_type == "lower-disconnected-double-null":
+            ixs_inner = ixs1
+            ixs_outer = ixs2
+        elif dnd_type == "upper-disconnected-double-null":
+            ixs_inner = ixs2
+            ixs_outer = ixs1
+        else:
+            raise ValueError(f"Unsupported dnd_type: '{dnd_type}'")
 
         if keep_yboundaries:
             ybndry = guards["y"]
@@ -924,7 +941,7 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_lower_inner_PFR.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(jys11 + 1)),
+            n_noregions.isel(x=slice(ixs_inner + mxg), theta=slice(jys11 + 1)),
             n_lower_inner_PFR.isel(theta=slice(-myg if myg != 0 else None)),
         )
         if myg > 0:
@@ -932,7 +949,7 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + mxg), theta=slice(jys22 + 1, jys22 + 1 + myg)
+                    x=slice(ixs_inner + mxg), theta=slice(jys22 + 1, jys22 + 1 + myg)
                 ).values,
                 n_lower_inner_PFR.isel(theta=slice(-myg, None)).values,
             )
@@ -942,26 +959,39 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_lower_inner_intersep.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 - mxg, ixs2 + mxg), theta=slice(jys11 + 1)),
+            n_noregions.isel(
+                x=slice(ixs_inner - mxg, ixs_outer + mxg), theta=slice(jys11 + 1)
+            ),
             n_lower_inner_intersep.isel(theta=slice(-myg if myg != 0 else None)),
         )
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - mxg, ixs2 + mxg),
-                    theta=slice(jys11 + 1, jys11 + 1 + myg),
-                ).values,
-                n_lower_inner_intersep.isel(theta=slice(-myg, None)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in inner SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys11 + 1, jys11 + 1 + myg),
+                    ).values,
+                    n_lower_inner_intersep.isel(theta=slice(-myg, None)).values,
+                )
+            else:
+                # Connects to intersep in lower outer divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys22 + 1, jys22 + 1 + myg),
+                    ).values,
+                    n_lower_inner_intersep.isel(theta=slice(-myg, None)).values,
+                )
 
         n_lower_inner_SOL = n.bout.from_region("lower_inner_SOL")
 
         # Remove attributes that are expected to be different
         del n_lower_inner_SOL.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1)),
+            n_noregions.isel(x=slice(ixs_outer - mxg, None), theta=slice(jys11 + 1)),
             n_lower_inner_SOL.isel(theta=slice(-myg if myg != 0 else None)),
         )
         if myg > 0:
@@ -969,7 +999,8 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1, jys11 + 1 + myg)
+                    x=slice(ixs_outer - mxg, None),
+                    theta=slice(jys11 + 1, jys11 + 1 + myg),
                 ).values,
                 n_lower_inner_SOL.isel(theta=slice(-myg, None)).values,
             )
@@ -979,7 +1010,9 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_inner_core.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(jys11 + 1, jys21 + 1)),
+            n_noregions.isel(
+                x=slice(ixs_inner + mxg), theta=slice(jys11 + 1, jys21 + 1)
+            ),
             n_inner_core.isel(theta=slice(myg, -myg if myg != 0 else None)),
         )
         if myg > 0:
@@ -987,13 +1020,13 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + mxg), theta=slice(jys22 + 1 - myg, jys22 + 1)
+                    x=slice(ixs_inner + mxg), theta=slice(jys22 + 1 - myg, jys22 + 1)
                 ).values,
                 n_inner_core.isel(theta=slice(myg)).values,
             )
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + mxg), theta=slice(jys12 + 1, jys12 + 1 + myg)
+                    x=slice(ixs_inner + mxg), theta=slice(jys12 + 1, jys12 + 1 + myg)
                 ).values,
                 n_inner_core.isel(theta=slice(-myg, None)).values,
             )
@@ -1004,27 +1037,50 @@ class TestRegion:
         del n_inner_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - mxg, ixs2 + mxg), theta=slice(jys11 + 1, jys21 + 1)
+                x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                theta=slice(jys11 + 1, jys21 + 1),
             ),
             n_inner_intersep.isel(theta=slice(myg, -myg if myg != 0 else None)),
         )
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - mxg, ixs2 + mxg),
-                    theta=slice(jys11 + 1 - myg, jys11 + 1),
-                ).values,
-                n_inner_intersep.isel(theta=slice(myg)).values,
-            )
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - mxg, ixs2 + mxg),
-                    theta=slice(jys12 + 1, jys12 + 1 + myg),
-                ).values,
-                n_inner_intersep.isel(theta=slice(-myg, None)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in lower inner divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys11 + 1 - myg, jys11 + 1),
+                    ).values,
+                    n_inner_intersep.isel(theta=slice(myg)).values,
+                )
+
+                # Connects to intersep in outer SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys12 + 1, jys12 + 1 + myg),
+                    ).values,
+                    n_inner_intersep.isel(theta=slice(-myg, None)).values,
+                )
+            else:
+                # Connects to intersep in outer SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys22 + 1 - myg, jys22 + 1),
+                    ).values,
+                    n_inner_intersep.isel(theta=slice(myg)).values,
+                )
+
+                # Connects to intersep in upper inner divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys21 + 1, jys21 + 1 + myg),
+                    ).values,
+                    n_inner_intersep.isel(theta=slice(-myg, None)).values,
+                )
 
         n_inner_sol = n.bout.from_region("inner_SOL")
 
@@ -1032,7 +1088,7 @@ class TestRegion:
         del n_inner_sol.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1, jys21 + 1)
+                x=slice(ixs_outer - mxg, None), theta=slice(jys11 + 1, jys21 + 1)
             ),
             n_inner_sol.isel(theta=slice(myg, -myg if myg != 0 else None)),
         )
@@ -1041,13 +1097,15 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - mxg, None), theta=slice(jys11 + 1 - myg, jys11 + 1)
+                    x=slice(ixs_outer - mxg, None),
+                    theta=slice(jys11 + 1 - myg, jys11 + 1),
                 ).values,
                 n_inner_sol.isel(theta=slice(myg)).values,
             )
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - mxg, None), theta=slice(jys21 + 1, jys21 + 1 + myg)
+                    x=slice(ixs_outer - mxg, None),
+                    theta=slice(jys21 + 1, jys21 + 1 + myg),
                 ).values,
                 n_inner_sol.isel(theta=slice(-myg, None)).values,
             )
@@ -1057,7 +1115,9 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_upper_inner_PFR.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(jys21 + 1, ny_inner)),
+            n_noregions.isel(
+                x=slice(ixs_inner + mxg), theta=slice(jys21 + 1, ny_inner)
+            ),
             n_upper_inner_PFR.isel(theta=slice(myg, None)),
         )
         if myg > 0:
@@ -1065,7 +1125,7 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + mxg), theta=slice(jys12 + 1 - myg, jys12 + 1)
+                    x=slice(ixs_inner + mxg), theta=slice(jys12 + 1 - myg, jys12 + 1)
                 ).values,
                 n_upper_inner_PFR.isel(theta=slice(myg)).values,
             )
@@ -1076,20 +1136,32 @@ class TestRegion:
         del n_upper_inner_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - mxg, ixs2 + mxg), theta=slice(jys21 + 1, ny_inner)
+                x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                theta=slice(jys21 + 1, ny_inner),
             ),
             n_upper_inner_intersep.isel(theta=slice(myg, None)),
         )
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - mxg, ixs2 + mxg),
-                    theta=slice(jys12 + 1 - myg, jys12 + 1),
-                ).values,
-                n_upper_inner_intersep.isel(theta=slice(myg)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in upper outer divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys12 + 1 - myg, jys12 + 1),
+                    ).values,
+                    n_upper_inner_intersep.isel(theta=slice(myg)).values,
+                )
+            else:
+                # Connects to intersep in inner SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys21 + 1 - myg, jys21 + 1),
+                    ).values,
+                    n_upper_inner_intersep.isel(theta=slice(myg)).values,
+                )
 
         n_upper_inner_SOL = n.bout.from_region("upper_inner_SOL")
 
@@ -1097,7 +1169,7 @@ class TestRegion:
         del n_upper_inner_SOL.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs2 - mxg, None), theta=slice(jys21 + 1, ny_inner)
+                x=slice(ixs_outer - mxg, None), theta=slice(jys21 + 1, ny_inner)
             ),
             n_upper_inner_SOL.isel(theta=slice(myg, None)),
         )
@@ -1106,7 +1178,8 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - mxg, None), theta=slice(jys21 + 1 - myg, jys21 + 1)
+                    x=slice(ixs_outer - mxg, None),
+                    theta=slice(jys21 + 1 - myg, jys21 + 1),
                 ).values,
                 n_upper_inner_SOL.isel(theta=slice(myg)).values,
             )
@@ -1116,7 +1189,9 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_upper_outer_PFR.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(ny_inner, jys12 + 1)),
+            n_noregions.isel(
+                x=slice(ixs_inner + mxg), theta=slice(ny_inner, jys12 + 1)
+            ),
             n_upper_outer_PFR.isel(theta=slice(-myg if myg != 0 else None)),
         )
         if myg > 0:
@@ -1124,7 +1199,7 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + mxg), theta=slice(jys21 + 1, jys21 + 1 + myg)
+                    x=slice(ixs_inner + mxg), theta=slice(jys21 + 1, jys21 + 1 + myg)
                 ).values,
                 n_upper_outer_PFR.isel(theta=slice(-myg, None)).values,
             )
@@ -1135,20 +1210,32 @@ class TestRegion:
         del n_upper_outer_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - mxg, ixs2 + mxg), theta=slice(ny_inner, jys12 + 1)
+                x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                theta=slice(ny_inner, jys12 + 1),
             ),
             n_upper_outer_intersep.isel(theta=slice(-myg if myg != 0 else None)),
         )
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - mxg, ixs2 + mxg),
-                    theta=slice(jys21 + 1, jys21 + 1 + myg),
-                ).values,
-                n_upper_outer_intersep.isel(theta=slice(-myg, None)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in upper inner divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys21 + 1, jys21 + 1 + myg),
+                    ).values,
+                    n_upper_outer_intersep.isel(theta=slice(-myg, None)).values,
+                )
+            else:
+                # Connects to intersep in outer SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys12 + 1, jys12 + 1 + myg),
+                    ).values,
+                    n_upper_outer_intersep.isel(theta=slice(-myg, None)).values,
+                )
 
         n_upper_outer_SOL = n.bout.from_region("upper_outer_SOL")
 
@@ -1156,7 +1243,7 @@ class TestRegion:
         del n_upper_outer_SOL.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs2 - mxg, None), theta=slice(ny_inner, jys12 + 1)
+                x=slice(ixs_outer - mxg, None), theta=slice(ny_inner, jys12 + 1)
             ),
             n_upper_outer_SOL.isel(theta=slice(-myg if myg != 0 else None)),
         )
@@ -1165,7 +1252,8 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - mxg, None), theta=slice(jys12 + 1, jys12 + 1 + myg)
+                    x=slice(ixs_outer - mxg, None),
+                    theta=slice(jys12 + 1, jys12 + 1 + myg),
                 ).values,
                 n_upper_outer_SOL.isel(theta=slice(-myg, None)).values,
             )
@@ -1175,7 +1263,9 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_outer_core.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(jys12 + 1, jys22 + 1)),
+            n_noregions.isel(
+                x=slice(ixs_inner + mxg), theta=slice(jys12 + 1, jys22 + 1)
+            ),
             n_outer_core.isel(theta=slice(myg, -myg if myg != 0 else None)),
         )
         if myg > 0:
@@ -1183,13 +1273,13 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + mxg), theta=slice(jys21 + 1 - myg, jys21 + 1)
+                    x=slice(ixs_inner + mxg), theta=slice(jys21 + 1 - myg, jys21 + 1)
                 ).values,
                 n_outer_core.isel(theta=slice(myg)).values,
             )
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + mxg), theta=slice(jys11 + 1, jys11 + 1 + myg)
+                    x=slice(ixs_inner + mxg), theta=slice(jys11 + 1, jys11 + 1 + myg)
                 ).values,
                 n_outer_core.isel(theta=slice(-myg, None)).values,
             )
@@ -1200,27 +1290,48 @@ class TestRegion:
         del n_outer_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - mxg, ixs2 + mxg), theta=slice(jys12 + 1, jys22 + 1)
+                x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                theta=slice(jys12 + 1, jys22 + 1),
             ),
             n_outer_intersep.isel(theta=slice(myg, -myg if myg != 0 else None)),
         )
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - mxg, ixs2 + mxg),
-                    theta=slice(jys21 + 1 - myg, jys21 + 1),
-                ).values,
-                n_outer_intersep.isel(theta=slice(myg)).values,
-            )
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - mxg, ixs2 + mxg),
-                    theta=slice(jys22 + 1, jys22 + 1 + myg),
-                ).values,
-                n_outer_intersep.isel(theta=slice(-myg, None)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in inner SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys21 + 1 - myg, jys21 + 1),
+                    ).values,
+                    n_outer_intersep.isel(theta=slice(myg)).values,
+                )
+                # Connects to intersep in lower outer divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys22 + 1, jys22 + 1 + myg),
+                    ).values,
+                    n_outer_intersep.isel(theta=slice(-myg, None)).values,
+                )
+            else:
+                # Connects to intersep in upper outer divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys12 + 1 - myg, jys12 + 1),
+                    ).values,
+                    n_outer_intersep.isel(theta=slice(myg)).values,
+                )
+                # Connects to intersep in inner SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys11 + 1, jys11 + 1 + myg),
+                    ).values,
+                    n_outer_intersep.isel(theta=slice(-myg, None)).values,
+                )
 
         n_outer_sol = n.bout.from_region("outer_SOL")
 
@@ -1228,7 +1339,7 @@ class TestRegion:
         del n_outer_sol.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs2 - mxg, None), theta=slice(jys12 + 1, jys22 + 1)
+                x=slice(ixs_outer - mxg, None), theta=slice(jys12 + 1, jys22 + 1)
             ),
             n_outer_sol.isel(theta=slice(myg, -myg if myg != 0 else None)),
         )
@@ -1237,13 +1348,15 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - mxg, None), theta=slice(jys12 + 1 - myg, jys12 + 1)
+                    x=slice(ixs_outer - mxg, None),
+                    theta=slice(jys12 + 1 - myg, jys12 + 1),
                 ).values,
                 n_outer_sol.isel(theta=slice(myg)).values,
             )
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - mxg, None), theta=slice(jys22 + 1, jys22 + 1 + myg)
+                    x=slice(ixs_outer - mxg, None),
+                    theta=slice(jys22 + 1, jys22 + 1 + myg),
                 ).values,
                 n_outer_sol.isel(theta=slice(-myg, None)).values,
             )
@@ -1253,7 +1366,7 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_lower_outer_PFR.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 + mxg), theta=slice(jys22 + 1, None)),
+            n_noregions.isel(x=slice(ixs_inner + mxg), theta=slice(jys22 + 1, None)),
             n_lower_outer_PFR.isel(theta=slice(myg, None)),
         )
         if myg > 0:
@@ -1261,7 +1374,7 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + mxg), theta=slice(jys11 + 1 - myg, jys11 + 1)
+                    x=slice(ixs_inner + mxg), theta=slice(jys11 + 1 - myg, jys11 + 1)
                 ).values,
                 n_lower_outer_PFR.isel(theta=slice(myg)).values,
             )
@@ -1272,27 +1385,40 @@ class TestRegion:
         del n_lower_outer_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - mxg, ixs2 + mxg), theta=slice(jys22 + 1, None)
+                x=slice(ixs_inner - mxg, ixs_outer + mxg), theta=slice(jys22 + 1, None)
             ),
             n_lower_outer_intersep.isel(theta=slice(myg, None)),
         )
         if myg > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - mxg, ixs2 + mxg),
-                    theta=slice(jys22 + 1 - myg, jys22 + 1),
-                ).values,
-                n_lower_outer_intersep.isel(theta=slice(myg)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in outer SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys22 + 1 - myg, jys22 + 1),
+                    ).values,
+                    n_lower_outer_intersep.isel(theta=slice(myg)).values,
+                )
+            else:
+                # Connects to intersep in lower inner divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - mxg, ixs_outer + mxg),
+                        theta=slice(jys11 + 1 - myg, jys11 + 1),
+                    ).values,
+                    n_lower_outer_intersep.isel(theta=slice(myg)).values,
+                )
 
         n_lower_outer_SOL = n.bout.from_region("lower_outer_SOL")
 
         # Remove attributes that are expected to be different
         del n_lower_outer_SOL.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs2 - mxg, None), theta=slice(jys22 + 1, None)),
+            n_noregions.isel(
+                x=slice(ixs_outer - mxg, None), theta=slice(jys22 + 1, None)
+            ),
             n_lower_outer_SOL.isel(theta=slice(myg, None)),
         )
         if myg > 0:
@@ -1300,7 +1426,8 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - mxg, None), theta=slice(jys22 + 1 - myg, jys22 + 1)
+                    x=slice(ixs_outer - mxg, None),
+                    theta=slice(jys22 + 1 - myg, jys22 + 1),
                 ).values,
                 n_lower_outer_SOL.isel(theta=slice(myg)).values,
             )
@@ -1310,6 +1437,9 @@ class TestRegion:
     @pytest.mark.parametrize(
         "with_guards", [0, {"x": 1}, {"theta": 1}, {"x": 1, "theta": 1}, 1]
     )
+    @pytest.mark.parametrize(
+        "dnd_type", ["lower-disconnected-double-null", "upper-disconnected-double-null"]
+    )
     def test_region_disconnecteddoublenull_get_one_guard(
         self,
         bout_xyt_example_files,
@@ -1317,6 +1447,7 @@ class TestRegion:
         keep_xboundaries,
         keep_yboundaries,
         with_guards,
+        dnd_type,
     ):
         # Note using more than MXG x-direction points and MYG y-direction points per
         # output file ensures tests for whether boundary cells are present do not fail
@@ -1329,7 +1460,7 @@ class TestRegion:
             nt=1,
             guards=guards,
             grid="grid",
-            topology="disconnected-double-null",
+            topology=dnd_type,
         )
 
         ds = open_boutdataset(
@@ -1352,6 +1483,15 @@ class TestRegion:
             ixs2 = ds.metadata["ixseps2"]
         else:
             ixs2 = ds.metadata["ixseps2"] - guards["x"]
+
+        if dnd_type == "lower-disconnected-double-null":
+            ixs_inner = ixs1
+            ixs_outer = ixs2
+        elif dnd_type == "upper-disconnected-double-null":
+            ixs_inner = ixs2
+            ixs_outer = ixs1
+        else:
+            raise ValueError(f"Unsupported dnd_type: '{dnd_type}'")
 
         if keep_yboundaries:
             ybndry = guards["y"]
@@ -1384,7 +1524,7 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_lower_inner_PFR.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 + xguards), theta=slice(jys11 + 1)),
+            n_noregions.isel(x=slice(ixs_inner + xguards), theta=slice(jys11 + 1)),
             n_lower_inner_PFR.isel(theta=slice(-yguards if yguards != 0 else None)),
         )
         if yguards > 0:
@@ -1392,7 +1532,8 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + xguards), theta=slice(jys22 + 1, jys22 + 1 + yguards)
+                    x=slice(ixs_inner + xguards),
+                    theta=slice(jys22 + 1, jys22 + 1 + yguards),
                 ).values,
                 n_lower_inner_PFR.isel(theta=slice(-yguards, None)).values,
             )
@@ -1405,7 +1546,8 @@ class TestRegion:
         del n_lower_inner_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - xguards, ixs2 + xguards), theta=slice(jys11 + 1)
+                x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                theta=slice(jys11 + 1),
             ),
             n_lower_inner_intersep.isel(
                 theta=slice(-yguards if yguards != 0 else None)
@@ -1414,13 +1556,24 @@ class TestRegion:
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - xguards, ixs2 + xguards),
-                    theta=slice(jys11 + 1, jys11 + 1 + yguards),
-                ).values,
-                n_lower_inner_intersep.isel(theta=slice(-yguards, None)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in inner SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys11 + 1, jys11 + 1 + yguards),
+                    ).values,
+                    n_lower_inner_intersep.isel(theta=slice(-yguards, None)).values,
+                )
+            else:
+                # Connects to intersep in lower outer divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys22 + 1, jys22 + 1 + yguards),
+                    ).values,
+                    n_lower_inner_intersep.isel(theta=slice(-yguards, None)).values,
+                )
 
         n_lower_inner_SOL = n.bout.from_region(
             "lower_inner_SOL", with_guards=with_guards
@@ -1429,7 +1582,9 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_lower_inner_SOL.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs2 - xguards, None), theta=slice(jys11 + 1)),
+            n_noregions.isel(
+                x=slice(ixs_outer - xguards, None), theta=slice(jys11 + 1)
+            ),
             n_lower_inner_SOL.isel(theta=slice(-yguards if yguards != 0 else None)),
         )
         if yguards > 0:
@@ -1437,7 +1592,7 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - xguards, None),
+                    x=slice(ixs_outer - xguards, None),
                     theta=slice(jys11 + 1, jys11 + 1 + yguards),
                 ).values,
                 n_lower_inner_SOL.isel(theta=slice(-yguards, None)).values,
@@ -1449,7 +1604,7 @@ class TestRegion:
         del n_inner_core.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 + xguards), theta=slice(jys11 + 1, jys21 + 1)
+                x=slice(ixs_inner + xguards), theta=slice(jys11 + 1, jys21 + 1)
             ),
             n_inner_core.isel(theta=slice(yguards, -yguards if yguards != 0 else None)),
         )
@@ -1458,13 +1613,15 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + xguards), theta=slice(jys22 + 1 - yguards, jys22 + 1)
+                    x=slice(ixs_inner + xguards),
+                    theta=slice(jys22 + 1 - yguards, jys22 + 1),
                 ).values,
                 n_inner_core.isel(theta=slice(yguards)).values,
             )
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + xguards), theta=slice(jys12 + 1, jys12 + 1 + yguards)
+                    x=slice(ixs_inner + xguards),
+                    theta=slice(jys12 + 1, jys12 + 1 + yguards),
                 ).values,
                 n_inner_core.isel(theta=slice(-yguards, None)).values,
             )
@@ -1475,7 +1632,7 @@ class TestRegion:
         del n_inner_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - xguards, ixs2 + xguards),
+                x=slice(ixs_inner - xguards, ixs_outer + xguards),
                 theta=slice(jys11 + 1, jys21 + 1),
             ),
             n_inner_intersep.isel(
@@ -1485,20 +1642,42 @@ class TestRegion:
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - xguards, ixs2 + xguards),
-                    theta=slice(jys11 + 1 - yguards, jys11 + 1),
-                ).values,
-                n_inner_intersep.isel(theta=slice(yguards)).values,
-            )
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - xguards, ixs2 + xguards),
-                    theta=slice(jys12 + 1, jys12 + 1 + yguards),
-                ).values,
-                n_inner_intersep.isel(theta=slice(-yguards, None)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in lower inner divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys11 + 1 - yguards, jys11 + 1),
+                    ).values,
+                    n_inner_intersep.isel(theta=slice(yguards)).values,
+                )
+
+                # Connects to intersep in outer SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys12 + 1, jys12 + 1 + yguards),
+                    ).values,
+                    n_inner_intersep.isel(theta=slice(-yguards, None)).values,
+                )
+            else:
+                # Connects to intersep in outer SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys22 + 1 - yguards, jys22 + 1),
+                    ).values,
+                    n_inner_intersep.isel(theta=slice(yguards)).values,
+                )
+
+                # Connects to intersep in upper inner divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys21 + 1, jys21 + 1 + yguards),
+                    ).values,
+                    n_inner_intersep.isel(theta=slice(-yguards, None)).values,
+                )
 
         n_inner_sol = n.bout.from_region("inner_SOL", with_guards=with_guards)
 
@@ -1506,7 +1685,7 @@ class TestRegion:
         del n_inner_sol.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs2 - xguards, None), theta=slice(jys11 + 1, jys21 + 1)
+                x=slice(ixs_outer - xguards, None), theta=slice(jys11 + 1, jys21 + 1)
             ),
             n_inner_sol.isel(theta=slice(yguards, -yguards if yguards != 0 else None)),
         )
@@ -1515,14 +1694,14 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - xguards, None),
+                    x=slice(ixs_outer - xguards, None),
                     theta=slice(jys11 + 1 - yguards, jys11 + 1),
                 ).values,
                 n_inner_sol.isel(theta=slice(yguards)).values,
             )
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - xguards, None),
+                    x=slice(ixs_outer - xguards, None),
                     theta=slice(jys21 + 1, jys21 + 1 + yguards),
                 ).values,
                 n_inner_sol.isel(theta=slice(-yguards, None)).values,
@@ -1535,7 +1714,9 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_upper_inner_PFR.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 + xguards), theta=slice(jys21 + 1, ny_inner)),
+            n_noregions.isel(
+                x=slice(ixs_inner + xguards), theta=slice(jys21 + 1, ny_inner)
+            ),
             n_upper_inner_PFR.isel(theta=slice(yguards, None)),
         )
         if yguards > 0:
@@ -1543,7 +1724,8 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + xguards), theta=slice(jys12 + 1 - yguards, jys12 + 1)
+                    x=slice(ixs_inner + xguards),
+                    theta=slice(jys12 + 1 - yguards, jys12 + 1),
                 ).values,
                 n_upper_inner_PFR.isel(theta=slice(yguards)).values,
             )
@@ -1556,7 +1738,7 @@ class TestRegion:
         del n_upper_inner_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - xguards, ixs2 + xguards),
+                x=slice(ixs_inner - xguards, ixs_outer + xguards),
                 theta=slice(jys21 + 1, ny_inner),
             ),
             n_upper_inner_intersep.isel(theta=slice(yguards, None)),
@@ -1564,13 +1746,24 @@ class TestRegion:
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - xguards, ixs2 + xguards),
-                    theta=slice(jys12 + 1 - yguards, jys12 + 1),
-                ).values,
-                n_upper_inner_intersep.isel(theta=slice(yguards)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in upper outer divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys12 + 1 - yguards, jys12 + 1),
+                    ).values,
+                    n_upper_inner_intersep.isel(theta=slice(yguards)).values,
+                )
+            else:
+                # Connects to intersep in upper outer divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys21 + 1 - yguards, jys21 + 1),
+                    ).values,
+                    n_upper_inner_intersep.isel(theta=slice(yguards)).values,
+                )
 
         n_upper_inner_SOL = n.bout.from_region(
             "upper_inner_SOL", with_guards=with_guards
@@ -1580,7 +1773,7 @@ class TestRegion:
         del n_upper_inner_SOL.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs2 - xguards, None), theta=slice(jys21 + 1, ny_inner)
+                x=slice(ixs_outer - xguards, None), theta=slice(jys21 + 1, ny_inner)
             ),
             n_upper_inner_SOL.isel(theta=slice(yguards, None)),
         )
@@ -1589,7 +1782,7 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - xguards, None),
+                    x=slice(ixs_outer - xguards, None),
                     theta=slice(jys21 + 1 - yguards, jys21 + 1),
                 ).values,
                 n_upper_inner_SOL.isel(theta=slice(yguards)).values,
@@ -1602,7 +1795,9 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_upper_outer_PFR.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 + xguards), theta=slice(ny_inner, jys12 + 1)),
+            n_noregions.isel(
+                x=slice(ixs_inner + xguards), theta=slice(ny_inner, jys12 + 1)
+            ),
             n_upper_outer_PFR.isel(theta=slice(-yguards if yguards != 0 else None)),
         )
         if yguards > 0:
@@ -1610,7 +1805,8 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + xguards), theta=slice(jys21 + 1, jys21 + 1 + yguards)
+                    x=slice(ixs_inner + xguards),
+                    theta=slice(jys21 + 1, jys21 + 1 + yguards),
                 ).values,
                 n_upper_outer_PFR.isel(theta=slice(-yguards, None)).values,
             )
@@ -1623,7 +1819,7 @@ class TestRegion:
         del n_upper_outer_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - xguards, ixs2 + xguards),
+                x=slice(ixs_inner - xguards, ixs_outer + xguards),
                 theta=slice(ny_inner, jys12 + 1),
             ),
             n_upper_outer_intersep.isel(
@@ -1633,13 +1829,24 @@ class TestRegion:
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - xguards, ixs2 + xguards),
-                    theta=slice(jys21 + 1, jys21 + 1 + yguards),
-                ).values,
-                n_upper_outer_intersep.isel(theta=slice(-yguards, None)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in upper inner divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys21 + 1, jys21 + 1 + yguards),
+                    ).values,
+                    n_upper_outer_intersep.isel(theta=slice(-yguards, None)).values,
+                )
+            else:
+                # Connects to intersep in outer SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys12 + 1, jys12 + 1 + yguards),
+                    ).values,
+                    n_upper_outer_intersep.isel(theta=slice(-yguards, None)).values,
+                )
 
         n_upper_outer_SOL = n.bout.from_region(
             "upper_outer_SOL", with_guards=with_guards
@@ -1649,7 +1856,7 @@ class TestRegion:
         del n_upper_outer_SOL.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs2 - xguards, None), theta=slice(ny_inner, jys12 + 1)
+                x=slice(ixs_outer - xguards, None), theta=slice(ny_inner, jys12 + 1)
             ),
             n_upper_outer_SOL.isel(theta=slice(-yguards if yguards != 0 else None)),
         )
@@ -1658,7 +1865,7 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - xguards, None),
+                    x=slice(ixs_outer - xguards, None),
                     theta=slice(jys12 + 1, jys12 + 1 + yguards),
                 ).values,
                 n_upper_outer_SOL.isel(theta=slice(-yguards, None)).values,
@@ -1670,7 +1877,7 @@ class TestRegion:
         del n_outer_core.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 + xguards), theta=slice(jys12 + 1, jys22 + 1)
+                x=slice(ixs_inner + xguards), theta=slice(jys12 + 1, jys22 + 1)
             ),
             n_outer_core.isel(theta=slice(yguards, -yguards if yguards != 0 else None)),
         )
@@ -1679,13 +1886,15 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + xguards), theta=slice(jys21 + 1 - yguards, jys21 + 1)
+                    x=slice(ixs_inner + xguards),
+                    theta=slice(jys21 + 1 - yguards, jys21 + 1),
                 ).values,
                 n_outer_core.isel(theta=slice(yguards)).values,
             )
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + xguards), theta=slice(jys11 + 1, jys11 + 1 + yguards)
+                    x=slice(ixs_inner + xguards),
+                    theta=slice(jys11 + 1, jys11 + 1 + yguards),
                 ).values,
                 n_outer_core.isel(theta=slice(-yguards, None)).values,
             )
@@ -1696,7 +1905,7 @@ class TestRegion:
         del n_outer_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - xguards, ixs2 + xguards),
+                x=slice(ixs_inner - xguards, ixs_outer + xguards),
                 theta=slice(jys12 + 1, jys22 + 1),
             ),
             n_outer_intersep.isel(
@@ -1706,20 +1915,42 @@ class TestRegion:
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - xguards, ixs2 + xguards),
-                    theta=slice(jys21 + 1 - yguards, jys21 + 1),
-                ).values,
-                n_outer_intersep.isel(theta=slice(yguards)).values,
-            )
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - xguards, ixs2 + xguards),
-                    theta=slice(jys22 + 1, jys22 + 1 + yguards),
-                ).values,
-                n_outer_intersep.isel(theta=slice(-yguards, None)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in inner SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys21 + 1 - yguards, jys21 + 1),
+                    ).values,
+                    n_outer_intersep.isel(theta=slice(yguards)).values,
+                )
+
+                # Connects to intersep in lower outer divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys22 + 1, jys22 + 1 + yguards),
+                    ).values,
+                    n_outer_intersep.isel(theta=slice(-yguards, None)).values,
+                )
+            else:
+                # Connects to intersep in upper outer divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys12 + 1 - yguards, jys12 + 1),
+                    ).values,
+                    n_outer_intersep.isel(theta=slice(yguards)).values,
+                )
+
+                # Connects to intersep in inner SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys11 + 1, jys11 + 1 + yguards),
+                    ).values,
+                    n_outer_intersep.isel(theta=slice(-yguards, None)).values,
+                )
 
         n_outer_sol = n.bout.from_region("outer_SOL", with_guards=with_guards)
 
@@ -1727,7 +1958,7 @@ class TestRegion:
         del n_outer_sol.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs2 - xguards, None), theta=slice(jys12 + 1, jys22 + 1)
+                x=slice(ixs_outer - xguards, None), theta=slice(jys12 + 1, jys22 + 1)
             ),
             n_outer_sol.isel(theta=slice(yguards, -yguards if yguards != 0 else None)),
         )
@@ -1736,14 +1967,14 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - xguards, None),
+                    x=slice(ixs_outer - xguards, None),
                     theta=slice(jys12 + 1 - yguards, jys12 + 1),
                 ).values,
                 n_outer_sol.isel(theta=slice(yguards)).values,
             )
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - xguards, None),
+                    x=slice(ixs_outer - xguards, None),
                     theta=slice(jys22 + 1, jys22 + 1 + yguards),
                 ).values,
                 n_outer_sol.isel(theta=slice(-yguards, None)).values,
@@ -1756,7 +1987,9 @@ class TestRegion:
         # Remove attributes that are expected to be different
         del n_lower_outer_PFR.attrs["regions"]
         xrt.assert_identical(
-            n_noregions.isel(x=slice(ixs1 + xguards), theta=slice(jys22 + 1, None)),
+            n_noregions.isel(
+                x=slice(ixs_inner + xguards), theta=slice(jys22 + 1, None)
+            ),
             n_lower_outer_PFR.isel(theta=slice(yguards, None)),
         )
         if yguards > 0:
@@ -1764,7 +1997,8 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs1 + xguards), theta=slice(jys11 + 1 - yguards, jys11 + 1)
+                    x=slice(ixs_inner + xguards),
+                    theta=slice(jys11 + 1 - yguards, jys11 + 1),
                 ).values,
                 n_lower_outer_PFR.isel(theta=slice(yguards)).values,
             )
@@ -1777,20 +2011,32 @@ class TestRegion:
         del n_lower_outer_intersep.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs1 - xguards, ixs2 + xguards), theta=slice(jys22 + 1, None)
+                x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                theta=slice(jys22 + 1, None),
             ),
             n_lower_outer_intersep.isel(theta=slice(yguards, None)),
         )
         if yguards > 0:
             # check y-guards, which were 'communicated' by from_region
             # Coordinates are not equal, so only compare array values
-            npt.assert_equal(
-                n_noregions.isel(
-                    x=slice(ixs1 - xguards, ixs2 + xguards),
-                    theta=slice(jys22 + 1 - yguards, jys22 + 1),
-                ).values,
-                n_lower_outer_intersep.isel(theta=slice(yguards)).values,
-            )
+            if dnd_type == "lower-disconnected-double-null":
+                # Connects to intersep in outer SOL
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys22 + 1 - yguards, jys22 + 1),
+                    ).values,
+                    n_lower_outer_intersep.isel(theta=slice(yguards)).values,
+                )
+            else:
+                # Connects to intersep in lower inner divertor leg
+                npt.assert_equal(
+                    n_noregions.isel(
+                        x=slice(ixs_inner - xguards, ixs_outer + xguards),
+                        theta=slice(jys11 + 1 - yguards, jys11 + 1),
+                    ).values,
+                    n_lower_outer_intersep.isel(theta=slice(yguards)).values,
+                )
 
         n_lower_outer_SOL = n.bout.from_region(
             "lower_outer_SOL", with_guards=with_guards
@@ -1800,7 +2046,7 @@ class TestRegion:
         del n_lower_outer_SOL.attrs["regions"]
         xrt.assert_identical(
             n_noregions.isel(
-                x=slice(ixs2 - xguards, None), theta=slice(jys22 + 1, None)
+                x=slice(ixs_outer - xguards, None), theta=slice(jys22 + 1, None)
             ),
             n_lower_outer_SOL.isel(theta=slice(yguards, None)),
         )
@@ -1809,7 +2055,7 @@ class TestRegion:
             # Coordinates are not equal, so only compare array values
             npt.assert_equal(
                 n_noregions.isel(
-                    x=slice(ixs2 - xguards, None),
+                    x=slice(ixs_outer - xguards, None),
                     theta=slice(jys22 + 1 - yguards, jys22 + 1),
                 ).values,
                 n_lower_outer_SOL.isel(theta=slice(yguards)).values,

--- a/xbout/tests/test_region.py
+++ b/xbout/tests/test_region.py
@@ -1756,7 +1756,7 @@ class TestRegion:
                     n_upper_inner_intersep.isel(theta=slice(yguards)).values,
                 )
             else:
-                # Connects to intersep in upper outer divertor leg
+                # Connects to intersep in inner SOL
                 npt.assert_equal(
                     n_noregions.isel(
                         x=slice(ixs_inner - xguards, ixs_outer + xguards),


### PR DESCRIPTION
Upper double disconnected double null topology has `ixseps1 > ixseps2` and needs to be handled separately from lower disconnected double null. The previous 'disconnected double null' was actually only lower disconnected double null.