### PR TITLE
Document a workaround for conflicts in open_boutdataset(); some tidying

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -1017,9 +1017,9 @@ class BoutDataArrayAccessor:
         """
         return plotfuncs.plot2d_wrapper(self.data, xr.plot.pcolormesh, ax=ax, **kwargs)
 
-    def regions(self, ax=None, **kwargs):
+    def plot_regions(self, ax=None, **kwargs):
         """
         Plot the regions into which xBOUT splits radial-poloidal arrays to handle
         tokamak topology.
         """
-        return plotfuncs.regions(self.data, ax=ax, **kwargs)
+        return plotfuncs.plot_regions(self.data, ax=ax, **kwargs)

--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -1000,13 +1000,26 @@ class BoutDataArrayAccessor:
 
     # BOUT-specific plotting functionality: methods that plot on a poloidal (R-Z) plane
     def contour(self, ax=None, **kwargs):
+        """
+        Contour-plot a radial-poloidal slice on the R-Z plane
+        """
         return plotfuncs.plot2d_wrapper(self.data, xr.plot.contour, ax=ax, **kwargs)
 
     def contourf(self, ax=None, **kwargs):
+        """
+        Filled-contour-plot a radial-poloidal slice on the R-Z plane
+        """
         return plotfuncs.plot2d_wrapper(self.data, xr.plot.contourf, ax=ax, **kwargs)
 
     def pcolormesh(self, ax=None, **kwargs):
+        """
+        Colour-plot a radial-poloidal slice on the R-Z plane
+        """
         return plotfuncs.plot2d_wrapper(self.data, xr.plot.pcolormesh, ax=ax, **kwargs)
 
     def regions(self, ax=None, **kwargs):
+        """
+        Plot the regions into which xBOUT splits radial-poloidal arrays to handle
+        tokamak topology.
+        """
         return plotfuncs.regions(self.data, ax=ax, **kwargs)

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -143,7 +143,7 @@ class BoutDatasetAccessor:
         return _from_region(self.data, name, with_guards)
 
     @property
-    def regions(self):
+    def _regions(self):
         if "regions" not in self.data.attrs:
             raise ValueError(
                 "Called a method requiring regions, but these have not been created. "

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -78,6 +78,21 @@ def open_boutdataset(
     `run_name` are ignored. `geometry` is treated specially, and can be passed when
     reloading a Dataset (along with `gridfilepath` if needed).
 
+    Troubleshooting
+    ---------------
+    Variable conflicts: sometimes, for example when loading data from multiple restarts,
+    some variables may have conflicts (e.g. a source term was changed between some of
+    the restarts, but the source term is saved as time-independent, without a
+    t-dimension). In this case one workaround is to pass a list of variable names to the
+    keyword argument `drop_vars` to ignore the variables with conflicts, e.g. if `"S1"`
+    and `"S2"` have conflicts
+    ```
+    ds = open_boutdataset("data*/boutdata.nc", drop_vars=["S1", "S2"])
+    ```
+    will open a Dataset which is missing `"S1"` and `"S2"`.\
+    [`drop_vars` is an argument of `xarray.open_dataset()` that is passed down through
+    `kwargs`.]
+
     Parameters
     ----------
     datapath : str or (list or tuple of xr.Dataset), optional
@@ -124,7 +139,7 @@ def open_boutdataset(
     info : bool or "terse", optional
     kwargs : optional
         Keyword arguments are passed down to `xarray.open_mfdataset`, which in
-        turn extra kwargs down to `xarray.open_dataset`.
+        turn passes extra kwargs down to `xarray.open_dataset`.
 
     Returns
     -------

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -342,9 +342,6 @@ def collect(
     info=True,
     prefix="BOUT.dmp",
 ):
-
-    from os.path import join
-
     """
 
     Extract the data pertaining to a specified variable in a BOUT++ data set
@@ -384,6 +381,7 @@ def collect(
     ds : numpy.ndarray
 
     """
+    from os.path import join
 
     datapath = join(path, prefix + "*.nc")
 

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -24,7 +24,7 @@ if (
     matplotlib.rcParams["pcolor.shading"] = "auto"
 
 
-def regions(da, ax=None, **kwargs):
+def plot_regions(da, ax=None, **kwargs):
     """
     Plots each logical plotting region as a different color for debugging.
 

--- a/xbout/plotting/utils.py
+++ b/xbout/plotting/utils.py
@@ -64,7 +64,10 @@ def plot_separatrix(da, sep_pos, ax, radial_coord="x"):
 
 def _decompose_regions(da):
 
-    return {region: da.bout.from_region(region, with_guards=1) for region in da.regions}
+    return {
+        region: da.bout.from_region(region, with_guards=1)
+        for region in da.bout._regions
+    }
 
 
 def _is_core_only(da):
@@ -90,7 +93,7 @@ def plot_separatrices(da, ax, *, x="R", y="Z"):
     ycoord = da0.metadata["bout_ydim"]
 
     for da_region in da_regions.values():
-        inner = list(da_region.regions.values())[0].connection_inner_x
+        inner = list(da_region.bout._regions.values())[0].connection_inner_x
         if inner in da_regions:
             da_inner = da_regions[inner]
 
@@ -136,14 +139,14 @@ def plot_targets(da, ax, *, x="R", y="Z", hatching=True):
         y_boundary_guards = 0
 
     for da_region in da_regions.values():
-        if list(da_region.regions.values())[0].connection_lower_y is None:
+        if list(da_region.bout._regions.values())[0].connection_lower_y is None:
             # lower target exists
             x_target = da_region.coords[x].isel(**{ycoord: y_boundary_guards})
             y_target = da_region.coords[y].isel(**{ycoord: y_boundary_guards})
             [line] = ax.plot(x_target, y_target, "k-", linewidth=2)
             if hatching:
                 _add_hatching(line, ax)
-        if list(da_region.regions.values())[0].connection_upper_y is None:
+        if list(da_region.bout._regions.values())[0].connection_upper_y is None:
             # upper target exists
             x_target = da_region.coords[x].isel(**{ycoord: -y_boundary_guards - 1})
             y_target = da_region.coords[y].isel(**{ycoord: -y_boundary_guards - 1})

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -1221,11 +1221,11 @@ def _concat_inner_guards(da, da_global, mxg):
     if mxg <= 0:
         return da
 
-    if len(da.regions) > 1:
+    if len(da.bout._regions) > 1:
         raise ValueError("da passed should have only one region")
-    region = list(da.regions.values())[0]
+    region = list(da.bout._regions.values())[0]
 
-    if region.connection_inner_x not in da_global.regions:
+    if region.connection_inner_x not in da_global.bout._regions:
         # No connection, or plotting restricted set of regions not including this
         # connection
         return da
@@ -1236,9 +1236,9 @@ def _concat_inner_guards(da, da_global, mxg):
     ycoord = da_global.metadata["bout_ydim"]
 
     da_inner = da_global.bout.from_region(region.connection_inner_x, with_guards=0)
-    if len(da_inner.regions) > 1:
+    if len(da_inner.bout._regions) > 1:
         raise ValueError("da_inner should have only one region")
-    region_inner = list(da_inner.regions.values())[0]
+    region_inner = list(da_inner.bout._regions.values())[0]
 
     if (
         myg_da > 0
@@ -1276,7 +1276,7 @@ def _concat_inner_guards(da, da_global, mxg):
         da_inner_lower = da_inner_lower.isel(
             **{xcoord: slice(-mxg, None), ycoord: slice(-myg_da, None)}
         )
-        save_regions = da_inner.regions
+        save_regions = da_inner.bout._regions
         da_inner = xr.concat((da_inner_lower, da_inner), ycoord, join="exact")
         # xr.concat takes attributes from the first variable, but we need da_inner's
         # regions
@@ -1314,7 +1314,7 @@ def _concat_inner_guards(da, da_global, mxg):
         da_inner[xcoord].data[...] = new_xcoord.data
         da_inner[ycoord].data[...] = new_ycoord.data
 
-    save_regions = da.regions
+    save_regions = da.bout._regions
     da = xr.concat((da_inner, da), xcoord, join="exact")
     # xr.concat takes attributes from the first variable (for xarray>=0.15.0, keeps attrs
     # that are the same in all objects for xarray<0.15.0)
@@ -1332,11 +1332,11 @@ def _concat_outer_guards(da, da_global, mxg):
     if mxg <= 0:
         return da
 
-    if len(da.regions) > 1:
+    if len(da.bout._regions) > 1:
         raise ValueError("da passed should have only one region")
-    region = list(da.regions.values())[0]
+    region = list(da.bout._regions.values())[0]
 
-    if region.connection_outer_x not in da_global.regions:
+    if region.connection_outer_x not in da_global.bout._regions:
         # No connection, or plotting restricted set of regions not including this
         # connection
         return da
@@ -1347,9 +1347,9 @@ def _concat_outer_guards(da, da_global, mxg):
     ycoord = da_global.metadata["bout_ydim"]
 
     da_outer = da_global.bout.from_region(region.connection_outer_x, with_guards=0)
-    if len(da_outer.regions) > 1:
+    if len(da_outer.bout._regions) > 1:
         raise ValueError("da_outer should have only one region")
-    region_outer = list(da_outer.regions.values())[0]
+    region_outer = list(da_outer.bout._regions.values())[0]
 
     if (
         myg_da > 0
@@ -1387,7 +1387,7 @@ def _concat_outer_guards(da, da_global, mxg):
         da_outer_lower = da_outer_lower.isel(
             **{xcoord: slice(-mxg, None), ycoord: slice(-myg_da, None)}
         )
-        save_regions = da_outer.regions
+        save_regions = da_outer.bout._regions
         da_outer = xr.concat((da_outer_lower, da_outer), ycoord, join="exact")
         # xr.concat takes attributes from the first variable, but we need da_outer's
         # regions
@@ -1425,7 +1425,7 @@ def _concat_outer_guards(da, da_global, mxg):
         da_outer[xcoord].data[...] = new_xcoord.data
         da_outer[ycoord].data[...] = new_ycoord.data
 
-    save_regions = da.regions
+    save_regions = da.bout._regions
     da = xr.concat((da, da_outer), xcoord, join="exact")
     # xarray<0.15.0 only keeps attrs that are the same on all variables passed to concat
     da.attrs["regions"] = save_regions
@@ -1442,11 +1442,11 @@ def _concat_lower_guards(da, da_global, mxg, myg):
     if myg <= 0:
         return da
 
-    if len(da.regions) > 1:
+    if len(da.bout._regions) > 1:
         raise ValueError("da passed should have only one region")
-    region = list(da.regions.values())[0]
+    region = list(da.bout._regions.values())[0]
 
-    if region.connection_lower_y not in da_global.regions:
+    if region.connection_lower_y not in da_global.bout._regions:
         # No connection, or plotting restricted set of regions not including this
         # connection
         return da
@@ -1525,7 +1525,7 @@ def _concat_lower_guards(da, da_global, mxg, myg):
         da_lower[xcoord].data[...] = new_xcoord.data
         da_lower[ycoord].data[...] = new_ycoord.data
 
-    save_regions = da.regions
+    save_regions = da.bout._regions
     da = xr.concat((da_lower, da), ycoord, join="exact")
     # xr.concat takes attributes from the first variable (for xarray>=0.15.0, keeps attrs
     # that are the same in all objects for xarray<0.15.0)
@@ -1543,11 +1543,11 @@ def _concat_upper_guards(da, da_global, mxg, myg):
     if myg <= 0:
         return da
 
-    if len(da.regions) > 1:
+    if len(da.bout._regions) > 1:
         raise ValueError("da passed should have only one region")
-    region = list(da.regions.values())[0]
+    region = list(da.bout._regions.values())[0]
 
-    if region.connection_upper_y not in da_global.regions:
+    if region.connection_upper_y not in da_global.bout._regions:
         # No connection, or plotting restricted set of regions not including this
         # connection
         return da
@@ -1625,7 +1625,7 @@ def _concat_upper_guards(da, da_global, mxg, myg):
         da_upper[xcoord].data[...] = new_xcoord.data
         da_upper[ycoord].data[...] = new_ycoord.data
 
-    save_regions = da.regions
+    save_regions = da.bout._regions
     da = xr.concat((da, da_upper), ycoord, join="exact")
     # xarray<0.15.0 only keeps attrs that are the same on all variables passed to concat
     da.attrs["regions"] = save_regions
@@ -1637,7 +1637,7 @@ def _from_region(ds_or_da, name, with_guards):
     # ensure we do not modify the input
     ds_or_da = ds_or_da.copy(deep=True)
 
-    region = ds_or_da.regions[name]
+    region = ds_or_da.bout._regions[name]
     xcoord = ds_or_da.metadata["bout_xdim"]
     ycoord = ds_or_da.metadata["bout_ydim"]
 
@@ -1669,7 +1669,7 @@ def _from_region(ds_or_da, name, with_guards):
 
     # If the result (which only has a single region) is passed to from_region a
     # second time, don't want to slice anything.
-    single_region = list(result.regions.values())[0]
+    single_region = list(result.bout._regions.values())[0]
     single_region.xinner_ind = None
     single_region.xouter_ind = None
     single_region.ylower_ind = None

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -456,7 +456,7 @@ _bounding_surface_checks = {}
 
 
 def _check_upper_y(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
-    region = list(ds_region.regions.values())[0]
+    region = list(ds_region.bout._regions.values())[0]
     xcoord = ds_region.metadata["bout_xdim"]
     ycoord = ds_region.metadata["bout_ydim"]
 
@@ -489,7 +489,7 @@ _bounding_surface_checks["upper_y"] = _check_upper_y
 
 
 def _check_inner_x(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
-    region = list(ds_region.regions.values())[0]
+    region = list(ds_region.bout._regions.values())[0]
     xcoord = ds_region.metadata["bout_xdim"]
     ycoord = ds_region.metadata["bout_ydim"]
 
@@ -522,7 +522,7 @@ _bounding_surface_checks["inner_x"] = _check_inner_x
 
 
 def _check_lower_y(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
-    region = list(ds_region.regions.values())[0]
+    region = list(ds_region.bout._regions.values())[0]
     xcoord = ds_region.metadata["bout_xdim"]
     ycoord = ds_region.metadata["bout_ydim"]
 
@@ -550,7 +550,7 @@ _bounding_surface_checks["lower_y"] = _check_lower_y
 
 
 def _check_outer_x(ds_region, boundary_points, xbndry, ybndry, Rcoord, Zcoord):
-    region = list(ds_region.regions.values())[0]
+    region = list(ds_region.bout._regions.values())[0]
     xcoord = ds_region.metadata["bout_xdim"]
     ycoord = ds_region.metadata["bout_ydim"]
 
@@ -597,7 +597,7 @@ def _follow_boundary(ds, start_region, start_direction, xbndry, ybndry, Rcoord, 
         visited_regions.append(this_region)
 
         ds_region = ds.bout.from_region(this_region, with_guards=0)
-        region = ds.regions[this_region]
+        region = ds.bout._regions[this_region]
 
         # Get all boundary points from this region, and decide which region to go to next
         this_region = None
@@ -665,14 +665,14 @@ def _get_bounding_surfaces(ds, coords):
 
     # First find the outer boundary
     start_region = None
-    for name, region in ds.regions.items():
+    for name, region in ds.bout._regions.items():
         if region.connection_lower_y is None and region.connection_outer_x is None:
             start_region = name
             break
     if start_region is None:
         # No y-boundary region found, presumably is core-only simulation. Start on any
         # region with an outer-x boundary
-        for name, region in ds.regions.items():
+        for name, region in ds.bout._regions.items():
             if region.connection_outer_x is None:
                 start_region = name
     if start_region is None:
@@ -682,7 +682,7 @@ def _get_bounding_surfaces(ds, coords):
 
     # First region has outer-x boundary, but we only visit start_region once, so need to
     # add all boundaries in it the first time.
-    region = ds.regions[start_region]
+    region = ds.bout._regions[start_region]
     if region.connection_upper_y is None:
         start_direction = "inner_x"
     elif region.connection_inner_x is None and region.connection_lower_y is None:
@@ -705,7 +705,7 @@ def _get_bounding_surfaces(ds, coords):
 
     # Look for an inner boundary
     ############################
-    remaining_regions = set(ds.regions) - set(checked_regions)
+    remaining_regions = set(ds.bout._regions) - set(checked_regions)
     start_region = None
     if not remaining_regions:
         # Check for separate inner-x boundary on any of the already visited regions.
@@ -715,9 +715,9 @@ def _get_bounding_surfaces(ds, coords):
         # a separate inner boundary
         for r in checked_regions:
             if (
-                ds.regions[r].connection_inner_x is None
-                and ds.regions[r].connection_lower_y is not None
-                and ds.regions[r].connection_upper_y is not None
+                ds.bout._regions[r].connection_inner_x is None
+                and ds.bout._regions[r].connection_lower_y is not None
+                and ds.bout._regions[r].connection_upper_y is not None
                 and checked_regions.count(r) < 2
             ):
                 start_region = r
@@ -725,9 +725,9 @@ def _get_bounding_surfaces(ds, coords):
     else:
         for r in remaining_regions:
             if (
-                ds.regions[r].connection_inner_x is None
-                and ds.regions[r].connection_lower_y is not None
-                and ds.regions[r].connection_upper_y is not None
+                ds.bout._regions[r].connection_inner_x is None
+                and ds.bout._regions[r].connection_lower_y is not None
+                and ds.bout._regions[r].connection_upper_y is not None
             ):
                 start_region = r
                 break
@@ -744,11 +744,11 @@ def _get_bounding_surfaces(ds, coords):
         boundaries.append(boundary)
         checked_regions += more_checked_regions
 
-        remaining_regions = set(ds.regions) - set(checked_regions)
+        remaining_regions = set(ds.bout._regions) - set(checked_regions)
 
     # If there are any remaining regions, they should not have any boundaries
     for r in remaining_regions:
-        region = ds.regions[r]
+        region = ds.bout._regions[r]
         if (
             region.connection_lower_y is None
             or region.connection_outer_x is None


### PR DESCRIPTION
* Add troubleshooting section to `open_boutdataset` docstring. Says what to do if variables conflict when combining data from several restarts.
* Tidying up of other docstrings
* Refactor `regions` property to `_regions`, ensure it is being used correctly - previously I think `attrs["regions"]` was (accidentally) being used through the `xarray` feature of making things `attrs` accessible with `.foo` syntax.