### PR TITLE
Fix integration of Field2D variables

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -457,7 +457,7 @@ class BoutDatasetAccessor:
             if cumulative_t:
                 integral = integral.cumulative_integrate(coord=tcoord)
             else:
-                integral = integral.integrate(dim=tcoord)
+                integral = integral.integrate(coord=tcoord)
 
         return integral
 

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -437,19 +437,21 @@ class BoutDatasetAccessor:
 
         spatial_dims = set(dims) - set([tcoord])
 
+        integrand = variable * spatial_volume_element
+
         # Need to check if the variable being integrated is a Field2D, which does not
         # have a z-dimension to sum over. Other variables are OK because metric
         # coefficients, dx and dy all have both x- and y-dimensions so variable would be
         # broadcast to include them if necessary
         missing_z_sum = zcoord in dims and zcoord not in variable.dims
 
-        integrand = variable * spatial_volume_element
-
-        integral = integrand.sum(dim=spatial_dims)
-
         # If integrand is a Field2D, need to multiply by nz if integrating over z
         if missing_z_sum:
+            spatial_dims -= set(zcoord)
+            integral = integrand.sum(dim=spatial_dims)
             integral = integral * ds.sizes[zcoord]
+        else:
+            integral = integrand.sum(dim=spatial_dims)
 
         if tcoord in dims:
             if cumulative_t:

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -1304,6 +1304,89 @@ class TestBoutDatasetMethods:
             rtol=1.4e-4,
         )
 
+        # Create and test Field2D
+        ds["S"][...] = (tfunc * xfunc * yfunc).squeeze()
+
+        # S is 'axisymmetric' so z-integral is just the length of the
+        # z-dimension
+        zintegral = 36.0
+
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims="t"),
+            (tintegral * xfunc * yfunc).squeeze(),
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims="x"),
+            (tfunc * xintegral * yfunc).squeeze(),
+            rtol=1.0e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims="y"),
+            (tfunc * xfunc * yintegral).squeeze(),
+            rtol=1.0e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims="z"),
+            (tfunc * xfunc * yfunc * zintegral).squeeze(),
+            rtol=1.0e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims=["t", "x"]),
+            (tintegral * xintegral * yfunc).squeeze(),
+            rtol=1.0e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims=["t", "y"]),
+            (tintegral * xfunc * yintegral).squeeze(),
+            rtol=1.0e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims=["t", "z"]),
+            (tintegral * xfunc * yfunc * zintegral).squeeze(),
+            rtol=1.0e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims=["x", "y"]),
+            (tfunc * xintegral * yintegral).squeeze(),
+            rtol=1.0e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims=["x", "z"]),
+            (tfunc * xintegral * yfunc * zintegral).squeeze(),
+            rtol=1.0e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims=["y", "z"]),
+            (tfunc * xfunc * yintegral * zintegral).squeeze(),
+            rtol=1.2e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims=["t", "x", "y"]),
+            (tintegral * xintegral * yintegral),
+            rtol=1.0e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims=["t", "x", "z"]),
+            (tintegral * xintegral * yfunc * zintegral).squeeze(),
+            rtol=1.0e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims=["t", "y", "z"]),
+            (tintegral * xfunc * yintegral * zintegral).squeeze(),
+            rtol=1.2e-4,
+        )
+        # default dims
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S"),
+            (tfunc * xintegral * yintegral * zintegral).squeeze(),
+            rtol=1.4e-4,
+        )
+        npt.assert_allclose(
+            ds.bout.integrate_midpoints("S", dims=["t", "x", "y", "z"]),
+            (tintegral * xintegral * yintegral * zintegral),
+            rtol=1.4e-4,
+        )
+
     @pytest.mark.parametrize(
         "location", ["CELL_CENTRE", "CELL_XLOW", "CELL_YLOW", "CELL_ZLOW"]
     )

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -1138,6 +1138,7 @@ class TestBoutDatasetMethods:
             (
                 "n",
                 "T",
+                "S",
                 "g11",
                 "g22",
                 "g33",

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -464,10 +464,16 @@ def create_bout_ds(
 
     T = DataArray(data, dims=["t", "x", "y", "z"])
     n = DataArray(data, dims=["t", "x", "y", "z"])
+    S = DataArray(data[:, :, :, 0], dims=["t", "x", "y"])
     for v in [n, T]:
         v.attrs["direction_y"] = "Standard"
         v.attrs["cell_location"] = "CELL_CENTRE"
-    ds = Dataset({"n": n, "T": T})
+        v.attrs["direction_z"] = "Standard"
+    for v in [S]:
+        v.attrs["direction_y"] = "Standard"
+        v.attrs["cell_location"] = "CELL_CENTRE"
+        v.attrs["direction_z"] = "Average"
+    ds = Dataset({"n": n, "T": T, "S": S})
 
     # BOUT_VERSION needed so that we know that number of points in z is MZ, not MZ-1 (as
     # it was in BOUT++ before v4.0


### PR DESCRIPTION
Previously `BoutDataset.integrate_midpoints()` failed for `Field2D` variables.