### PR TITLE
Interpolate to new grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Generated files:
+_version.py

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -790,7 +790,9 @@ class BoutDatasetAccessor:
         variables : str or sequence of str, optional
             The evolving variables needed in the restart files. If not given explicitly,
             all time-evolving variables in the Dataset will be used, which may result in
-            larger restart files than necessary.
+            larger restart files than necessary. If there is no time-dimension in the
+            Dataset (e.g. if it was loaded from restart files), then all variables will
+            be added if this argument is not given explicitly.
         savepath : str, default '.'
             Directory to save the created restart files under
         nxpe : int, optional

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -18,6 +18,7 @@ import numpy as np
 from dask.diagnostics import ProgressBar
 
 from .geometries import apply_geometry
+from .load import open_boutdataset
 from .plotting.animate import (
     animate_poloidal,
     animate_pcolormesh,
@@ -343,6 +344,114 @@ class BoutDatasetAccessor:
             elif xcoord not in da.dims:
                 ds[var] = da
             # Can't interpolate a variable that depends on x but not y, so just skip
+
+        # Apply geometry
+        ds = apply_geometry(ds, ds.geometry)
+
+        return ds
+
+    def interpolate_to_new_grid(self, variables, new_gridfile, **kwargs):
+        """
+        Interpolate the DataSet onto a new set of grid points, given by a grid file.
+
+        The grid file is asssumed to represent the same equilibrium as the one
+        associated by the original DataSet, so that psi-values and poloidal distances
+        along psi-contours of the equilibrium are the same.
+
+        Parameters
+        ----------
+        variables : str or sequence of str or ...
+            The names of the variables to interpolate. If 'variables=...' is passed
+            explicitly, then interpolate all variables in the Dataset.
+        new_gridfile : str, pathlib.Path or Dataset
+            Path to a new grid file, or grid file opened as a Dataset.
+        method : str, optional
+            The interpolation method to use. Options from xarray.DataSet.interp(),
+            currently: linear, nearest, zero, slinear, quadratic, cubic. Default is
+            'cubic'.
+
+        Returns
+        -------
+        A new Dataset containing the variables interpolated to the new grid. The new
+        Dataset is a valid BoutDataset, although containing only the specified
+        variables.
+        """
+
+        print("Interpolating to new grid:")
+
+        if variables is ...:
+            variables = [v for v in self.data]
+
+        if not isinstance(new_gridfile, xr.Dataset):
+            new_gridfile = open_boutdataset(
+                new_gridfile,
+                keep_xboundaries=self.data.metadata["keep_xboundaries"],
+                keep_yboundaries=self.data.metadata["keep_yboundaries"],
+                drop_variables=["theta"],
+                info=False,
+            )
+            new_gridfile = apply_geometry(new_gridfile, self.data.geometry)
+
+        if isinstance(variables, str):
+            variables = [variables]
+        if isinstance(variables, tuple):
+            variables = list(variables)
+
+        # Need to start with a Dataset with attrs as merge() drops the attrs of the
+        # passed-in argument.
+        # Make sure the first variable has all dimensions so we don't lose any
+        # coordinates
+        def find_with_dims(first_var, dims):
+            if first_var is None:
+                dims = set(dims)
+                for v in variables:
+                    if set(self.data[v].dims) == dims:
+                        first_var = v
+                        break
+            return first_var
+
+        tcoord = self.data.metadata.get("bout_tdim", "t")
+        zcoord = self.data.metadata.get("bout_zdim", "z")
+        first_var = find_with_dims(None, self.data.dims)
+        first_var = find_with_dims(first_var, set(self.data.dims) - set(tcoord))
+        first_var = find_with_dims(first_var, set(self.data.dims) - set(zcoord))
+        first_var = find_with_dims(
+            first_var, set(self.data.dims) - set([tcoord, zcoord])
+        )
+        if first_var is None:
+            raise ValueError(
+                f"Could not find variable to interpolate with both "
+                f"{ds.metadata.get('bout_xdim', 'x')} and "
+                f"{ds.metadata.get('bout_ydim', 'y')} dimensions"
+            )
+        variables.remove(first_var)
+        print(first_var)
+        ds = self.data[first_var].bout.interpolate_to_new_grid(
+            new_gridfile, return_dataset=True, **kwargs
+        )
+        xcoord = ds.metadata.get("bout_xdim", "x")
+        ycoord = ds.metadata.get("bout_ydim", "y")
+        for var in variables:
+            print(var)
+            da = self.data[var]
+            if xcoord in da.dims and ycoord in da.dims:
+                ds = ds.merge(
+                    da.bout.interpolate_to_new_grid(
+                        new_gridfile, return_dataset=True, **kwargs
+                    )
+                )
+            elif xcoord in da.dims:
+                print(
+                    f"{var} depends on x but not y, so do not know how to interpolate "
+                    f"to new grid"
+                )
+            elif ycoord in da.dims:
+                print(
+                    f"{var} depends on y but not x, so do not know how to interpolate "
+                    f"to new grid"
+                )
+            else:
+                ds[var] = da
 
         # Apply geometry
         ds = apply_geometry(ds, ds.geometry)

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -374,6 +374,8 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
             "poloidal_distance",
             "poloidal_distance_ylow",
             "total_poloidal_distance",
+            "zShift",
+            "zShift_ylow",
         ],
     )
 
@@ -413,6 +415,14 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     else:
         ds = ds.set_coords(("Rxy", "Zxy"))
 
+    # Rename zShift_ylow if it was added from grid file, to be consistent with name if
+    # it was added from dump file
+    if "zShift_CELL_YLOW" in ds and "zShift_ylow" in ds:
+        # Remove redundant copy
+        del ds["zShift_ylow"]
+    elif "zShift_ylow" in ds:
+        ds = ds.rename(zShift_ylow="zShift_CELL_YLOW")
+
     if "poloidal_distance" in ds:
         ds = ds.set_coords(
             ["poloidal_distance", "poloidal_distance_ylow", "total_poloidal_distance"]
@@ -420,6 +430,8 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
 
     # Add zShift as a coordinate, so that it gets interpolated along with a variable
     ds = _set_as_coord(ds, "zShift")
+    if "zShift_CELL_YLOW" in ds:
+        ds = _set_as_coord(ds, "zShift_CELL_YLOW")
 
     ds = _create_regions_toroidal(ds)
 

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -364,7 +364,17 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
 
     # Get extra geometry information from grid file if it's not in the dump files
     ds = _add_vars_from_grid(
-        ds, grid, ["psixy", "Rxy", "Zxy"], optional_variables=["Bpxy", "Brxy", "Bzxy"]
+        ds,
+        grid,
+        ["psixy", "Rxy", "Zxy"],
+        optional_variables=[
+            "Bpxy",
+            "Brxy",
+            "Bzxy",
+            "poloidal_distance",
+            "poloidal_distance_ylow",
+            "total_poloidal_distance",
+        ],
     )
 
     if "t" in ds.dims:
@@ -402,6 +412,11 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
         ds = ds.set_coords(("R", "Z"))
     else:
         ds = ds.set_coords(("Rxy", "Zxy"))
+
+    if "poloidal_distance" in ds:
+        ds = ds.set_coords(
+            ["poloidal_distance", "poloidal_distance_ylow", "total_poloidal_distance"]
+        )
 
     # Add zShift as a coordinate, so that it gets interpolated along with a variable
     ds = _set_as_coord(ds, "zShift")

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -7,6 +7,7 @@ import numpy as np
 from .region import Region, _create_regions_toroidal, _create_single_region
 from .utils import (
     _add_attrs_to_var,
+    _make_1d_xcoord,
     _set_attrs_on_all_vars,
     _set_as_coord,
     _1d_coord_from_spacing,
@@ -139,21 +140,7 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
         updated_ds = updated_ds.drop_vars("t_array")
 
     if xcoord not in updated_ds.coords:
-        # Make index 'x' a coordinate, useful for handling global indexing
-        # Note we have to use the index value, not the value calculated from 'dx' because
-        # 'dx' may not be consistent between different regions (e.g. core and PFR).
-        # For some geometries xcoord may have already been created by
-        # add_geometry_coords, in which case we do not need this.
-        nx = updated_ds.dims[xcoord]
-
-        # can't use commented out version, uncommented one works around xarray bug
-        # removing attrs
-        # https://github.com/pydata/xarray/issues/4415
-        # https://github.com/pydata/xarray/issues/4393
-        # updated_ds = updated_ds.assign_coords(**{xcoord: np.arange(nx)})
-        updated_ds[xcoord] = (xcoord, np.arange(nx))
-
-        _add_attrs_to_var(updated_ds, xcoord)
+        _make_1d_xcoord(updated_ds)
 
     if ycoord not in updated_ds.coords:
         ny = updated_ds.dims[ycoord]

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -936,17 +936,28 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2, **kw
         )
         grid = grid.drop_dims(unrecognised_dims)
 
-    if not keep_xboundaries:
+    if keep_xboundaries:
+        # Set MXG so that it is picked up in metadata - needed for applying geometry,
+        # etc.
+        grid["MXG"] = mxg
+    else:
         xboundaries = mxg
         if xboundaries > 0:
             grid = grid.isel(x=slice(xboundaries, -xboundaries, None))
-    if not keep_yboundaries:
-        try:
-            yboundaries = int(grid["y_boundary_guards"])
-        except KeyError:
-            # y_boundary_guards variable not in grid file - older grid files
-            # never had y-boundary cells
-            yboundaries = 0
+        # Set MXG so that it is picked up in metadata - needed for applying geometry,
+        # etc.
+        grid["MXG"] = 0
+    try:
+        yboundaries = int(grid["y_boundary_guards"])
+    except KeyError:
+        # y_boundary_guards variable not in grid file - older grid files
+        # never had y-boundary cells
+        yboundaries = 0
+    if keep_yboundaries:
+        # Set MYG so that it is picked up in metadata - needed for applying geometry,
+        # etc.
+        grid["MYG"] = yboundaries
+    else:
         if yboundaries > 0:
             # Remove y-boundary cells from first divertor target
             grid = grid.isel(y=slice(yboundaries, -yboundaries, None))
@@ -963,6 +974,9 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2, **kw
                     compat="identical",
                     join="exact",
                 )
+        # Set MYG so that it is picked up in metadata - needed for applying geometry,
+        # etc.
+        grid["MYG"] = 0
 
     if "z" in grid_chunks and "z" not in grid.dims:
         del grid_chunks["z"]

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -260,6 +260,7 @@ def open_boutdataset(
             chunks=chunks,
             keep_xboundaries=keep_xboundaries,
             keep_yboundaries=keep_yboundaries,
+            **kwargs,
         )
     else:
         raise ValueError(f"internal error: unexpected input_type={input_type}")
@@ -899,7 +900,7 @@ def _get_limit(side, dim, keep_boundaries, boundaries, guards):
     return limit
 
 
-def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2):
+def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2, **kwargs):
     """
     Opens a single grid file. Implements slightly different logic for
     boundaries to deal with different conventions in a BOUT grid file.
@@ -917,7 +918,9 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2):
 
     if _is_path(datapath):
         gridfilepath = Path(datapath)
-        grid = xr.open_dataset(gridfilepath, engine=_check_filetype(gridfilepath))
+        grid = xr.open_dataset(
+            gridfilepath, engine=_check_filetype(gridfilepath), **kwargs
+        )
     else:
         grid = datapath
 

--- a/xbout/region.py
+++ b/xbout/region.py
@@ -1568,6 +1568,22 @@ def _concat_lower_guards(da, da_global, mxg, myg):
         da_lower[xcoord].data[...] = new_xcoord.data
         da_lower[ycoord].data[...] = new_ycoord.data
 
+    if "poloidal_distance" in da.coords and myg > 0:
+        # Special handling for core regions to deal with branch cut
+        if "core" in region.name:
+            # import pdb; pdb.set_trace()
+            # Try to detect whether there is branch cut at lower boundary: if there is
+            # poloidal_distance_ylow should be zero at the boundary of this region
+            poloidal_distance_bottom = da["poloidal_distance_ylow"].isel({ycoord: 0})
+            if all(abs(poloidal_distance_bottom) < 1.0e-16):
+                # Offset so that the poloidal_distance in da_lower is continuous from the
+                # poloidal_distance in this region.
+                # Expect there to be y-boundary cells in the Dataset, this will probably
+                # fail if there are not.
+                total_poloidal_distance = da["total_poloidal_distance"]
+                da_lower["poloidal_distance"] -= total_poloidal_distance
+                da_lower["poloidal_distance_ylow"] -= total_poloidal_distance
+
     save_regions = da.bout._regions
     da = xr.concat((da_lower, da), ycoord, join="exact")
     # xr.concat takes attributes from the first variable (for xarray>=0.15.0, keeps attrs
@@ -1667,6 +1683,24 @@ def _concat_upper_guards(da, da_global, mxg, myg):
         # da_upper = da_upper.assign_coords(**{xcoord: new_xcoord, ycoord: new_ycoord})
         da_upper[xcoord].data[...] = new_xcoord.data
         da_upper[ycoord].data[...] = new_ycoord.data
+
+    if "poloidal_distance" in da.coords and myg > 0:
+        # Special handling for core regions to deal with branch cut
+        if "core" in region.name:
+            # import pdb; pdb.set_trace()
+            # Try to detect whether there is branch cut at upper boundary: if there is
+            # poloidal_distance_ylow should be zero at the boundary of da_upper
+            poloidal_distance_bottom = da_upper["poloidal_distance_ylow"].isel(
+                {ycoord: 0}
+            )
+            if all(abs(poloidal_distance_bottom) < 1.0e-16):
+                # Offset so that the poloidal_distance in da_upper is continuous from the
+                # poloidal_distance in this region.
+                # Expect there to be y-boundary cells in the Dataset, this will probably
+                # fail if there are not.
+                total_poloidal_distance = da["total_poloidal_distance"]
+                da_upper["poloidal_distance"] += total_poloidal_distance
+                da_upper["poloidal_distance_ylow"] += total_poloidal_distance
 
     save_regions = da.bout._regions
     da = xr.concat((da, da_upper), ycoord, join="exact")

--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -17,9 +17,9 @@ def create_example_grid_file(tmp_path_factory):
     """
 
     # Create grid dataset
-    arr = np.arange(6).reshape(2, 3)
+    arr = np.arange(15).reshape(5, 3)
     grid = DataArray(data=arr, name="arr", dims=["x", "y"]).to_dataset()
-    grid["dy"] = DataArray(np.ones((2, 3)), dims=["x", "y"])
+    grid["dy"] = DataArray(np.ones((5, 3)), dims=["x", "y"])
     grid = grid.set_coords(["dy"])
 
     # Create temporary directory
@@ -44,7 +44,11 @@ class TestOpenGrid:
     def test_open_grid_extra_dims(self, create_example_grid_file, tmp_path_factory):
         example_grid = open_dataset(create_example_grid_file)
 
-        new_var = DataArray(name="new", data=[[1, 2], [8, 9]], dims=["x", "w"])
+        new_var = DataArray(
+            name="new",
+            data=[[1, 2], [8, 9], [16, 17], [27, 28], [37, 38]],
+            dims=["x", "w"],
+        )
 
         dodgy_grid_directory = tmp_path_factory.mktemp("dodgy_grid")
         dodgy_grid_path = dodgy_grid_directory.joinpath("dodgy_grid.nc")

--- a/xbout/tests/test_utils.py
+++ b/xbout/tests/test_utils.py
@@ -6,7 +6,7 @@ import xarray.testing as xrt
 
 from xbout.utils import (
     _set_attrs_on_all_vars,
-    _update_metadata_increased_resolution,
+    _update_metadata_increased_y_resolution,
     _1d_coord_from_spacing,
 )
 
@@ -54,7 +54,7 @@ class TestUtils:
             "MYSUB": 7,
         }
 
-        da = _update_metadata_increased_resolution(da, 3)
+        da = _update_metadata_increased_y_resolution(da, n=3)
 
         assert da.metadata["jyseps1_1"] == 5
         assert da.metadata["jyseps2_1"] == 8

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -142,17 +142,24 @@ def _update_metadata_increased_y_resolution(
     n : int, optional
         The factor to increase the y-resolution by. If n is not given, y-dependent
         metadata variables are set to -1, assuming they will be corrected later.
+    jyseps1_1, jyseps2_1, jyseps1_2, jyseps2_2, ny_inner, ny : int
+        Metadata variables for y-grid. Should not be passed if `n` is passed.
     """
 
     # Take deepcopy to ensure we do not alter metadata of other variables
     da.attrs["metadata"] = deepcopy(da.metadata)
 
-    def update_jyseps(name):
+    def update_jyseps(name, value):
         # If any jyseps<=0, need to leave as is
         if da.metadata[name] > 0:
             if n is None:
-                da.metadata[name] = -1
+                if value is None:
+                    da.metadata[name] = -1
+                else:
+                    da.metadata[name] = value
             else:
+                if value is not None:
+                    raise ValueError(f"n set, but value also passed to {name}")
                 da.metadata[name] = n * (da.metadata[name] + 1) - 1
 
     update_jyseps("jyseps1_1", jyseps1_1)
@@ -160,10 +167,15 @@ def _update_metadata_increased_y_resolution(
     update_jyseps("jyseps1_2", jyseps1_2)
     update_jyseps("jyseps2_2", jyseps2_2)
 
-    def update_ny(name):
+    def update_ny(name, value):
         if n is None:
-            da.metadata[name] = -1
+            if value is None:
+                da.metadata[name] = -1
+            else:
+                da.metadata[name] = value
         else:
+            if value is not None:
+                raise ValueError(f"n set, but value also passed to {name}")
             da.metadata[name] = n * da.metadata[name]
 
     update_ny("ny", ny)

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -120,7 +120,17 @@ def _update_metadata_increased_x_resolution(da, *, ixseps1=None, ixseps2=None, n
     return da
 
 
-def _update_metadata_increased_y_resolution(da, n):
+def _update_metadata_increased_y_resolution(
+    da,
+    *,
+    n=None,
+    jyseps1_1=None,
+    jyseps2_1=None,
+    jyseps1_2=None,
+    jyseps2_2=None,
+    ny_inner=None,
+    ny=None,
+):
     """
     Update the metadata variables to account for a y-direction resolution increased by a
     factor n.
@@ -129,8 +139,9 @@ def _update_metadata_increased_y_resolution(da, n):
     ----------
     da : DataArray
         The variable to update
-    n : int
-        The factor to increase the y-resolution by
+    n : int, optional
+        The factor to increase the y-resolution by. If n is not given, y-dependent
+        metadata variables are set to -1, assuming they will be corrected later.
     """
 
     # Take deepcopy to ensure we do not alter metadata of other variables
@@ -139,19 +150,25 @@ def _update_metadata_increased_y_resolution(da, n):
     def update_jyseps(name):
         # If any jyseps<=0, need to leave as is
         if da.metadata[name] > 0:
-            da.metadata[name] = n * (da.metadata[name] + 1) - 1
+            if n is None:
+                da.metadata[name] = -1
+            else:
+                da.metadata[name] = n * (da.metadata[name] + 1) - 1
 
-    update_jyseps("jyseps1_1")
-    update_jyseps("jyseps2_1")
-    update_jyseps("jyseps1_2")
-    update_jyseps("jyseps2_2")
+    update_jyseps("jyseps1_1", jyseps1_1)
+    update_jyseps("jyseps2_1", jyseps2_1)
+    update_jyseps("jyseps1_2", jyseps1_2)
+    update_jyseps("jyseps2_2", jyseps2_2)
 
     def update_ny(name):
-        da.metadata[name] = n * da.metadata[name]
+        if n is None:
+            da.metadata[name] = -1
+        else:
+            da.metadata[name] = n * da.metadata[name]
 
-    update_ny("ny")
-    update_ny("ny_inner")
-    update_ny("MYSUB")
+    update_ny("ny", ny)
+    update_ny("ny_inner", ny_inner)
+    update_ny("MYSUB", None)
 
     # Update attrs of coordinates to be consistent with da
     for coord in da.coords:

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -344,28 +344,17 @@ def _split_into_restarts(ds, variables, savepath, nxpe, nype, tind, prefix, over
 
     ny_inner = ds.metadata["ny_inner"]
 
-    # These variables need to be saved to restart files in addition to evolving ones
-    restart_metadata_vars = [
-        "zperiod",
-        "MZSUB",
-        "MXG",
-        "MYG",
-        "MZG",
-        "nx",
-        "ny",
-        "nz",
-        "MZ",
-        "NZPE",
-        "ixseps1",
-        "ixseps2",
-        "jyseps1_1",
-        "jyseps2_1",
-        "jyseps1_2",
-        "jyseps2_2",
-        "ny_inner",
-        "ZMAX",
-        "ZMIN",
-        "BOUT_VERSION",
+    # These metadata variables are created by xBOUT, so should not be saved to restart
+    # files
+    restart_exclude_metadata_vars = [
+        "bout_tdim",
+        "bout_xdim",
+        "bout_ydim",
+        "bout_zdim",
+        "fine_interpolation_factor",
+        "is_restart",
+        "keep_xboundaries",
+        "keep_yboundaries",
     ]
 
     if variables is None:
@@ -455,8 +444,12 @@ def _split_into_restarts(ds, variables, savepath, nxpe, nype, tind, prefix, over
                 data_variable.attrs = {}
 
                 restart_ds[v] = data_variable
-            for v in restart_metadata_vars:
-                restart_ds[v] = ds.metadata[v]
+            for v in ds.metadata:
+                if v not in restart_exclude_metadata_vars:
+                    restart_ds[v] = ds.metadata[v]
+
+            # These variables need to be altered, because they depend on the number of
+            # files and/or the rank of this file.
             restart_ds["MXSUB"] = mxsub
             restart_ds["MYSUB"] = mysub
             restart_ds["NXPE"] = nxpe

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -396,8 +396,9 @@ def _split_into_restarts(ds, variables, savepath, nxpe, nype, tind, prefix, over
         "g_13",
         "g_23",
         "J",
+        "zShift",
     ]:
-        if v not in variables:
+        if v not in variables and v in ds:
             variables.append(v)
 
     # number of points in the domain on each processor, not including guard or boundary

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -463,6 +463,9 @@ def _split_into_restarts(ds, variables, savepath, nxpe, nype, tind, prefix, over
             restart_ds["PE_XIND"] = xproc
             restart_ds["PE_YIND"] = yproc
             restart_ds["hist_hi"] = hist_hi
+            restart_ds["PE_XIND"] = xproc
+            restart_ds["PE_YIND"] = yproc
+            restart_ds["MYPE"] = yproc * nxpe + xproc
 
             # tt is the simulation time where the restart happens
             restart_ds["tt"] = tt


### PR DESCRIPTION
Add methods `BoutDataset.interpolate_to_new_grid()`/`BoutDataArray.interpolate_to_new_grid()` to interpolate a Dataset or DataArray to a new grid. The new grid should be defined by a new grid file created using the same equilibrium as the original grid. Interpolation is done first radially (using psi as the coordinate) and then in the parallel direction (using poloidal distance along a psi-contour as the coordinate).

Also includes a new method `BoutData*.interpolate_radial()`, for radial interpolation, which is used inside `interpolate_to_new_grid()`.

Requires grid files generated using a version of hypnotoad including the changes in this PR, which saves poloidal distances to the grid files: https://github.com/boutproject/hypnotoad/pull/116.

Similar functionality to https://github.com/boutproject/boutdata/pull/56, but interpolates in radial/parallel directions rather than R/Z. Using radial/parallel may be an advantage when interpolating 3d restart files.

Todo:
* [ ] Unit test all functionality of utility functions `_update_metadata_increased_x_resolution()` and `_update_metadata_increased_y_resolution()`.
* [ ] Unit test `_make_1d_xcoord()`.
* [ ] Tests for `interpolate_radial()`. These could probably follow the pattern of those already existing for interpolate_parallel.
* [ ] Tests for `interpolate_to_new_grid()`.
* [ ] Option to do radial interpolation in field-aligned coordinates. Probably only suitable if most of the turbulence is around the outboard midplane, but may result in a smaller initial transient when restarting on the new grid due to better field-alignment of the perturbations.
* [ ] Interpolation in the toroidal direction.