### PR TITLE
Fixes for loading BOUT.restart.*.nc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Generated files:
+_version.py


### PR DESCRIPTION
`BOUT.restart.*.nc` files do not contain some variables that are required in `BOUT.dmp.*.nc` files, so need some special handling.