### PR TITLE
Pass `combine_attrs` arguments for compatibility with xarray-0.18; bump to xarray-0.17.0, Python 3.7

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,10 +20,10 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray numpy>=1.16.0"
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.17.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,10 +16,10 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray numpy>=1.16.0"
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.17.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -14,10 +14,10 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray!=0.14.0 numpy>=1.16.0"
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.16.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray numpy>=1.16.0"
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.17.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: true
 
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ build:
   image: latest
 
 python:
-  version: 3.6
+  version: 3.8
   pip_install: true
   extra_requirements:
     - docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ author = Thomas Nicholas
 author_email = thomas.nicholas@york.ac.uk
 description = Collect data from BOUT++ runs in python using xarray
 license = Apache
-python_requires = >=3.6
+python_requires = >=3.7
 long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
@@ -27,7 +27,7 @@ setup_requires =
     setuptools_scm[toml]>=3.4
     setuptools_scm_git_archive
 install_requires =
-    xarray>=0.16.0
+    xarray>=0.17.0
     boutdata>=0.1.2
     dask[array]>=2.10.0
     natsort>=5.5.0

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -288,7 +288,7 @@ class BoutDataArrayAccessor:
                 if "region" in part[self.data.name].attrs:
                     del part[self.data.name].attrs["region"]
 
-            result = xr.combine_by_coords(parts)
+            result = xr.combine_by_coords(parts, combine_attrs="drop_conflicts")
 
             if return_dataset:
                 return result

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -567,6 +567,7 @@ def _auto_open_mfboutdataset(
             concat_dim=concat_dims,
             data_vars=_BOUT_TIME_DEPENDENT_META_VARS,
             join="exact",
+            combine_attrs="no_conflicts",
         )
 
     # Remove any duplicate time values from concatenation


### PR DESCRIPTION
Need to pass `combine_attrs` arguments explicitly in a couple of places, otherwise tests fail with the most recent release of `xarray`. The new arguments require bumping the minimum supported version of `xarray` to 0.17.0, which requires bumping the minimum Python version to 3.7.