### PR TITLE
Add hook for submodules for extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ venv.bak/
 
 # Generated files:
 _version.py
+
+# Submodules
+xbout/modules/*/

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -12,6 +12,7 @@ from natsort import natsorted
 
 from . import geometries
 from .utils import _set_attrs_on_all_vars, _separate_metadata, _check_filetype, _is_path
+from .modules import avail as modules
 
 
 _BOUT_PER_PROC_VARIABLES = [
@@ -239,6 +240,14 @@ def open_boutdataset(
             ds = geometries.apply_geometry(ds, ds.attrs["geometry"])
         else:
             ds = geometries.apply_geometry(ds, None)
+
+        matches = [module for module in modules if module.does_match(ds)]
+        if len(matches):
+            assert (
+                len(matches) == 1
+            ), f"More than module claim to be able to read the dataset: {[x.__file__ for x in matches]}"
+            (match,) = matches
+            ds = match.update(ds)
 
         if info == "terse":
             print("Read in dataset from {}".format(str(Path(datapath))))

--- a/xbout/modules/__init__.py
+++ b/xbout/modules/__init__.py
@@ -1,0 +1,18 @@
+import pkgutil
+import importlib
+
+avail = []
+
+
+class skeleton:
+    name = "not set"
+
+    def does_match(self, ds):
+        return False
+
+    def update(self, ds):
+        return ds
+
+
+for module in pkgutil.iter_modules(__path__):
+    importlib.import_module(f"xbout.modules.{module.name}")


### PR DESCRIPTION
Alternative to xHERMES :-)

It allows to use xBOUT for loading any BOUT++ simulation. That way I don't have to think what simulation has generated the data. I just load it, and as long as an appropriate extension is installed, e.g. https://github.com/dschwoerer/xbout.modules.hermes for hermes (as a proof of concept).

After all, **I** don't want to do something hermes specific. I just want to have decent units ...

If there are some post-processing that would only ever a STORM user do, sure.

But I rather feel the other way round. I would like to have the same interface for my EMC3 simulations and my BOUT++ simulations. But the ones are `ds.emc3.*` the others `ds.bout.*` - I want to avoid this to go worse ...

Note that there is a pip bug with submodules and editable installs: https://github.com/pypa/pip/issues/11467