### PR TITLE
Add "is_restart" to metadata when reloading old data

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -203,6 +203,10 @@ def open_boutdataset(
 
         # Restore metadata from attrs
         metadata = attrs_to_dict(ds, "metadata")
+        if "is_restart" not in metadata:
+            # Loading data that was saved with a version of xbout from before
+            # "is_restart" was added, so need to add it to the metadata.
+            metadata["is_restart"] = int(is_restart)
         ds.attrs["metadata"] = metadata
         # Must do this for all variables and coordinates in dataset too
         for da in chain(ds.data_vars.values(), ds.coords.values()):


### PR DESCRIPTION
If data was saved by xbout before "is_restart", etc., were implemented, then "is_restart" will be missing from its metadata, causing errors when calling apply_geometry(). Need to check if "is_restart" is present, and add it if not.