### PR TITLE
Make 'controls' argument for animation methods more flexible

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -706,6 +706,12 @@ class BoutDataArrayAccessor:
         kwargs : dict, optional
             Additional keyword arguments are passed on to the plotting function
             (animatplot.blocks.Pcolormesh).
+
+        Returns
+        -------
+        animation or blocks
+            If animate==True, returns an animatplot.Animation object, otherwise
+            returns a list of animatplot.blocks.Pcolormesh instances.
         """
 
         data = self.data
@@ -809,6 +815,12 @@ class BoutDataArrayAccessor:
         kwargs : dict, optional
             Additional keyword arguments are passed on to the plotting function
             (animatplot.blocks.Line).
+
+        Returns
+        -------
+        animation or block
+            If animate==True, returns an animatplot.Animation object, otherwise
+            returns an animatplot.blocks.Line instance.
         """
 
         data = self.data

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -22,6 +22,7 @@ from .plotting.animate import (
     animate_poloidal,
     animate_pcolormesh,
     animate_line,
+    _add_controls,
     _normalise_time_coord,
     _parse_coord_option,
 )
@@ -845,7 +846,7 @@ class BoutDatasetAccessor:
         titles=None,
         aspect=None,
         extend=None,
-        controls=True,
+        controls="both",
         tight_layout=True,
         **kwargs,
     ):
@@ -908,8 +909,10 @@ class BoutDatasetAccessor:
             plots and "auto" for others.
         extend : str or None, optional
             Passed to fig.colorbar()
-        controls : bool, optional
-            If set to False, do not show the time-slider or pause button
+        controls : string or None, default "both"
+            By default, add both the timeline and play/pause toggle to the animation. If
+            "timeline" is passed add only the timeline, if "toggle" is passed add only
+            the play/pause toggle. If None or an empty string is passed, add neither.
         tight_layout : bool or dict, optional
             If set to False, don't call tight_layout() on the figure.
             If a dict is passed, the dict entries are passed as arguments to
@@ -1148,8 +1151,7 @@ class BoutDatasetAccessor:
                 tight_layout = {}
             fig.tight_layout(**tight_layout)
 
-        if controls:
-            anim.controls(timeline_slider_args={"text": time_label})
+        _add_controls(anim, controls, time_label)
 
         if save_as is not None:
             anim.save(save_as + ".gif", writer=PillowWriter(fps=fps))

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -916,6 +916,11 @@ class BoutDatasetAccessor:
             tight_layout()
         **kwargs : dict, optional
             Additional keyword arguments are passed on to each animation function
+
+        Returns
+        -------
+        animation
+            An animatplot.Animation object.
         """
 
         if animate_over is None:

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -25,6 +25,23 @@ if (
     matplotlib.rcParams["pcolor.shading"] = "auto"
 
 
+def _add_controls(anim, controls, t_label):
+    if controls == "both":
+        # Add both time slider and play/pause toggle
+        anim.controls(timeline_slider_args={"text": t_label})
+    elif controls == "timeline":
+        # Add time slider
+        anim.timeline_slider(text=t_label)
+    elif controls == "toggle":
+        # Add play/pause toggle
+        anim.toggle()
+    elif controls is None or controls == "":
+        # Add no controls
+        pass
+    else:
+        raise ValueError(f"Unrecognised value for controls={controls}")
+
+
 def _parse_coord_option(coord, axis_coords, da):
     if isinstance(axis_coords, dict):
         option_value = axis_coords.get(coord, None)
@@ -90,7 +107,7 @@ def animate_poloidal(
     animate=True,
     save_as=None,
     fps=10,
-    controls=True,
+    controls="both",
     aspect=None,
     extend=None,
     **kwargs,
@@ -146,8 +163,10 @@ def animate_poloidal(
         '<variable name>_over_<animate_over>.gif'
     fps : float, optional
         Frame rate for the animation
-    controls : bool, optional
-        If False, do not add the timeline and pause button to the animation
+    controls : string or None, default "both"
+        By default, add both the timeline and play/pause toggle to the animation. If
+        "timeline" is passed add only the timeline, if "toggle" is passed add only the
+        play/pause toggle. If None or an empty string is passed, add neither.
     aspect : str or None, optional
         Argument to set_aspect(), defaults to "equal"
     extend : str or None, optional
@@ -268,8 +287,7 @@ def animate_poloidal(
         timeline = amp.Timeline(t_values, fps=fps, units=t_suffix)
         anim = amp.Animation(blocks, timeline)
 
-        if controls:
-            anim.controls(timeline_slider_args={"text": t_label})
+        _add_controls(anim, controls, t_label)
 
         if save_as is not None:
             if save_as is True:
@@ -298,7 +316,7 @@ def animate_pcolormesh(
     cax=None,
     aspect=None,
     extend=None,
-    controls=True,
+    controls="both",
     **kwargs,
 ):
     """
@@ -360,8 +378,10 @@ def animate_pcolormesh(
         Argument to set_aspect(), defaults to "auto"
     extend : str or None, optional
         Passed to fig.colorbar()
-    controls : bool, optional
-        If False, do not add the timeline and pause button to the animation
+    controls : string or None, default "both"
+        By default, add both the timeline and play/pause toggle to the animation. If
+        "timeline" is passed add only the timeline, if "toggle" is passed add only the
+        play/pause toggle. If None or an empty string is passed, add neither.
     kwargs : dict, optional
         Additional keyword arguments are passed on to the animation function
         animatplot.blocks.Pcolormesh
@@ -480,8 +500,7 @@ def animate_pcolormesh(
     ax.set_ylabel(y_label)
 
     if animate:
-        if controls:
-            anim.controls(timeline_slider_args={"text": t_label})
+        _add_controls(anim, controls, t_label)
 
         if save_as is not None:
             if save_as is True:
@@ -505,7 +524,7 @@ def animate_line(
     sep_pos=None,
     ax=None,
     aspect=None,
-    controls=True,
+    controls="both",
     **kwargs,
 ):
     """
@@ -548,8 +567,10 @@ def animate_line(
         figure and axes, and plot to that
     aspect : str or None, optional
         Argument to set_aspect(), defaults to "auto"
-    controls : bool, optional
-        If False, do not add the timeline and pause button to the animation
+    controls : string or None, default "both"
+        By default, add both the timeline and play/pause toggle to the animation. If
+        "timeline" is passed add only the timeline, if "toggle" is passed add only the
+        play/pause toggle. If None or an empty string is passed, add neither.
     kwargs : dict, optional
         Additional keyword arguments are passed on to the plotting function
         animatplot.blocks.Line
@@ -623,8 +644,7 @@ def animate_line(
         ax.plot_vline(sep_pos, "--")
 
     if animate:
-        if controls:
-            anim.controls(timeline_slider_args={"text": t_label})
+        _add_controls(anim, controls, t_label)
 
         if save_as is not None:
             if save_as is True:

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -158,8 +158,9 @@ def animate_poloidal(
 
     Returns
     -------
-    blocks
-        List of animatplot.blocks.Pcolormesh instances
+    animation or blocks
+        If animate==True, returns an animatplot.Animation object, otherwise
+        returns a list of animatplot.blocks.Pcolormesh instances.
     """
 
     if animate_over is None:
@@ -275,6 +276,8 @@ def animate_poloidal(
                 save_as = "{}_over_{}".format(da.name, animate_over)
             anim.save(save_as + ".gif", writer=PillowWriter(fps=fps))
 
+        return anim
+
     return blocks
 
 
@@ -362,6 +365,12 @@ def animate_pcolormesh(
     kwargs : dict, optional
         Additional keyword arguments are passed on to the animation function
         animatplot.blocks.Pcolormesh
+
+    Returns
+    -------
+    animation or block
+        If animate==True, returns an animatplot.Animation object, otherwise
+        returns an animatplot.blocks.Pcolormesh instance.
     """
 
     if animate_over is None:
@@ -479,6 +488,8 @@ def animate_pcolormesh(
                 save_as = "{}_over_{}".format(variable, animate_over)
             anim.save(save_as + ".gif", writer=PillowWriter(fps=fps))
 
+        return anim
+
     return pcolormesh_block
 
 
@@ -542,6 +553,12 @@ def animate_line(
     kwargs : dict, optional
         Additional keyword arguments are passed on to the plotting function
         animatplot.blocks.Line
+
+    Returns
+    -------
+    animation or block
+        If animate==True, returns an animatplot.Animation object, otherwise
+        returns an animatplot.blocks.Line instance.
     """
 
     if animate_over is None:
@@ -613,5 +630,7 @@ def animate_line(
             if save_as is True:
                 save_as = "{}_over_{}".format(variable, animate_over)
             anim.save(save_as + ".gif", writer=PillowWriter(fps=fps))
+
+        return anim
 
     return line_block

--- a/xbout/tests/test_animate.py
+++ b/xbout/tests/test_animate.py
@@ -71,6 +71,41 @@ class TestAnimate:
 
         plt.close()
 
+    @pytest.mark.parametrize(
+        "controls",
+        [
+            ("both", False),
+            ("timeline", False),
+            ("toggle", False),
+            ("", False),
+            (None, False),
+            ("foo", True),
+        ],
+    )
+    def test_animate2D_controls_arg(self, create_test_file, controls):
+        controls, expect_error = controls
+
+        save_dir, ds = create_test_file
+
+        if expect_error:
+            with pytest.raises(ValueError, match="Unrecognised value for controls"):
+                animation = ds["n"].isel(x=1).bout.animate2D(controls=controls)
+        else:
+            animation = ds["n"].isel(x=1).bout.animate2D(controls=controls)
+
+            assert len(animation.blocks) == 1
+            assert isinstance(animation.blocks[0], Pcolormesh)
+            if controls in ["both", "timeline"]:
+                assert hasattr(animation, "slider")
+            else:
+                assert not hasattr(animation, "slider")
+            if controls in ["both", "toggle"]:
+                assert hasattr(animation, "button")
+            else:
+                assert not hasattr(animation, "button")
+
+            plt.close()
+
     def test_animate1D(self, create_test_file):
 
         save_dir, ds = create_test_file
@@ -80,6 +115,41 @@ class TestAnimate:
         assert isinstance(animation.blocks[0], Line)
 
         plt.close()
+
+    @pytest.mark.parametrize(
+        "controls",
+        [
+            ("both", False),
+            ("timeline", False),
+            ("toggle", False),
+            ("", False),
+            (None, False),
+            ("foo", True),
+        ],
+    )
+    def test_animate1D_controls_arg(self, create_test_file, controls):
+        controls, expect_error = controls
+
+        save_dir, ds = create_test_file
+
+        if expect_error:
+            with pytest.raises(ValueError, match="Unrecognised value for controls"):
+                animation = ds["n"].isel(y=2, z=0).bout.animate1D(controls=controls)
+        else:
+            animation = ds["n"].isel(y=2, z=0).bout.animate1D(controls=controls)
+
+            assert len(animation.blocks) == 1
+            assert isinstance(animation.blocks[0], Line)
+            if controls in ["both", "timeline"]:
+                assert hasattr(animation, "slider")
+            else:
+                assert not hasattr(animation, "slider")
+            if controls in ["both", "toggle"]:
+                assert hasattr(animation, "button")
+            else:
+                assert not hasattr(animation, "button")
+
+            plt.close()
 
     def test_animate_list(self, create_test_file):
 
@@ -409,3 +479,44 @@ class TestAnimate:
         assert animation.blocks[2].ax.title.get_text() == "b"
 
         plt.close()
+
+    @pytest.mark.parametrize(
+        "controls",
+        [
+            ("both", False),
+            ("timeline", False),
+            ("toggle", False),
+            ("", False),
+            (None, False),
+            ("foo", True),
+        ],
+    )
+    def test_animate_list_controls_arg(self, create_test_file, controls):
+        controls, expect_error = controls
+
+        save_dir, ds = create_test_file
+
+        if expect_error:
+            with pytest.raises(ValueError, match="Unrecognised value for controls"):
+                animation = ds.isel(z=3).bout.animate_list(
+                    ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], controls=controls
+                )
+        else:
+            animation = ds.isel(z=3).bout.animate_list(
+                ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], controls=controls
+            )
+
+            assert len(animation.blocks) == 3
+            assert isinstance(animation.blocks[0], Pcolormesh)
+            assert isinstance(animation.blocks[1], Pcolormesh)
+            assert isinstance(animation.blocks[2], Line)
+            if controls in ["both", "timeline"]:
+                assert hasattr(animation, "slider")
+            else:
+                assert not hasattr(animation, "slider")
+            if controls in ["both", "toggle"]:
+                assert hasattr(animation, "button")
+            else:
+                assert not hasattr(animation, "button")
+
+            plt.close()

--- a/xbout/tests/test_animate.py
+++ b/xbout/tests/test_animate.py
@@ -42,26 +42,32 @@ class TestAnimate:
 
         animation = ds["n"].isel(x=1).bout.animate2D(save_as="%s/testyz" % save_dir)
 
-        assert isinstance(animation, Pcolormesh)
+        assert len(animation.blocks) == 1
+        block = animation.blocks[0]
+        assert isinstance(block, Pcolormesh)
 
-        assert animation.ax.get_xlabel() == "y"
-        assert animation.ax.get_ylabel() == "z"
+        assert block.ax.get_xlabel() == "y"
+        assert block.ax.get_ylabel() == "z"
 
         plt.close()
 
         animation = ds["n"].isel(y=2).bout.animate2D(save_as="%s/testxz" % save_dir)
 
-        assert isinstance(animation, Pcolormesh)
-        assert animation.ax.get_xlabel() == "x"
-        assert animation.ax.get_ylabel() == "z"
+        assert len(animation.blocks) == 1
+        block = animation.blocks[0]
+        assert isinstance(block, Pcolormesh)
+        assert block.ax.get_xlabel() == "x"
+        assert block.ax.get_ylabel() == "z"
 
         plt.close()
 
         animation = ds["n"].isel(z=3).bout.animate2D(save_as="%s/testxy" % save_dir)
 
-        assert isinstance(animation, Pcolormesh)
-        assert animation.ax.get_xlabel() == "x"
-        assert animation.ax.get_ylabel() == "y"
+        assert len(animation.blocks) == 1
+        block = animation.blocks[0]
+        assert isinstance(block, Pcolormesh)
+        assert block.ax.get_xlabel() == "x"
+        assert block.ax.get_ylabel() == "y"
 
         plt.close()
 
@@ -70,7 +76,8 @@ class TestAnimate:
         save_dir, ds = create_test_file
         animation = ds["n"].isel(y=2, z=0).bout.animate1D(save_as="%s/test" % save_dir)
 
-        assert isinstance(animation, Line)
+        assert len(animation.blocks) == 1
+        assert isinstance(animation.blocks[0], Line)
 
         plt.close()
 
@@ -82,6 +89,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)]
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -96,6 +104,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)]
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Line)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -110,6 +119,7 @@ class TestAnimate:
             [["n", "T"], ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)]
         )
 
+        assert len(animation.blocks) == 4
         assert isinstance(animation.blocks[0], Line)
         assert isinstance(animation.blocks[1], Line)
         assert isinstance(animation.blocks[2], Pcolormesh)
@@ -137,6 +147,7 @@ class TestAnimate:
             ["n", ds["T"].isel(t=2), ds["n"].isel(y=1, z=2)], animate_over="x"
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -152,6 +163,7 @@ class TestAnimate:
             save_as="%s/test" % save_dir,
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -166,6 +178,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], fps=42
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -181,6 +194,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], nrows=2
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -195,6 +209,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], ncols=3
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -247,6 +262,7 @@ class TestAnimate:
             poloidal_plot=True,
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -263,6 +279,7 @@ class TestAnimate:
                 subplots_adjust={"hspace": 4, "wspace": 5},
             )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -277,6 +294,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], vmin=-0.1
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -291,6 +309,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], vmin=[0.0, 0.1, 0.2]
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -305,6 +324,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], vmax=1.1
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -319,6 +339,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], vmax=[1.0, 1.1, 1.2]
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -333,6 +354,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], logscale=True
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -347,6 +369,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], logscale=1.0e-2
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -362,6 +385,7 @@ class TestAnimate:
             logscale=[True, 1.0e-2, False],
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert isinstance(animation.blocks[1], Pcolormesh)
         assert isinstance(animation.blocks[2], Line)
@@ -376,6 +400,7 @@ class TestAnimate:
             ["n", ds["T"].isel(x=2), ds["n"].isel(y=1, z=2)], titles=["a", None, "b"]
         )
 
+        assert len(animation.blocks) == 3
         assert isinstance(animation.blocks[0], Pcolormesh)
         assert animation.blocks[0].ax.title.get_text() == "a"
         assert isinstance(animation.blocks[1], Pcolormesh)


### PR DESCRIPTION
Previously could only turn all controls on or off. Now can select from `"both"`, `"timeline"`, `"toggle"` or `None`.