### PR TITLE
Fix condition for 'bout_v5' behaviour of dz

### DIFF
--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -183,7 +183,9 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
 
         # In BOUT++ v5, dz is either a Field2D or Field3D.
         # We can use it as a 1D coordinate if it's a Field3D, _or_ if nz == 1
-        bout_v5 = updated_ds.metadata["BOUT_VERSION"] >= 5.0
+        bout_v5 = updated_ds.metadata["BOUT_VERSION"] > 5.0 or (
+            updated_ds.metadata["BOUT_VERSION"] == 5.0 and updated_ds["dz"].ndim == 2
+        )
         use_metric_3d = updated_ds.metadata.get("use_metric_3d", False)
         can_use_1d_z_coord = (nz == 1) or use_metric_3d
 


### PR DESCRIPTION
For output files created with `next` after it changed to pre-release of BOUT++ v5 but before `dz` was changed to a `Field2D`, creating the z-coordinate would previously fail (due to trying to index a scalar). Need to check for this case explicitly in the condition for applying `bout_v5` behaviour.

Fixes https://github.com/boutproject/xBOUT-examples/issues/13.