### PR TITLE
Cache input data for tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     xarray>=0.18.0
     boutdata>=0.1.4
     dask[array]>=2.10.0
-    frozendict>=2.0.6
+    gelidum>=0.5.3
     natsort>=5.5.0
     matplotlib>=3.1.1,!=3.3.0,!=3.3.1,!=3.3.2
     animatplot>=0.4.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     xarray>=0.18.0
     boutdata>=0.1.4
     dask[array]>=2.10.0
+    frozendict>=2.0.6
     natsort>=5.5.0
     matplotlib>=3.1.1,!=3.3.0,!=3.3.1,!=3.3.2
     animatplot>=0.4.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     netcdf4>=1.4.0
     Pillow>=6.1.0
     importlib-metadata; python_version < "3.8"
-tests_require = pytest >= 3.9.0
 include_package_data = True
 packages = find:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     netcdf4>=1.4.0
     Pillow>=6.1.0
     importlib-metadata; python_version < "3.8"
-tests_require = pytest >= 3.3.0
+tests_require = pytest >= 3.9.0
 include_package_data = True
 packages = find:
 

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -138,6 +138,10 @@ def open_boutdataset(
 
     if "reload" in input_type:
         if input_type == "reload":
+            if isinstance(datapath, Path):
+                # xr.open_mfdataset only accepts glob patterns as strings, not Path
+                # objects
+                datapath = str(datapath)
             ds = xr.open_mfdataset(
                 datapath,
                 chunks=chunks,

--- a/xbout/tests/test_against_collect.py
+++ b/xbout/tests/test_against_collect.py
@@ -10,21 +10,21 @@ old_collect = boutdata.collect
 
 
 class TestAccuracyAgainstOldCollect:
-    def test_single_file(self, tmpdir_factory):
+    def test_single_file(self, tmp_path_factory):
 
         # Create temp directory for files
-        test_dir = tmpdir_factory.mktemp("test_data")
+        test_dir = tmp_path_factory.mktemp("test_data")
 
         # Generate some test data
         generated_ds = create_bout_ds(syn_data_type="linear")
-        generated_ds.to_netcdf(str(test_dir.join("BOUT.dmp.0.nc")))
+        generated_ds.to_netcdf(test_dir.joinpath("BOUT.dmp.0.nc"))
 
         var = "n"
         expected = old_collect(var, path=test_dir, xguards=True, yguards=False)
 
         # Test against new standard - open_boutdataset
         with pytest.warns(UserWarning):
-            ds = open_boutdataset(test_dir.join("BOUT.dmp.0.nc"))
+            ds = open_boutdataset(test_dir.joinpath("BOUT.dmp.0.nc"))
         actual = ds[var].values
 
         assert expected.shape == actual.shape
@@ -36,24 +36,24 @@ class TestAccuracyAgainstOldCollect:
         assert expected.shape == actual.shape
         npt.assert_equal(actual, expected)
 
-    def test_multiple_files_along_x(self, tmpdir_factory):
+    def test_multiple_files_along_x(self, tmp_path_factory):
 
         # Create temp directory for files
-        test_dir = tmpdir_factory.mktemp("test_data")
+        test_dir = tmp_path_factory.mktemp("test_data")
 
         # Generate some test data
         ds_list, file_list = create_bout_ds_list(
             "BOUT.dmp", nxpe=3, nype=1, syn_data_type="linear"
         )
         for temp_ds, file_name in zip(ds_list, file_list):
-            temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
+            temp_ds.to_netcdf(test_dir.joinpath(file_name))
 
         var = "n"
         expected = old_collect(var, path=test_dir, prefix="BOUT.dmp", xguards=True)
 
         # Test against new standard - open_boutdataset
         with pytest.warns(UserWarning):
-            ds = open_boutdataset(test_dir.join("BOUT.dmp.*.nc"))
+            ds = open_boutdataset(test_dir.joinpath("BOUT.dmp.*.nc"))
         actual = ds[var].values
 
         assert expected.shape == actual.shape
@@ -65,24 +65,24 @@ class TestAccuracyAgainstOldCollect:
         assert expected.shape == actual.shape
         npt.assert_equal(actual, expected)
 
-    def test_multiple_files_along_y(self, tmpdir_factory):
+    def test_multiple_files_along_y(self, tmp_path_factory):
 
         # Create temp directory for files
-        test_dir = tmpdir_factory.mktemp("test_data")
+        test_dir = tmp_path_factory.mktemp("test_data")
 
         # Generate some test data
         ds_list, file_list = create_bout_ds_list(
             "BOUT.dmp", nxpe=1, nype=3, syn_data_type="linear"
         )
         for temp_ds, file_name in zip(ds_list, file_list):
-            temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
+            temp_ds.to_netcdf(test_dir.joinpath(file_name))
 
         var = "n"
         expected = old_collect(var, path=test_dir, prefix="BOUT.dmp", xguards=True)
 
         # Test against new standard - .open_boutdataset
         with pytest.warns(UserWarning):
-            ds = open_boutdataset(test_dir.join("BOUT.dmp.*.nc"))
+            ds = open_boutdataset(test_dir.joinpath("BOUT.dmp.*.nc"))
         actual = ds[var].values
 
         assert expected.shape == actual.shape
@@ -94,24 +94,24 @@ class TestAccuracyAgainstOldCollect:
         assert expected.shape == actual.shape
         npt.assert_equal(actual, expected)
 
-    def test_multiple_files_along_xy(self, tmpdir_factory):
+    def test_multiple_files_along_xy(self, tmp_path_factory):
 
         # Create temp directory for files
-        test_dir = tmpdir_factory.mktemp("test_data")
+        test_dir = tmp_path_factory.mktemp("test_data")
 
         # Generate some test data
         ds_list, file_list = create_bout_ds_list(
             "BOUT.dmp", nxpe=3, nype=3, syn_data_type="linear"
         )
         for temp_ds, file_name in zip(ds_list, file_list):
-            temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
+            temp_ds.to_netcdf(test_dir.joinpath(file_name))
 
         var = "n"
         expected = old_collect(var, path=test_dir, prefix="BOUT.dmp", xguards=True)
 
         # Test against new standard - .open_boutdataset
         with pytest.warns(UserWarning):
-            ds = open_boutdataset(test_dir.join("BOUT.dmp.*.nc"))
+            ds = open_boutdataset(test_dir.joinpath("BOUT.dmp.*.nc"))
         actual = ds[var].values
 
         assert expected.shape == actual.shape
@@ -123,16 +123,16 @@ class TestAccuracyAgainstOldCollect:
         assert expected.shape == actual.shape
         npt.assert_equal(actual, expected)
 
-    def test_metadata(self, tmpdir_factory):
+    def test_metadata(self, tmp_path_factory):
         # Create temp directory for files
-        test_dir = tmpdir_factory.mktemp("test_data")
+        test_dir = tmp_path_factory.mktemp("test_data")
 
         # Generate some test data
         generated_ds = create_bout_ds(syn_data_type="linear")
-        generated_ds.to_netcdf(str(test_dir.join("BOUT.dmp.0.nc")))
+        generated_ds.to_netcdf(test_dir.joinpath("BOUT.dmp.0.nc"))
 
         with pytest.warns(UserWarning):
-            ds = open_boutdataset(test_dir.join("BOUT.dmp.*.nc"))
+            ds = open_boutdataset(test_dir.joinpath("BOUT.dmp.*.nc"))
 
         for v in METADATA_VARS:
             expected = old_collect(v, path=test_dir)
@@ -144,9 +144,9 @@ class TestAccuracyAgainstOldCollect:
             actual = new_collect(v, path=test_dir)
             npt.assert_equal(actual, expected)
 
-    def test_new_collect_indexing_int(self, tmpdir_factory):
+    def test_new_collect_indexing_int(self, tmp_path_factory):
         # Create temp directory for files
-        test_dir = tmpdir_factory.mktemp("test_data")
+        test_dir = tmp_path_factory.mktemp("test_data")
 
         # Generate some test data
         ds_list, file_list = create_bout_ds_list(
@@ -154,7 +154,7 @@ class TestAccuracyAgainstOldCollect:
         )
 
         for temp_ds, file_name in zip(ds_list, file_list):
-            temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
+            temp_ds.to_netcdf(test_dir.joinpath(file_name))
 
         var = "n"
         indexers = ["tind", "xind", "yind", "zind"]
@@ -170,16 +170,16 @@ class TestAccuracyAgainstOldCollect:
             assert expected.shape == actual.shape
             npt.assert_equal(actual, expected)
 
-    def test_new_collect_indexing_list(self, tmpdir_factory):
+    def test_new_collect_indexing_list(self, tmp_path_factory):
         # Create temp directory for files
-        test_dir = tmpdir_factory.mktemp("test_data")
+        test_dir = tmp_path_factory.mktemp("test_data")
 
         # Generate some test data
         ds_list, file_list = create_bout_ds_list(
             "BOUT.dmp", nxpe=3, nype=3, syn_data_type="linear"
         )
         for temp_ds, file_name in zip(ds_list, file_list):
-            temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
+            temp_ds.to_netcdf(test_dir.joinpath(file_name))
 
         var = "n"
         indexers = ["tind", "xind", "yind", "zind"]
@@ -195,9 +195,9 @@ class TestAccuracyAgainstOldCollect:
             assert expected.shape == actual.shape
             npt.assert_equal(actual, expected)
 
-    def test_new_collect_indexing_slice(self, tmpdir_factory):
+    def test_new_collect_indexing_slice(self, tmp_path_factory):
         # Create temp directory for files
-        test_dir = tmpdir_factory.mktemp("test_data")
+        test_dir = tmp_path_factory.mktemp("test_data")
 
         # Generate some test data
         ds_list, file_list = create_bout_ds_list(
@@ -205,7 +205,7 @@ class TestAccuracyAgainstOldCollect:
         )
 
         for temp_ds, file_name in zip(ds_list, file_list):
-            temp_ds.to_netcdf(str(test_dir.join(str(file_name))))
+            temp_ds.to_netcdf(test_dir.joinpath(file_name))
 
         var = "n"
         indexers = ["tind", "xind", "yind", "zind"]

--- a/xbout/tests/test_animate.py
+++ b/xbout/tests/test_animate.py
@@ -12,20 +12,20 @@ from animatplot.blocks import Pcolormesh, Line
 
 
 @pytest.fixture
-def create_test_file(tmpdir_factory):
+def create_test_file(tmp_path_factory):
 
     # Create temp dir for output of animate1D/2D
-    save_dir = tmpdir_factory.mktemp("test_data")
+    save_dir = tmp_path_factory.mktemp("test_data")
 
     # Generate some test data
     ds_list, file_list = create_bout_ds_list(
         "BOUT.dmp", nxpe=3, nype=3, syn_data_type="linear"
     )
     for ds, file_name in zip(ds_list, file_list):
-        ds.to_netcdf(str(save_dir.join(str(file_name))))
+        ds.to_netcdf(save_dir.joinpath(file_name))
 
     with pytest.warns(UserWarning):
-        ds = open_boutdataset(save_dir.join("BOUT.dmp.*.nc"))  # Open test data
+        ds = open_boutdataset(save_dir.joinpath("BOUT.dmp.*.nc"))  # Open test data
 
     return save_dir, ds
 

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -56,23 +56,6 @@ class TestBoutDatasetIsXarrayDataset:
 
 
 class TestBoutDatasetMethods:
-    @pytest.mark.skip
-    def test_test_method(self, bout_xyt_example_files):
-        dataset_list = bout_xyt_example_files(None, nxpe=1, nype=1, nt=1)
-        ds = open_boutdataset(datapath=dataset_list, inputfilepath=None)
-        # ds = collect(path=path)
-        # bd = BoutAccessor(ds)
-        print(ds)
-        # ds.bout.test_method()
-        # print(ds.bout.options)
-        # print(ds.bout.metadata)
-        print(ds.isel(t=-1))
-
-        # ds.bout.set_extra_data('stored')
-        ds.bout.extra_data = "stored"
-
-        print(ds.bout.extra_data)
-
     def test_get_field_aligned(self, bout_xyt_example_files):
         dataset_list = bout_xyt_example_files(None, nxpe=3, nype=4, nt=1)
         with pytest.warns(UserWarning):

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -1789,7 +1789,8 @@ class TestSave:
             original = open_boutdataset(datapath=path, inputfilepath=None)
 
         # Save it to a netCDF file
-        savepath = path.parent.joinpath("temp_boutdata.nc")
+        savedir = tmp_path_factory.mktemp("test_save_all")
+        savepath = savedir.joinpath("temp_boutdata.nc")
         original.bout.save(savepath=savepath)
 
         # Load it again using bare xarray
@@ -1825,7 +1826,8 @@ class TestSave:
             )
 
         # Save it to a netCDF file
-        savepath = path.parent.joinpath("temp_boutdata.nc")
+        savedir = tmp_path_factory.mktemp("test_reload_all")
+        savepath = savedir.joinpath("temp_boutdata.nc")
         original.bout.save(savepath=savepath)
 
         # Load it again
@@ -1870,7 +1872,8 @@ class TestSave:
             original = open_boutdataset(datapath=path, inputfilepath=None)
 
         # Save it to a netCDF file
-        savepath = path.parent.joinpath("temp_boutdata.nc")
+        savedir = tmp_path_factory.mktemp("test_save_dtype")
+        savepath = savedir.joinpath("temp_boutdata.nc")
         original.bout.save(
             savepath=savepath, save_dtype=save_dtype, separate_vars=separate_vars
         )
@@ -1878,7 +1881,7 @@ class TestSave:
         # Load it again using bare xarray
         if separate_vars:
             for v in ["n", "T"]:
-                savepath = path.parent.joinpath(f"temp_boutdata_{v}.nc")
+                savepath = savedir.joinpath(f"temp_boutdata_{v}.nc")
                 recovered = open_dataset(savepath)
                 assert recovered[v].values.dtype == np.dtype(save_dtype)
         else:
@@ -1897,19 +1900,20 @@ class TestSave:
             original = open_boutdataset(datapath=path, inputfilepath=None)
 
         # Save it to a netCDF file
-        savepath = path.parent.joinpath("temp_boutdata.nc")
+        savedir = tmp_path_factory.mktemp("test_save_separate_variables")
+        savepath = savedir.joinpath("temp_boutdata.nc")
         original.bout.save(savepath=savepath, separate_vars=True)
 
         for var in ["n", "T"]:
             # Load it again using bare xarray
-            savepath = path.parent.joinpath("temp_boutdata_" + var + ".nc")
+            savepath = savedir.joinpath(f"temp_boutdata_{var}.nc")
             recovered = open_dataset(savepath)
 
             # Compare equal (not identical because attributes are changed when saving)
             xrt.assert_equal(recovered[var], original[var])
 
         # test open_boutdataset() on dataset saved with separate_vars=True
-        savepath = path.parent.joinpath("temp_boutdata_*.nc")
+        savepath = savedir.joinpath("temp_boutdata_*.nc")
         recovered = open_boutdataset(savepath)
         xrt.assert_identical(original, recovered)
 
@@ -1949,11 +1953,12 @@ class TestSave:
             )
 
         # Save it to a netCDF file
-        savepath = path.parent.joinpath("temp_boutdata.nc")
+        savedir = tmp_path_factory.mktemp("test_reload_separate_variables")
+        savepath = savedir.joinpath("temp_boutdata.nc")
         original.bout.save(savepath=savepath, separate_vars=True)
 
         # Load it again
-        savepath = path.parent.joinpath("temp_boutdata_*.nc")
+        savepath = savedir.joinpath("temp_boutdata_*.nc")
         recovered = open_boutdataset(savepath)
 
         # Compare
@@ -1996,17 +2001,18 @@ class TestSave:
 
         # Save it to a netCDF file
         tcoord = original.metadata.get("bout_tdim", "t")
-        savepath = path.parent.joinpath("temp_boutdata_1.nc")
+        savedir = tmp_path_factory.mktemp("test_reload_separate_variables_time_split")
+        savepath = savedir.joinpath("temp_boutdata_1.nc")
         original.isel({tcoord: slice(3)}).bout.save(
             savepath=savepath, separate_vars=True
         )
-        savepath = path.parent.joinpath("temp_boutdata_2.nc")
+        savepath = savedir.joinpath("temp_boutdata_2.nc")
         original.isel({tcoord: slice(3, None)}).bout.save(
             savepath=savepath, separate_vars=True
         )
 
         # Load it again
-        savepath = path.parent.joinpath("temp_boutdata_*.nc")
+        savepath = savedir.joinpath("temp_boutdata_*.nc")
         recovered = open_boutdataset(savepath)
 
         # Compare
@@ -2037,7 +2043,7 @@ class TestSaveRestart:
         ny = ds.metadata["ny"]
 
         # Save it to a netCDF file
-        savepath = path.parent
+        savepath = tmp_path_factory.mktemp("test_to_restart")
         if tind is None:
             ds.bout.to_restart(savepath=savepath, nxpe=nxpe, nype=nype)
         else:
@@ -2107,7 +2113,7 @@ class TestSaveRestart:
         ny = ds.metadata["ny"]
 
         # Save it to a netCDF file
-        savepath = path.parent
+        savepath = tmp_path_factory.mktemp("test_to_restart_change_npe")
         ds.bout.to_restart(savepath=savepath, nxpe=nxpe, nype=nype)
 
         mxsub = (nx - 4) // nxpe
@@ -2175,7 +2181,7 @@ class TestSaveRestart:
         ny = ds.metadata["ny"]
 
         # Save it to a netCDF file
-        savepath = path.parent
+        savepath = tmp_path_factory.mktemp("test_to_restart_change_npe_doublenull")
         ds.bout.to_restart(savepath=savepath, nxpe=nxpe, nype=nype)
 
         mxsub = (nx - 4) // nxpe
@@ -2243,6 +2249,8 @@ class TestSaveRestart:
         ny = ds.metadata["ny"]
 
         # Save it to a netCDF file
-        savepath = path.parent
+        savepath = tmp_path_factory.mktemp(
+            "test_to_restart_change_npe_doublenull_expect_fail"
+        )
         with pytest.raises(ValueError):
             ds.bout.to_restart(savepath=savepath, nxpe=nxpe, nype=nype)

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -6,7 +6,6 @@ import xarray.testing as xrt
 
 import dask.array
 import numpy as np
-from pathlib import Path
 from scipy.integrate import quad_vec
 
 from xbout.tests.test_load import bout_xyt_example_files, create_bout_ds
@@ -1796,10 +1795,10 @@ class TestLoadLogFile:
 
 
 class TestSave:
-    def test_save_all(self, tmpdir_factory, bout_xyt_example_files):
+    def test_save_all(self, tmp_path_factory, bout_xyt_example_files):
         # Create data
         path = bout_xyt_example_files(
-            tmpdir_factory, nxpe=4, nype=5, nt=1, write_to_disk=True
+            tmp_path_factory, nxpe=4, nype=5, nt=1, write_to_disk=True
         )
 
         # Load it as a boutdataset
@@ -1807,7 +1806,7 @@ class TestSave:
             original = open_boutdataset(datapath=path, inputfilepath=None)
 
         # Save it to a netCDF file
-        savepath = str(Path(path).parent) + "temp_boutdata.nc"
+        savepath = path.parent.joinpath("temp_boutdata.nc")
         original.bout.save(savepath=savepath)
 
         # Load it again using bare xarray
@@ -1817,13 +1816,13 @@ class TestSave:
         xrt.assert_equal(original, recovered)
 
     @pytest.mark.parametrize("geometry", [None, "toroidal"])
-    def test_reload_all(self, tmpdir_factory, bout_xyt_example_files, geometry):
+    def test_reload_all(self, tmp_path_factory, bout_xyt_example_files, geometry):
         # Create data
         path = bout_xyt_example_files(
-            tmpdir_factory, nxpe=4, nype=5, nt=1, grid="grid", write_to_disk=True
+            tmp_path_factory, nxpe=4, nype=5, nt=1, grid="grid", write_to_disk=True
         )
 
-        gridpath = str(Path(path).parent) + "/grid.nc"
+        gridpath = path.parent.joinpath("grid.nc")
 
         # Load it as a boutdataset
         if geometry is None:
@@ -1843,7 +1842,7 @@ class TestSave:
             )
 
         # Save it to a netCDF file
-        savepath = str(Path(path).parent) + "/temp_boutdata.nc"
+        savepath = path.parent.joinpath("temp_boutdata.nc")
         original.bout.save(savepath=savepath)
 
         # Load it again
@@ -1875,12 +1874,12 @@ class TestSave:
         "separate_vars", [False, pytest.param(True, marks=pytest.mark.long)]
     )
     def test_save_dtype(
-        self, tmpdir_factory, bout_xyt_example_files, save_dtype, separate_vars
+        self, tmp_path_factory, bout_xyt_example_files, save_dtype, separate_vars
     ):
 
         # Create data
         path = bout_xyt_example_files(
-            tmpdir_factory, nxpe=1, nype=1, nt=1, write_to_disk=True
+            tmp_path_factory, nxpe=1, nype=1, nt=1, write_to_disk=True
         )
 
         # Load it as a boutdataset
@@ -1888,7 +1887,7 @@ class TestSave:
             original = open_boutdataset(datapath=path, inputfilepath=None)
 
         # Save it to a netCDF file
-        savepath = str(Path(path).parent) + "/temp_boutdata.nc"
+        savepath = path.parent.joinpath("temp_boutdata.nc")
         original.bout.save(
             savepath=savepath, save_dtype=save_dtype, separate_vars=separate_vars
         )
@@ -1896,7 +1895,7 @@ class TestSave:
         # Load it again using bare xarray
         if separate_vars:
             for v in ["n", "T"]:
-                savepath = str(Path(path).parent) + f"/temp_boutdata_{v}.nc"
+                savepath = path.parent.joinpath(f"temp_boutdata_{v}.nc")
                 recovered = open_dataset(savepath)
                 assert recovered[v].values.dtype == np.dtype(save_dtype)
         else:
@@ -1905,9 +1904,9 @@ class TestSave:
             for v in original:
                 assert recovered[v].values.dtype == np.dtype(save_dtype)
 
-    def test_save_separate_variables(self, tmpdir_factory, bout_xyt_example_files):
+    def test_save_separate_variables(self, tmp_path_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(
-            tmpdir_factory, nxpe=4, nype=1, nt=1, write_to_disk=True
+            tmp_path_factory, nxpe=4, nype=1, nt=1, write_to_disk=True
         )
 
         # Load it as a boutdataset
@@ -1915,25 +1914,25 @@ class TestSave:
             original = open_boutdataset(datapath=path, inputfilepath=None)
 
         # Save it to a netCDF file
-        savepath = str(Path(path).parent) + "/temp_boutdata.nc"
+        savepath = path.parent.joinpath("temp_boutdata.nc")
         original.bout.save(savepath=savepath, separate_vars=True)
 
         for var in ["n", "T"]:
             # Load it again using bare xarray
-            savepath = str(Path(path).parent) + "/temp_boutdata_" + var + ".nc"
+            savepath = path.parent.joinpath("temp_boutdata_" + var + ".nc")
             recovered = open_dataset(savepath)
 
             # Compare equal (not identical because attributes are changed when saving)
             xrt.assert_equal(recovered[var], original[var])
 
         # test open_boutdataset() on dataset saved with separate_vars=True
-        savepath = str(Path(path).parent) + "/temp_boutdata_*.nc"
+        savepath = path.parent.joinpath("temp_boutdata_*.nc")
         recovered = open_boutdataset(savepath)
         xrt.assert_identical(original, recovered)
 
     @pytest.mark.parametrize("geometry", [None, "toroidal"])
     def test_reload_separate_variables(
-        self, tmpdir_factory, bout_xyt_example_files, geometry
+        self, tmp_path_factory, bout_xyt_example_files, geometry
     ):
         if geometry is not None:
             grid = "grid"
@@ -1941,11 +1940,11 @@ class TestSave:
             grid = None
 
         path = bout_xyt_example_files(
-            tmpdir_factory, nxpe=4, nype=1, nt=1, grid=grid, write_to_disk=True
+            tmp_path_factory, nxpe=4, nype=1, nt=1, grid=grid, write_to_disk=True
         )
 
         if grid is not None:
-            gridpath = str(Path(path).parent) + "/grid.nc"
+            gridpath = path.parent.joinpath("grid.nc")
         else:
             gridpath = None
 
@@ -1967,11 +1966,11 @@ class TestSave:
             )
 
         # Save it to a netCDF file
-        savepath = str(Path(path).parent) + "/temp_boutdata.nc"
+        savepath = path.parent.joinpath("temp_boutdata.nc")
         original.bout.save(savepath=savepath, separate_vars=True)
 
         # Load it again
-        savepath = str(Path(path).parent) + "/temp_boutdata_*.nc"
+        savepath = path.parent.joinpath("temp_boutdata_*.nc")
         recovered = open_boutdataset(savepath)
 
         # Compare
@@ -1979,7 +1978,7 @@ class TestSave:
 
     @pytest.mark.parametrize("geometry", [None, "toroidal"])
     def test_reload_separate_variables_time_split(
-        self, tmpdir_factory, bout_xyt_example_files, geometry
+        self, tmp_path_factory, bout_xyt_example_files, geometry
     ):
         if geometry is not None:
             grid = "grid"
@@ -1987,11 +1986,11 @@ class TestSave:
             grid = None
 
         path = bout_xyt_example_files(
-            tmpdir_factory, nxpe=4, nype=1, nt=1, grid=grid, write_to_disk=True
+            tmp_path_factory, nxpe=4, nype=1, nt=1, grid=grid, write_to_disk=True
         )
 
         if grid is not None:
-            gridpath = str(Path(path).parent) + "/grid.nc"
+            gridpath = path.parent.joinpath("grid.nc")
         else:
             gridpath = None
 
@@ -2014,17 +2013,17 @@ class TestSave:
 
         # Save it to a netCDF file
         tcoord = original.metadata.get("bout_tdim", "t")
-        savepath = str(Path(path).parent) + "/temp_boutdata_1.nc"
+        savepath = path.parent.joinpath("temp_boutdata_1.nc")
         original.isel({tcoord: slice(3)}).bout.save(
             savepath=savepath, separate_vars=True
         )
-        savepath = str(Path(path).parent) + "/temp_boutdata_2.nc"
+        savepath = path.parent.joinpath("temp_boutdata_2.nc")
         original.isel({tcoord: slice(3, None)}).bout.save(
             savepath=savepath, separate_vars=True
         )
 
         # Load it again
-        savepath = str(Path(path).parent) + "/temp_boutdata_*.nc"
+        savepath = path.parent.joinpath("temp_boutdata_*.nc")
         recovered = open_boutdataset(savepath)
 
         # Compare
@@ -2033,12 +2032,12 @@ class TestSave:
 
 class TestSaveRestart:
     @pytest.mark.parametrize("tind", [None, pytest.param(1, marks=pytest.mark.long)])
-    def test_to_restart(self, tmpdir_factory, bout_xyt_example_files, tind):
+    def test_to_restart(self, tmp_path_factory, bout_xyt_example_files, tind):
         nxpe = 3
         nype = 2
 
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=nxpe,
             nype=nype,
             nt=1,
@@ -2055,7 +2054,7 @@ class TestSaveRestart:
         ny = ds.metadata["ny"]
 
         # Save it to a netCDF file
-        savepath = Path(path).parent
+        savepath = path.parent
         if tind is None:
             ds.bout.to_restart(savepath=savepath, nxpe=nxpe, nype=nype)
         else:
@@ -2100,7 +2099,7 @@ class TestSaveRestart:
                         else:
                             assert restart_ds[v].values == check_ds.metadata[v]
 
-    def test_to_restart_change_npe(self, tmpdir_factory, bout_xyt_example_files):
+    def test_to_restart_change_npe(self, tmp_path_factory, bout_xyt_example_files):
         nxpe_in = 3
         nype_in = 2
 
@@ -2108,7 +2107,7 @@ class TestSaveRestart:
         nype = 4
 
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=nxpe_in,
             nype=nype_in,
             nt=1,
@@ -2125,7 +2124,7 @@ class TestSaveRestart:
         ny = ds.metadata["ny"]
 
         # Save it to a netCDF file
-        savepath = Path(path).parent
+        savepath = path.parent
         ds.bout.to_restart(savepath=savepath, nxpe=nxpe, nype=nype)
 
         mxsub = (nx - 4) // nxpe
@@ -2166,7 +2165,7 @@ class TestSaveRestart:
 
     @pytest.mark.long
     def test_to_restart_change_npe_doublenull(
-        self, tmpdir_factory, bout_xyt_example_files
+        self, tmp_path_factory, bout_xyt_example_files
     ):
         nxpe_in = 3
         nype_in = 6
@@ -2175,7 +2174,7 @@ class TestSaveRestart:
         nype = 12
 
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=nxpe_in,
             nype=nype_in,
             nt=1,
@@ -2193,7 +2192,7 @@ class TestSaveRestart:
         ny = ds.metadata["ny"]
 
         # Save it to a netCDF file
-        savepath = Path(path).parent
+        savepath = path.parent
         ds.bout.to_restart(savepath=savepath, nxpe=nxpe, nype=nype)
 
         mxsub = (nx - 4) // nxpe
@@ -2235,7 +2234,7 @@ class TestSaveRestart:
     @pytest.mark.long
     @pytest.mark.parametrize("npes", [(2, 6), (3, 4)])
     def test_to_restart_change_npe_doublenull_expect_fail(
-        self, tmpdir_factory, bout_xyt_example_files, npes
+        self, tmp_path_factory, bout_xyt_example_files, npes
     ):
         nxpe_in = 3
         nype_in = 6
@@ -2243,7 +2242,7 @@ class TestSaveRestart:
         nxpe, nype = npes
 
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=nxpe_in,
             nype=nype_in,
             nt=1,
@@ -2261,6 +2260,6 @@ class TestSaveRestart:
         ny = ds.metadata["ny"]
 
         # Save it to a netCDF file
-        savepath = Path(path).parent
+        savepath = path.parent
         with pytest.raises(ValueError):
             ds.bout.to_restart(savepath=savepath, nxpe=nxpe, nype=nype)

--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from xarray import Dataset, DataArray, open_dataset, merge
 from xarray.testing import assert_equal
 import pytest
@@ -10,7 +8,7 @@ from xbout.geometries import register_geometry, REGISTERED_GEOMETRIES
 
 
 @pytest.fixture
-def create_example_grid_file(tmpdir_factory):
+def create_example_grid_file(tmp_path_factory):
     """
     Mocks up a set of BOUT-like netCDF files, and return the temporary test
     directory containing them.
@@ -25,13 +23,13 @@ def create_example_grid_file(tmpdir_factory):
     grid = grid.set_coords(["dy"])
 
     # Create temporary directory
-    save_dir = tmpdir_factory.mktemp("griddata")
+    save_dir = tmp_path_factory.mktemp("griddata")
 
     # Save
-    filepath = str(save_dir.join("grid.nc"))
+    filepath = save_dir.joinpath("grid.nc")
     grid.to_netcdf(filepath, engine="netcdf4")
 
-    return Path(filepath)
+    return filepath
 
 
 class TestOpenGrid:
@@ -43,13 +41,13 @@ class TestOpenGrid:
         assert_equal(result, open_dataset(example_grid))
         result.close()
 
-    def test_open_grid_extra_dims(self, create_example_grid_file, tmpdir_factory):
+    def test_open_grid_extra_dims(self, create_example_grid_file, tmp_path_factory):
         example_grid = open_dataset(create_example_grid_file)
 
         new_var = DataArray(name="new", data=[[1, 2], [8, 9]], dims=["x", "w"])
 
-        dodgy_grid_directory = tmpdir_factory.mktemp("dodgy_grid")
-        dodgy_grid_path = str(dodgy_grid_directory.join("dodgy_grid.nc"))
+        dodgy_grid_directory = tmp_path_factory.mktemp("dodgy_grid")
+        dodgy_grid_path = dodgy_grid_directory.joinpath("dodgy_grid.nc")
         merge([example_grid, new_var]).to_netcdf(dodgy_grid_path, engine="netcdf4")
 
         with pytest.warns(

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -436,6 +436,9 @@ def create_bout_ds_list(
     return ds_list, file_list
 
 
+_create_bout_ds_cache = {}
+
+
 def create_bout_ds(
     syn_data_type="random",
     lengths=(6, 2, 4, 7),
@@ -450,6 +453,13 @@ def create_bout_ds(
     bout_v5=False,
     metric_3D=False,
 ):
+    call_args = _get_kwargs()
+
+    try:
+        # Has been called with the same signature before, just return the cached result
+        return deepcopy(_create_bout_ds_cache[call_args])
+    except KeyError:
+        pass
 
     if metric_3D and not bout_v5:
         raise ValueError("3D metric requires BOUT++ v5")
@@ -693,10 +703,21 @@ def create_bout_ds(
     # get the file number
     ds.encoding["source"] = f"BOUT.dmp.{num}.nc"
 
-    return ds
+    _create_bout_ds_cache[call_args] = ds
+    return deepcopy(ds)
+
+
+_create_bout_grid_ds_cache = {}
 
 
 def create_bout_grid_ds(xsize=2, ysize=4, guards={}, topology="core", ny_inner=0):
+    call_args = _get_kwargs()
+
+    try:
+        # Has been called with the same signature before, just return the cached result
+        return deepcopy(_create_bout_grid_ds_cache[call_args])
+    except KeyError:
+        pass
 
     # Set the shape of the data in this dataset
     mxg = guards.get("x", 0)
@@ -734,7 +755,8 @@ def create_bout_grid_ds(xsize=2, ysize=4, guards={}, topology="core", ny_inner=0
         }
     )
 
-    return ds
+    _create_bout_grid_ds_cache[call_args] = ds
+    return deepcopy(ds)
 
 
 # Note, MYPE, PE_XIND and PE_YIND not included, since they are different for each

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -25,55 +25,59 @@ from xbout.load import (
 from xbout.utils import _separate_metadata
 
 
-def test_check_extensions(tmpdir):
-    files_dir = tmpdir.mkdir("data")
-    example_nc_file = files_dir.join("example.nc")
-    example_nc_file.write("content_nc")
+def test_check_extensions(tmp_path):
+    files_dir = tmp_path.joinpath("data")
+    files_dir.mkdir()
+    example_nc_file = files_dir.joinpath("example.nc")
+    example_nc_file.write_text("content_nc")
 
-    filetype = _check_filetype(Path(str(example_nc_file)))
+    filetype = _check_filetype(example_nc_file)
     assert filetype == "netcdf4"
 
-    example_hdf5_file = files_dir.join("example.h5netcdf")
-    example_hdf5_file.write("content_hdf5")
+    example_hdf5_file = files_dir.joinpath("example.h5netcdf")
+    example_hdf5_file.write_text("content_hdf5")
 
-    filetype = _check_filetype(Path(str(example_hdf5_file)))
+    filetype = _check_filetype(example_hdf5_file)
     assert filetype == "h5netcdf"
 
-    example_invalid_file = files_dir.join("example.txt")
-    example_hdf5_file.write("content_txt")
+    example_invalid_file = files_dir.joinpath("example.txt")
+    example_hdf5_file.write_text("content_txt")
     with pytest.raises(IOError):
-        filetype = _check_filetype(Path(str(example_invalid_file)))
+        filetype = _check_filetype(example_invalid_file)
 
 
 class TestPathHandling:
-    def test_glob_expansion_single(self, tmpdir):
-        files_dir = tmpdir.mkdir("data")
-        example_file = files_dir.join("example.0.nc")
-        example_file.write("content")
+    def test_glob_expansion_single(self, tmp_path):
+        files_dir = tmp_path.joinpath("data")
+        files_dir.mkdir()
+        example_file = files_dir.joinpath("example.0.nc")
+        example_file.write_text("content")
 
-        path = Path(str(example_file))
+        path = example_file
         filepaths = _expand_wildcards(path)
-        assert filepaths[0] == Path(str(example_file))
+        assert filepaths[0] == example_file
 
-        path = Path(str(files_dir.join("example.*.nc")))
+        path = files_dir.joinpath("example.*.nc")
         filepaths = _expand_wildcards(path)
-        assert filepaths[0] == Path(str(example_file))
+        assert filepaths[0] == example_file
 
     @pytest.mark.parametrize(
         "ii, jj", [(1, 1), (1, 4), (3, 1), (5, 3), (12, 1), (1, 12), (121, 2), (3, 111)]
     )
-    def test_glob_expansion_both(self, tmpdir, ii, jj):
-        files_dir = tmpdir.mkdir("data")
+    def test_glob_expansion_both(self, tmp_path, ii, jj):
+        files_dir = tmp_path.joinpath("data")
+        files_dir.mkdir()
         filepaths = []
         for i in range(ii):
-            example_run_dir = files_dir.mkdir("run" + str(i))
+            example_run_dir = files_dir.joinpath("run" + str(i))
+            example_run_dir.mkdir()
             for j in range(jj):
-                example_file = example_run_dir.join("example." + str(j) + ".nc")
-                example_file.write("content")
-                filepaths.append(Path(str(example_file)))
+                example_file = example_run_dir.joinpath("example." + str(j) + ".nc")
+                example_file.write_text("content")
+                filepaths.append(example_file)
         expected_filepaths = natsorted(filepaths, key=lambda filepath: str(filepath))
 
-        path = Path(str(files_dir.join("run*/example.*.nc")))
+        path = files_dir.joinpath("run*/example.*.nc")
         actual_filepaths = _expand_wildcards(path)
 
         assert actual_filepaths == expected_filepaths
@@ -81,27 +85,30 @@ class TestPathHandling:
     @pytest.mark.parametrize(
         "ii, jj", [(1, 1), (1, 4), (3, 1), (5, 3), (1, 12), (3, 111)]
     )
-    def test_glob_expansion_brackets(self, tmpdir, ii, jj):
-        files_dir = tmpdir.mkdir("data")
+    def test_glob_expansion_brackets(self, tmp_path, ii, jj):
+        files_dir = tmp_path.joinpath("data")
+        files_dir.mkdir()
         filepaths = []
         for i in range(ii):
-            example_run_dir = files_dir.mkdir("run" + str(i))
+            example_run_dir = files_dir.joinpath("run" + str(i))
+            example_run_dir.mkdir()
             for j in range(jj):
-                example_file = example_run_dir.join("example." + str(j) + ".nc")
-                example_file.write("content")
-                filepaths.append(Path(str(example_file)))
+                example_file = example_run_dir.joinpath("example." + str(j) + ".nc")
+                example_file.write_text("content")
+                filepaths.append(example_file)
         expected_filepaths = natsorted(filepaths, key=lambda filepath: str(filepath))
 
-        path = Path(str(files_dir.join("run[1-9]/example.*.nc")))
+        path = files_dir.joinpath("run[1-9]/example.*.nc")
         actual_filepaths = _expand_wildcards(path)
 
         assert actual_filepaths == expected_filepaths[jj:]
 
-    def test_no_files(self, tmpdir):
-        files_dir = tmpdir.mkdir("data")
+    def test_no_files(self, tmp_path):
+        files_dir = tmp_path.joinpath("data")
+        files_dir.mkdir()
 
         with pytest.raises(IOError):
-            path = Path(str(files_dir.join("run*/example.*.nc")))
+            path = files_dir.joinpath("run*/example.*.nc")
             actual_filepaths = _expand_filepaths(path)
 
 
@@ -243,12 +250,12 @@ class TestArrange:
 
 
 @pytest.fixture()
-def bout_xyt_example_files(tmpdir_factory):
+def bout_xyt_example_files(tmp_path_factory):
     return _bout_xyt_example_files
 
 
 def _bout_xyt_example_files(
-    tmpdir_factory,
+    tmp_path_factory,
     prefix="BOUT.dmp",
     lengths=(6, 2, 4, 7),
     nxpe=4,
@@ -329,20 +336,20 @@ def _bout_xyt_example_files(
             return ds_list
         else:
             return ds_list, grid_ds
-    elif tmpdir_factory is None:
-        raise ValueError("tmpdir_factory required when write_to_disk=True")
+    elif tmp_path_factory is None:
+        raise ValueError("tmp_path_factory required when write_to_disk=True")
 
-    save_dir = tmpdir_factory.mktemp("data")
+    save_dir = tmp_path_factory.mktemp("data")
 
     for ds, file_name in zip(ds_list, file_list):
-        ds.to_netcdf(str(save_dir.join(str(file_name))))
+        ds.to_netcdf(save_dir.joinpath(file_name))
 
     if grid is not None:
-        grid_ds.to_netcdf(str(save_dir.join(grid + ".nc")))
+        grid_ds.to_netcdf(save_dir.joinpath(grid + ".nc"))
 
     # Return a glob-like path to all files created, which has all file numbers replaced
     # with a single asterix
-    path = str(save_dir.join(str(file_list[-1])))
+    path = str(save_dir.joinpath(file_list[-1]))
 
     count = 1
     if nt > 1:
@@ -351,7 +358,7 @@ def _bout_xyt_example_files(
     # tests don't get confused by pytest's persistent temporary directories (which are also designated
     # by different numbers)
     glob_pattern = (re.sub(r"\d+", "*", path[::-1], count=count))[::-1]
-    return glob_pattern
+    return Path(glob_pattern)
 
 
 def create_bout_ds_list(
@@ -759,9 +766,9 @@ class TestStripMetadata:
 
 # TODO also test loading multiple files which have guard cells
 class TestOpen:
-    def test_single_file(self, tmpdir_factory, bout_xyt_example_files):
+    def test_single_file(self, tmp_path_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(
-            tmpdir_factory, nxpe=1, nype=1, nt=1, write_to_disk=True
+            tmp_path_factory, nxpe=1, nype=1, nt=1, write_to_disk=True
         )
         with pytest.warns(UserWarning):
             actual = open_boutdataset(datapath=path, keep_xboundaries=False)
@@ -785,9 +792,9 @@ class TestOpen:
             fake = open_boutdataset(datapath=fake_ds_list, keep_xboundaries=False)
         xrt.assert_identical(actual, fake)
 
-    def test_squashed_file(self, tmpdir_factory, bout_xyt_example_files):
+    def test_squashed_file(self, tmp_path_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(
-            tmpdir_factory, nxpe=4, nype=3, nt=1, squashed=True, write_to_disk=True
+            tmp_path_factory, nxpe=4, nype=3, nt=1, squashed=True, write_to_disk=True
         )
         with pytest.warns(UserWarning):
             actual = open_boutdataset(datapath=path, keep_xboundaries=False)
@@ -818,10 +825,14 @@ class TestOpen:
         "keep_yboundaries", [False, pytest.param(True, marks=pytest.mark.long)]
     )
     def test_squashed_doublenull(
-        self, tmpdir_factory, bout_xyt_example_files, keep_xboundaries, keep_yboundaries
+        self,
+        tmp_path_factory,
+        bout_xyt_example_files,
+        keep_xboundaries,
+        keep_yboundaries,
     ):
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=4,
             nype=6,
             nt=1,
@@ -852,10 +863,14 @@ class TestOpen:
         "keep_yboundaries", [False, pytest.param(True, marks=pytest.mark.long)]
     )
     def test_squashed_doublenull_file(
-        self, tmpdir_factory, bout_xyt_example_files, keep_xboundaries, keep_yboundaries
+        self,
+        tmp_path_factory,
+        bout_xyt_example_files,
+        keep_xboundaries,
+        keep_yboundaries,
     ):
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=4,
             nype=6,
             nt=1,
@@ -880,9 +895,9 @@ class TestOpen:
         assert ds.sizes["y"] == 32 if keep_yboundaries else 24
         assert ds.sizes["z"] == 7
 
-    def test_combine_along_x(self, tmpdir_factory, bout_xyt_example_files):
+    def test_combine_along_x(self, tmp_path_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=4,
             nype=1,
             nt=1,
@@ -916,9 +931,9 @@ class TestOpen:
             fake = open_boutdataset(datapath=fake_ds_list, keep_xboundaries=False)
         xrt.assert_identical(actual, fake)
 
-    def test_combine_along_y(self, tmpdir_factory, bout_xyt_example_files):
+    def test_combine_along_y(self, tmp_path_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=1,
             nype=3,
             nt=1,
@@ -959,10 +974,10 @@ class TestOpen:
     )
     @pytest.mark.parametrize("lengths", [(6, 2, 4, 7), (6, 2, 4, 1)])
     def test_combine_along_xy(
-        self, tmpdir_factory, bout_xyt_example_files, bout_v5, metric_3D, lengths
+        self, tmp_path_factory, bout_xyt_example_files, bout_v5, metric_3D, lengths
     ):
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=4,
             nype=3,
             nt=1,
@@ -1020,10 +1035,10 @@ class TestOpen:
             fake = open_boutdataset(datapath=fake_ds_list, keep_xboundaries=False)
         xrt.assert_identical(actual, fake)
 
-    def test_toroidal(self, tmpdir_factory, bout_xyt_example_files):
+    def test_toroidal(self, tmp_path_factory, bout_xyt_example_files):
         # actually write these to disk to test the loading fully
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=3,
             nype=3,
             nt=1,
@@ -1034,12 +1049,12 @@ class TestOpen:
         actual = open_boutdataset(
             datapath=path,
             geometry="toroidal",
-            gridfilepath=Path(path).parent.joinpath("grid.nc"),
+            gridfilepath=path.parent.joinpath("grid.nc"),
         )
 
         # check dataset can be saved
-        save_dir = tmpdir_factory.mktemp("data")
-        actual.bout.save(str(save_dir.join("boutdata.nc")))
+        save_dir = tmp_path_factory.mktemp("data")
+        actual.bout.save(save_dir.joinpath("boutdata.nc"))
 
         # check creation without writing to disk gives identical result
         fake_ds_list, fake_grid_ds = bout_xyt_example_files(
@@ -1055,9 +1070,9 @@ class TestOpen:
         )
         xrt.assert_identical(actual, fake)
 
-    def test_salpha(self, tmpdir_factory, bout_xyt_example_files):
+    def test_salpha(self, tmp_path_factory, bout_xyt_example_files):
         path = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=3,
             nype=3,
             nt=1,
@@ -1068,12 +1083,12 @@ class TestOpen:
         actual = open_boutdataset(
             datapath=path,
             geometry="s-alpha",
-            gridfilepath=Path(path).parent.joinpath("grid.nc"),
+            gridfilepath=path.parent.joinpath("grid.nc"),
         )
 
         # check dataset can be saved
-        save_dir = tmpdir_factory.mktemp("data")
-        actual.bout.save(str(save_dir.join("boutdata.nc")))
+        save_dir = tmp_path_factory.mktemp("data")
+        actual.bout.save(save_dir.joinpath("boutdata.nc"))
 
         # check creation without writing to disk gives identical result
         fake_ds_list, fake_grid_ds = bout_xyt_example_files(
@@ -1084,9 +1099,9 @@ class TestOpen:
         )
         xrt.assert_identical(actual, fake)
 
-    def test_drop_vars(self, tmpdir_factory, bout_xyt_example_files):
+    def test_drop_vars(self, tmp_path_factory, bout_xyt_example_files):
         datapath = bout_xyt_example_files(
-            tmpdir_factory,
+            tmp_path_factory,
             nxpe=4,
             nype=1,
             nt=1,

--- a/xbout/tests/utils_for_tests.py
+++ b/xbout/tests/utils_for_tests.py
@@ -1,4 +1,6 @@
 from boutdata.data import BoutOptionsFile
+from frozendict import frozendict
+import inspect
 import numpy as np
 from pathlib import Path
 
@@ -111,3 +113,33 @@ def set_geometry_from_input_file(ds, name):
             ds[v] = ds[v].copy(data=np.broadcast_to(float("nan"), ds[v].shape))
 
     return ds, options
+
+
+def _get_kwargs(ignore=None):
+    """
+    Get the arguments of a function as a frozendict. Extended version of code from here:
+    https://stackoverflow.com/a/65927265
+
+    Parameters
+    ----------
+    ignore : str or Sequence of str
+        Arguments to drop when constructing the returned frozendict
+    """
+    frame = inspect.currentframe().f_back
+    keys, _, _, values = inspect.getargvalues(frame)
+    kwargs = {}
+    keys_to_ignore = ["self"]
+    if ignore is not None:
+        if isinstance(ignore, str):
+            ignore = [ignore]
+        keys_to_ignore += ignore
+    for key in keys:
+        if key not in keys_to_ignore:
+            value = values[key]
+            if isinstance(value, dict):
+                value = frozendict(value)
+            if isinstance(value, list):
+                value = tuple(value)
+            kwargs[key] = value
+
+    return frozendict(kwargs)

--- a/xbout/tests/utils_for_tests.py
+++ b/xbout/tests/utils_for_tests.py
@@ -1,5 +1,5 @@
 from boutdata.data import BoutOptionsFile
-from frozendict import frozendict
+from gelidum import freeze
 import inspect
 import numpy as np
 from pathlib import Path
@@ -136,10 +136,6 @@ def _get_kwargs(ignore=None):
     for key in keys:
         if key not in keys_to_ignore:
             value = values[key]
-            if isinstance(value, dict):
-                value = frozendict(value)
-            if isinstance(value, list):
-                value = tuple(value)
             kwargs[key] = value
 
-    return frozendict(kwargs)
+    return freeze(kwargs)


### PR DESCRIPTION
When creating input files/Datasets for tests, save them in a cache and return a copy if the same arguments are given to the data-creation function(s). Helps to speed things up a bit - seems to shave about 20mins of the CI runs.

Includes an update changing the use of Pytest's `tmpdir_factory` and `tmpdir` for `tmp_path_factory` and `tmp_path`. The latter return a `pathlib.Path` object instead of Pytests's `py.path`, which is more convenient and compatible with standard Python path-handling. I think those changes are actually most of the changed lines though - for just the caching updates, see 4e4e1427c1c4ac2aeae1e9cbd99e71ccbefd243c and ac191a3a2e45c7370dd8d7c71dfbfe0e9bddcb87.

Partial fix for #213.