### PR TITLE
Fix calculation of `hist_hi` in BoutDataset.to_restart()

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -802,7 +802,13 @@ class BoutDatasetAccessor:
             Number of processors in the y-direction. If not given, keep the number used
             for the original simulation
         tind : int, default -1
-            Time-index of the slice to write to the restart files
+            Time-index of the slice to write to the restart files. Note, when creating
+            restart files from 'dump' files it is recommended to open the Dataset using
+            the full time range and use the `tind` argument here, rather than selecting
+            a time point manually, so that the calculation of `hist_hi` in the output
+            can be correct (which requires knowing the existing value of `hist_hi`
+            (output step count at the end of the simulation), `tind` and the total
+            number of time points in the current output data).
         prefix : str, default "BOUT.restart"
             Prefix to use for names of restart files
         overwrite : bool, default False

--- a/xbout/calc/tests/test_turbulence.py
+++ b/xbout/calc/tests/test_turbulence.py
@@ -19,7 +19,7 @@ class TestRootMeanSquare:
         dat = np.array([5, 7, 3.2, -1, -4.4])
         orig = DataArray(dat, dims=["x"])
 
-        sum_squares = np.sum(dat ** 2)
+        sum_squares = np.sum(dat**2)
         mean_squares = sum_squares / dat.size
         rootmeansquare = np.sqrt(mean_squares)
 
@@ -31,7 +31,7 @@ class TestRootMeanSquare:
     def test_reduce_2d(self, dim, axis):
         dat = np.array([[5, 7, 3.2, -1, -4.4], [-1, -2.5, 0, 8, 3.0]])
         orig = DataArray(dat, dims=["x", "t"])
-        sum_squares = np.sum(dat ** 2, axis=axis)
+        sum_squares = np.sum(dat**2, axis=axis)
         mean_squares = sum_squares / dat.shape[axis]
         rootmeansquare = np.sqrt(mean_squares)
 
@@ -44,7 +44,7 @@ class TestRootMeanSquare:
         orig = DataArray(dat, dims=["x", "t"])
         chunked = orig.chunk({"x": 1})
         axis = 1
-        sum_squares = np.sum(dat ** 2, axis=axis)
+        sum_squares = np.sum(dat**2, axis=axis)
         mean_squares = sum_squares / dat.shape[axis]
         rootmeansquare = np.sqrt(mean_squares)
 

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -81,7 +81,7 @@ def _normalise_time_coord(time_values):
     tmax = time_values.max()
     if tmax < 1.0e-2 or tmax > 1.0e6:
         scale_pow = int(np.floor(np.log10(tmax)))
-        scale_factor = 10 ** scale_pow
+        scale_factor = 10**scale_pow
         time_values = time_values / scale_factor
         suffix = f"e{scale_pow}"
     else:

--- a/xbout/tests/test_boutdataarray.py
+++ b/xbout/tests/test_boutdataarray.py
@@ -602,7 +602,7 @@ class TestBoutDataArrayMethods:
 
         def f(t):
             t = np.sin(t)
-            return t ** 3 - t ** 2 + t - 1.0
+            return t**3 - t**2 + t - 1.0
 
         n.data = f(theta).broadcast_like(n)
 
@@ -664,7 +664,7 @@ class TestBoutDataArrayMethods:
 
         def f(t):
             t = np.sin(t)
-            return t ** 3 - t ** 2 + t - 1.0
+            return t**3 - t**2 + t - 1.0
 
         n.data = f(theta).broadcast_like(n)
 
@@ -712,7 +712,7 @@ class TestBoutDataArrayMethods:
 
         def f(t):
             t = np.sin(t)
-            return t ** 3 - t ** 2 + t - 1.0
+            return t**3 - t**2 + t - 1.0
 
         n.data = f(theta).broadcast_like(n)
 
@@ -761,7 +761,7 @@ class TestBoutDataArrayMethods:
 
         def f(t):
             t = np.sin(3.0 * t)
-            return t ** 3 - t ** 2 + t - 1.0
+            return t**3 - t**2 + t - 1.0
 
         n.data = f(theta).broadcast_like(n)
 
@@ -834,7 +834,7 @@ class TestBoutDataArrayMethods:
 
         def f_y(t):
             t = np.sin(3.0 * t)
-            return t ** 3 - t ** 2 + t - 1.0
+            return t**3 - t**2 + t - 1.0
 
         f = f_y(theta) * (x + 1.0)
 
@@ -886,7 +886,7 @@ class TestBoutDataArrayMethods:
 
         def f_y(t):
             t = np.sin(t)
-            return t ** 3 - t ** 2 + t - 1.0
+            return t**3 - t**2 + t - 1.0
 
         f = f_y(theta) * (x + 1.0)
 

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -1204,14 +1204,14 @@ class TestBoutDatasetMethods:
         ds["dy"].data[...] = 0.2
         ds["dz"] = 0.3
         tfunc = 1.5 * t
-        xfunc = x ** 2
-        yfunc = 10.0 * y - y ** 2
-        zfunc = 2.0 * z ** 2 - 30.0 * z
+        xfunc = x**2
+        yfunc = 10.0 * y - y**2
+        zfunc = 2.0 * z**2 - 30.0 * z
         ds["n"].data[...] = tfunc * xfunc * yfunc * zfunc
         tintegral = 48.0
         xintegral = 1000.0 / 3.0
-        yintegral = 5.0 * 22.0 ** 2 - 22.0 ** 3 / 3.0
-        zintegral = 2.0 * 36.0 ** 3 / 3.0 - 15.0 * 36.0 ** 2
+        yintegral = 5.0 * 22.0**2 - 22.0**3 / 3.0
+        zintegral = 2.0 * 36.0**3 / 3.0 - 15.0 * 36.0**2
         npt.assert_allclose(
             ds.bout.integrate_midpoints("n", dims="t"),
             (tintegral * xfunc * yfunc * zfunc).squeeze(),
@@ -1429,28 +1429,28 @@ class TestBoutDatasetMethods:
         # Default is to integrate over all spatial dimensions
         npt.assert_allclose(
             ds.bout.integrate_midpoints("n"),
-            2.0 * np.pi * R * np.pi * (router ** 2 - rinner ** 2),
+            2.0 * np.pi * R * np.pi * (router**2 - rinner**2),
             rtol=1.0e-5,
             atol=0.0,
         )
         # Pass all spatial dims explicitly
         npt.assert_allclose(
             ds.bout.integrate_midpoints("n", dims=["x", "theta", "zeta"]),
-            2.0 * np.pi * R * np.pi * (router ** 2 - rinner ** 2),
+            2.0 * np.pi * R * np.pi * (router**2 - rinner**2),
             rtol=1.0e-5,
             atol=0.0,
         )
         # Integrate in time too
         npt.assert_allclose(
             ds.bout.integrate_midpoints("n", dims=["t", "x", "theta", "zeta"]),
-            T_total * 2.0 * np.pi * R * np.pi * (router ** 2 - rinner ** 2),
+            T_total * 2.0 * np.pi * R * np.pi * (router**2 - rinner**2),
             rtol=1.0e-5,
             atol=0.0,
         )
         # Integrate in time using dims=...
         npt.assert_allclose(
             ds.bout.integrate_midpoints("n", dims=...),
-            T_total * 2.0 * np.pi * R * np.pi * (router ** 2 - rinner ** 2),
+            T_total * 2.0 * np.pi * R * np.pi * (router**2 - rinner**2),
             rtol=1.0e-5,
             atol=0.0,
         )
@@ -1459,7 +1459,7 @@ class TestBoutDatasetMethods:
             ds.bout.integrate_midpoints(
                 "n", dims=["t", "x", "theta", "zeta"], cumulative_t=True
             ),
-            T_cumulative * 2.0 * np.pi * R * np.pi * (router ** 2 - rinner ** 2),
+            T_cumulative * 2.0 * np.pi * R * np.pi * (router**2 - rinner**2),
             rtol=1.0e-5,
             atol=0.0,
         )
@@ -1496,14 +1496,14 @@ class TestBoutDatasetMethods:
         # router and circle with radius rinner, pi*(router**2 - rinner**2)
         npt.assert_allclose(
             ds.bout.integrate_midpoints("n", dims=["x", "theta"]),
-            np.pi * (router ** 2 - rinner ** 2),
+            np.pi * (router**2 - rinner**2),
             rtol=1.0e-5,
             atol=0.0,
         )
         # Integrate in time too
         npt.assert_allclose(
             ds.bout.integrate_midpoints("n", dims=["t", "x", "theta"]),
-            T_total * np.pi * (router ** 2 - rinner ** 2),
+            T_total * np.pi * (router**2 - rinner**2),
             rtol=1.0e-5,
             atol=0.0,
         )
@@ -1514,7 +1514,7 @@ class TestBoutDatasetMethods:
             ),
             T_cumulative[:, np.newaxis]
             * np.pi
-            * (router ** 2 - rinner ** 2)
+            * (router**2 - rinner**2)
             * np.ones(ds.sizes["zeta"])[np.newaxis, :],
             rtol=1.0e-5,
             atol=0.0,
@@ -1651,9 +1651,9 @@ class TestBoutDatasetMethods:
         #                  / (cos(theta/2)**2 + (1-r/R0)/(1+r/R0)*sin(theta/2)**2)**2
         #               )
         # field line length is int_{0}^{2 pi} dl
-        a = r ** 2
+        a = r**2
         c = (1 - r / R) / (1 + r / R)
-        b = q ** 2 * c
+        b = q**2 * c
 
         def func(theta):
             return np.sqrt(

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -2110,12 +2110,14 @@ class TestSaveRestart:
         nxpe = 3
         nype = 2
 
+        nt = 6
+
         path = bout_xyt_example_files(
             tmp_path_factory,
             nxpe=nxpe,
             nype=nype,
             nt=1,
-            lengths=[6, 4, 4, 7],
+            lengths=[nt, 4, 4, 7],
             guards={"x": 2, "y": 2},
             write_to_disk=True,
         )
@@ -2170,7 +2172,10 @@ class TestSaveRestart:
                         xrt.assert_equal(restart_ds[v], check_ds[v])
                     else:
                         if v == "hist_hi":
-                            assert restart_ds[v].values == -1
+                            if t >= 0:
+                                assert restart_ds[v].values == t
+                            else:
+                                assert restart_ds[v].values == nt - 1
                         elif v == "tt":
                             assert restart_ds[v].values == t_array
                         elif v not in rank_dependent_vars:
@@ -2183,12 +2188,14 @@ class TestSaveRestart:
         nxpe = 2
         nype = 4
 
+        nt = 6
+
         path = bout_xyt_example_files(
             tmp_path_factory,
             nxpe=nxpe_in,
             nype=nype_in,
             nt=1,
-            lengths=[6, 4, 4, 7],
+            lengths=[nt, 4, 4, 7],
             guards={"x": 2, "y": 2},
             write_to_disk=True,
         )
@@ -2237,7 +2244,7 @@ class TestSaveRestart:
                         if v in ["NXPE", "NYPE", "MXSUB", "MYSUB"]:
                             pass
                         elif v == "hist_hi":
-                            assert restart_ds[v].values == -1
+                            assert restart_ds[v].values == nt - 1
                         elif v == "tt":
                             assert restart_ds[v].values == t_array
                         elif v not in rank_dependent_vars:
@@ -2253,13 +2260,15 @@ class TestSaveRestart:
         nxpe = 1
         nype = 12
 
+        nt = 6
+
         path = bout_xyt_example_files(
             tmp_path_factory,
             nxpe=nxpe_in,
             nype=nype_in,
             nt=1,
             guards={"x": 2, "y": 2},
-            lengths=(6, 5, 4, 7),
+            lengths=(nt, 5, 4, 7),
             topology="upper-disconnected-double-null",
             write_to_disk=True,
         )
@@ -2308,7 +2317,7 @@ class TestSaveRestart:
                         if v in ["NXPE", "NYPE", "MXSUB", "MYSUB"]:
                             pass
                         elif v == "hist_hi":
-                            assert restart_ds[v].values == -1
+                            assert restart_ds[v].values == nt - 1
                         elif v == "tt":
                             assert restart_ds[v].values == t_array
                         elif v not in rank_dependent_vars:

--- a/xbout/tests/test_load.py
+++ b/xbout/tests/test_load.py
@@ -713,8 +713,10 @@ def create_bout_ds(
     else:
         ds["dz"] = 2.0 * np.pi / nz
 
-    ds["iteration"] = t_length
+    ds["iteration"] = t_length - 1
+    ds["hist_hi"] = t_length - 1
     ds["t_array"] = DataArray(np.arange(t_length, dtype=float) * 10.0, dims="t")
+    ds["tt"] = ds["t_array"][-1]
 
     # xarray adds this encoding when opening a file. Emulate here as it may be used to
     # get the file number
@@ -793,6 +795,8 @@ METADATA_VARS = [
     "MXSUB",
     "MYSUB",
     "MZSUB",
+    "hist_hi",
+    "iteration",
     "ixseps1",
     "ixseps2",
     "jyseps1_1",
@@ -800,6 +804,7 @@ METADATA_VARS = [
     "jyseps2_1",
     "jyseps2_2",
     "ny_inner",
+    "tt",
     "zperiod",
     "ZMIN",
     "ZMAX",

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -400,7 +400,15 @@ def _split_into_restarts(ds, variables, savepath, nxpe, nype, tind, prefix, over
     final_hist_hi = ds.metadata.get("hist_hi", -1)
     if "t" in ds.dims:
         nt = ds.sizes["t"]
-        hist_hi = final_hist_hi - (nt - 1 - tind)
+        if tind < 0:
+            absolute_tind = tind + nt
+            if absolute_tind < 0:
+                absolute_tind = 0
+        elif tind >= nt:
+            absolute_tind = nt - 1
+        else:
+            absolute_tind = tind
+        hist_hi = final_hist_hi - (nt - 1 - absolute_tind)
         if hist_hi < 0:
             hist_hi = -1
     else:

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -397,16 +397,18 @@ def _split_into_restarts(ds, variables, savepath, nxpe, nype, tind, prefix, over
 
     # hist_hi represents the number of iterations before the restart. Attempt to
     # reconstruct here
-    iteration = ds.metadata.get("iteration", -1)
+    final_hist_hi = ds.metadata.get("hist_hi", -1)
     if "t" in ds.dims:
         nt = ds.sizes["t"]
-        hist_hi = iteration - (nt - tind)
+        hist_hi = final_hist_hi - (nt - 1 - tind)
         if hist_hi < 0:
             hist_hi = -1
-    elif "hist_hi" in ds.metadata:
-        hist_hi = ds.metadata["hist_hi"]
     else:
-        hist_hi = -1
+        # Either input is a set of restart files, in which case we should just use
+        # `hist_hi` if it exists, or the user has already selected a single time-point,
+        # and the best guess we have left is the existing `hist_hi` (although it might
+        # not be right).
+        hist_hi = final_hist_hi
 
     has_second_divertor = ds.metadata["jyseps2_1"] != ds.metadata["jyseps1_2"]
 


### PR DESCRIPTION
Have to use `hist_hi` (total number of output steps including all restarts), not `iteration` (total number of output steps in the latest
run) to reconstruct `hist_hi` for restart files.

Note: in cases where the BOUT++ simulation used a `Monitor` that is called more frequently than the output monitor, `hist_hi` was incorrect until this PR was merged: https://github.com/boutproject/BOUT-dev/pull/2534. In simulations affected by that bug, it's not really possible to get `hist_hi` 'right'.