### PR TITLE
Convert byte-strings to str when loading data

### DIFF
--- a/xbout/tests/test_against_collect.py
+++ b/xbout/tests/test_against_collect.py
@@ -136,12 +136,22 @@ class TestAccuracyAgainstOldCollect:
 
         for v in METADATA_VARS:
             expected = old_collect(v, path=test_dir)
+            if v == "run_id":
+                # Workaround for weird handling of byte arrays.
+                # Also convert to utf-8, like workaround in _separate_metadata().
+                expected = expected.tobytes().decode("utf-8")
             # Check metadata against new standard - open_boutdataset
             actual = ds.bout.metadata[v]
             npt.assert_equal(actual, expected)
 
             # Check against backwards compatible collect function
             actual = new_collect(v, path=test_dir)
+            if v == "run_id":
+                expected = old_collect(v, path=test_dir)
+                # Workaround for weird handling of byte array.
+                # Conversion to str is not done by xBOUT-based collect(), which uses
+                # _auto_open_mfboutdataset(), not the full open_boutdataset().
+                expected = expected.tobytes()
             npt.assert_equal(actual, expected)
 
     def test_new_collect_indexing_int(self, tmp_path_factory):

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -696,6 +696,7 @@ def create_bout_ds(
     else:
         ds["dz"] = 2.0 * np.pi / nz
 
+    ds["run_id"] = b"x" * 36
     ds["iteration"] = t_length
     ds["t_array"] = DataArray(np.arange(t_length, dtype=float) * 10.0, dims="t")
 
@@ -787,6 +788,7 @@ METADATA_VARS = [
     "ZMIN",
     "ZMAX",
     "use_metric_3d",
+    "run_id",
 ]
 
 

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -69,6 +69,14 @@ def _separate_metadata(ds):
 
     # Save metadata as a dictionary
     metadata_vals = [ds[var].values.item() for var in scalar_vars]
+
+    # xarray cannot save byte-strings to NetCDF, so convert all byte-strings to str.
+    # Doing this conversion at load-time so that when re-loading an xbout-saved Dataset
+    # it should be identical to the Dataset before saving.
+    metadata_vals = [
+        v.decode("utf-8") if isinstance(v, bytes) else v for v in metadata_vals
+    ]
+
     metadata = dict(zip(scalar_vars, metadata_vals))
 
     # Add default values for dimensions to metadata. These may be modified later by


### PR DESCRIPTION
char-arrays are loaded in Python as byte-strings (of type `bytes`). These cannot be saved to NetCDF by xarray as attributes. For consistency between saved and re-loaded Datasets, convert all byte-strings in metadata to utf-8 strings when loading data (if we converted only when saving data then the Dataset being saved could have `bytes` metadata variables, while the re-loaded Dataset would have `str`).

Also adds a byte-string "run_id" variable to the test Datasets, which should prevent regressions of this bug-fix.