### PR TITLE
Fix color scales in `animate_list()`

### DIFF
--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -221,7 +221,7 @@ def animate_poloidal(
         extend = "neither"
 
     # create colorbar
-    norm = _create_norm(logscale, kwargs.get("norm", None), vmin, vmax)
+    norm = _create_norm(logscale, kwargs.pop("norm", None), vmin, vmax)
     sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap)
     sm.set_array([])
     cmap = sm.get_cmap()
@@ -262,6 +262,7 @@ def animate_poloidal(
                     da_region.values,
                     ax=ax,
                     cmap=cmap,
+                    norm=norm,
                     **kwargs,
                 )
             )


### PR DESCRIPTION
Need to always pass `norm` to amp.blocks.Pcolormesh(), as well as `cmap`, otherwise different regions actually get normalised to their own min/max.

Bug probably introduced in #196.