### PR TITLE
Allow to pass directory relative to which the grid is.

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -311,6 +311,9 @@ def open_boutdataset(
             print("Applying {} geometry conventions".format(geometry))
 
         if _is_dir(gridfilepath):
+            assert ds.options.get(
+                "grid", None
+            ), "specified gridfilepath as directory, but grid not in options"
             gridfilepath += "/" + ds.options["grid"]
         if gridfilepath is not None:
             grid = _open_grid(

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -311,10 +311,12 @@ def open_boutdataset(
             print("Applying {} geometry conventions".format(geometry))
 
         if _is_dir(gridfilepath):
-            assert ds.options.get(
-                "grid", None
-            ), "specified gridfilepath as directory, but grid not in options"
-            gridfilepath += "/" + ds.options["grid"]
+            if "grid" in ds.options:
+                gridfilepath += "/" + ds.options["grid"]
+            else:
+                warn(
+                    "gridfilepath set to a directory, but no grid used in simulation. Continuing without grid."
+                )
         if gridfilepath is not None:
             grid = _open_grid(
                 gridfilepath,

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -11,7 +11,13 @@ from numpy import unique
 from natsort import natsorted
 
 from . import geometries
-from .utils import _set_attrs_on_all_vars, _separate_metadata, _check_filetype, _is_path
+from .utils import (
+    _set_attrs_on_all_vars,
+    _separate_metadata,
+    _check_filetype,
+    _is_path,
+    _is_dir,
+)
 
 
 _BOUT_PER_PROC_VARIABLES = [
@@ -302,6 +308,8 @@ def open_boutdataset(
         if info:
             print("Applying {} geometry conventions".format(geometry))
 
+        if _is_dir(gridfilepath):
+            gridfilepath += "/" + ds.options["grid"]
         if gridfilepath is not None:
             grid = _open_grid(
                 gridfilepath,

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -127,6 +127,8 @@ def open_boutdataset(
     gridfilepath : str, optional
         The path to a grid file, containing any variables needed to apply the geometry
         specified by the 'geometry' option, which are not contained in the dump files.
+        This may either be the path of the grid file itself, or the directory
+        relative to which the grid from the settings file can be found.
     keep_xboundaries : bool, optional
         If true, keep x-direction boundary cells (the cells past the physical
         edges of the grid, where boundary conditions are set); increases the

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from itertools import chain
 from pathlib import Path
+import os
 
 import numpy as np
 import xarray as xr
@@ -44,6 +45,10 @@ def _is_path(p):
         return True
     except TypeError:
         return False
+
+
+def _is_dir(p):
+    return os.path.isdir(p)
 
 
 def _separate_metadata(ds):

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -48,7 +48,7 @@ def _is_path(p):
 
 
 def _is_dir(p):
-    return os.path.isdir(p)
+    return _is_path(p) and os.path.isdir(p)
 
 
 def _separate_metadata(ds):


### PR DESCRIPTION
This allows to not having to remember which grid was used for a simulation, as that is already part of the options.