### PR TITLE
Option for cumulative time integral in integrate_midpoints() [bump minimum xarray to 0.18.0]

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: false
 
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages. Note, using numpy==1.18.0 as a workaround because numpy==1.17.0 is not supported on Python-3.7, even though we should currently support numpy==1.17.0.
       fail-fast: false
 
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: false
 
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.17.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.17.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages. Note, using numpy==1.18.0 as a workaround because numpy==1.17.0 is not supported on Python-3.7, even though we should currently support numpy==1.17.0.
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: true
 
     steps:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.17.0 dask==2.10.0 numpy==1.16.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: true
 
     steps:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0" # test with oldest supported version of packages. Note, using numpy==1.18.0 as a workaround because numpy==1.17.0 is not supported on Python-3.7, even though we should currently support numpy==1.17.0.
       fail-fast: true
 
     steps:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
+          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.17.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==6.1.0 fsspec" # test with oldest supported version of packages. Note, using numpy==1.16.0 as a workaround for some weird fails on Travis, in principle we should work with numpy>=1.13.3. We should not need to install fsspec explicitly, but at the moment are getting import errors in the tests due to fsspec not being present - should remove in future, probably when dask version is increased.
       fail-fast: true
 
     steps:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -113,7 +113,7 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    needs: [pytest, black]
+    needs: [pytest, pytest-min-versions, black]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ setup_requires =
     setuptools_scm[toml]>=3.4
     setuptools_scm_git_archive
 install_requires =
-    xarray>=0.17.0
+    xarray>=0.18.0
     boutdata>=0.1.4
     dask[array]>=2.10.0
     natsort>=5.5.0

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -261,7 +261,7 @@ class BoutDatasetAccessor:
 
         return ds
 
-    def integrate_midpoints(self, variable, *, dims=None):
+    def integrate_midpoints(self, variable, *, dims=None, cumulative_t=False):
         """
         Integrate using the midpoint rule for spatial dimensions, and trapezium rule for
         time.
@@ -302,6 +302,10 @@ class BoutDatasetAccessor:
             Dimensions to integrate over. Can be any combination of of the dimensions of
             the Dataset. Defaults to integration over all spatial dimensions. If `...`
             is passed, integrate over all dimensions including time.
+        cumulative_t : bool, default False
+            If integrating in time, return the cumulative integral (integral from the
+            beginning up to each point in the time dimension) instead of the definite
+            integral.
         """
         ds = self.data
 
@@ -447,7 +451,10 @@ class BoutDatasetAccessor:
             integral = integral * ds.sizes[zcoord]
 
         if tcoord in dims:
-            integral = integral.integrate(dim=tcoord)
+            if cumulative_t:
+                integral = integral.cumulative_integrate(coord=tcoord)
+            else:
+                integral = integral.integrate(dim=tcoord)
 
         return integral
 

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -1354,6 +1354,7 @@ class TestBoutDatasetMethods:
             r = r - Lr / (2.0 * nx)
         q = options.evaluate_scalar("mesh:q")
         T_total = (ds.sizes["t"] - 1) * (ds["t"][1] - ds["t"][0]).values
+        T_cumulative = np.arange(ds.sizes["t"]) * (ds["t"][1] - ds["t"][0]).values
 
         # Volume of torus with circular cross-section of major radius R and minor radius
         # a is 2*pi*R*pi*a^2
@@ -1386,6 +1387,15 @@ class TestBoutDatasetMethods:
             rtol=1.0e-5,
             atol=0.0,
         )
+        # Cumulative integral in time
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints(
+                "n", dims=["t", "x", "theta", "zeta"], cumulative_t=True
+            ),
+            T_cumulative * 2.0 * np.pi * R * np.pi * (router ** 2 - rinner ** 2),
+            rtol=1.0e-5,
+            atol=0.0,
+        )
 
         # Area of torus with circular cross-section of major radius R and minor radius a
         # is 2*pi*R*2*pi*a
@@ -1404,6 +1414,16 @@ class TestBoutDatasetMethods:
             rtol=1.0e-5,
             atol=0.0,
         )
+        # Cumulative integral in time
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints(
+                "n", dims=["t", "theta", "zeta"], cumulative_t=True
+            ),
+            T_cumulative[:, np.newaxis]
+            * (2.0 * np.pi * R * 2.0 * np.pi * r)[np.newaxis, :],
+            rtol=1.0e-5,
+            atol=0.0,
+        )
 
         # Area of cross section in poloidal plane is difference of circle with radius
         # router and circle with radius rinner, pi*(router**2 - rinner**2)
@@ -1417,6 +1437,18 @@ class TestBoutDatasetMethods:
         npt.assert_allclose(
             ds.bout.integrate_midpoints("n", dims=["t", "x", "theta"]),
             T_total * np.pi * (router ** 2 - rinner ** 2),
+            rtol=1.0e-5,
+            atol=0.0,
+        )
+        # Cumulative integral in time
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints(
+                "n", dims=["t", "x", "theta"], cumulative_t=True
+            ),
+            T_cumulative[:, np.newaxis]
+            * np.pi
+            * (router ** 2 - rinner ** 2)
+            * np.ones(ds.sizes["zeta"])[np.newaxis, :],
             rtol=1.0e-5,
             atol=0.0,
         )
@@ -1442,6 +1474,17 @@ class TestBoutDatasetMethods:
             rtol=1.0e-5,
             atol=0.0,
         )
+        # Cumulative integral in time
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints(
+                "n", dims=["t", "x", "zeta"], cumulative_t=True
+            ),
+            T_cumulative[:, np.newaxis]
+            * (np.pi * (Rinner + Router) * Lr)
+            * np.ones(ds.sizes["theta"])[np.newaxis, :],
+            rtol=1.0e-5,
+            atol=0.0,
+        )
 
         # Radial lines have length Lr
         npt.assert_allclose(
@@ -1454,6 +1497,15 @@ class TestBoutDatasetMethods:
         npt.assert_allclose(
             ds.bout.integrate_midpoints("n", dims=["t", "x"]),
             T_total * Lr,
+            rtol=1.0e-5,
+            atol=0.0,
+        )
+        # Cumulative integral in time
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("n", dims=["t", "x"], cumulative_t=True),
+            T_cumulative[:, np.newaxis, np.newaxis]
+            * Lr
+            * np.ones([ds.sizes["theta"], ds.sizes["zeta"]])[np.newaxis, :, :],
             rtol=1.0e-5,
             atol=0.0,
         )
@@ -1473,6 +1525,15 @@ class TestBoutDatasetMethods:
             T_total
             * (2.0 * np.pi * r)[:, np.newaxis]
             * np.ones(ds.sizes["zeta"])[np.newaxis, :],
+            rtol=1.0e-5,
+            atol=0.0,
+        )
+        # Cumulative integral in time
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("n", dims=["t", "theta"], cumulative_t=True),
+            T_cumulative[:, np.newaxis, np.newaxis]
+            * (2.0 * np.pi * r)[np.newaxis, :, np.newaxis]
+            * np.ones(ds.sizes["zeta"])[np.newaxis, np.newaxis, :],
             rtol=1.0e-5,
             atol=0.0,
         )
@@ -1555,6 +1616,17 @@ class TestBoutDatasetMethods:
             rtol=1.0e-5,
             atol=0.0,
         )
+        # Cumulative integral in time
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints(
+                "n_aligned", dims=["t", "theta"], cumulative_t=True
+            ),
+            T_cumulative[:, np.newaxis, np.newaxis]
+            * integral[np.newaxis, :, np.newaxis]
+            * np.ones(ds.sizes["zeta"])[np.newaxis, np.newaxis, :],
+            rtol=1.0e-5,
+            atol=0.0,
+        )
 
         # Toroidal lines have length 2*pi*Rxy
         if location == "CELL_CENTRE":
@@ -1572,6 +1644,14 @@ class TestBoutDatasetMethods:
         npt.assert_allclose(
             ds.bout.integrate_midpoints("n", dims=["t", "zeta"]),
             T_total * (2.0 * np.pi * R_2d),
+            rtol=1.0e-5,
+            atol=0.0,
+        )
+        # Cumulative integral in time
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("n", dims=["t", "zeta"], cumulative_t=True),
+            T_cumulative[:, np.newaxis, np.newaxis]
+            * (2.0 * np.pi * R_2d).values[np.newaxis, :, :],
             rtol=1.0e-5,
             atol=0.0,
         )


### PR DESCRIPTION
Adds an option to make the time integral in `integrate_midpoints` cumulative (t-dependent) instead of total.

Requires the minimum xarray to be 0.18.0 to provide the `cumulative_integrate()` method. Does anyone have a problem with this?