### PR TITLE
Remove unnecessary (and possibly wrong) .data when y_fine is used

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -352,7 +352,7 @@ class BoutDataArrayAccessor:
         da[ycoord].attrs = {}
 
         da = da.interp(
-            {ycoord: y_fine.data},
+            {ycoord: y_fine},
             assume_sorted=True,
             method=method,
             kwargs={"fill_value": "extrapolate"},


### PR DESCRIPTION
The use of `y_fine.data` rather than `y_fine` is probably left over from an early implementation where `y_fine` was a `DataArray` rather than a numpy array.