### PR TITLE
logscale for animate_line()

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -1239,10 +1239,15 @@ class BoutDatasetAccessor:
                             aspect=this_aspect,
                             vmin=this_vmin,
                             vmax=this_vmax,
+                            logscale=this_logscale,
                             **this_kwargs,
                         )
                     )
                 else:
+                    if this_vmin is None:
+                        this_vmin = min(np.min(w).values for w in v)
+                    if this_vmax is None:
+                        this_vmax = max(np.max(w).values for w in v)
                     for w in v:
                         blocks.append(
                             animate_line(
@@ -1254,6 +1259,7 @@ class BoutDatasetAccessor:
                                 aspect=this_aspect,
                                 vmin=this_vmin,
                                 vmax=this_vmax,
+                                logscale=this_logscale,
                                 label=w.name,
                                 **this_kwargs,
                             )

--- a/xbout/plotting/animate.py
+++ b/xbout/plotting/animate.py
@@ -520,6 +520,7 @@ def animate_line(
     axis_coords=None,
     vmin=None,
     vmax=None,
+    logscale=False,
     fps=10,
     save_as=None,
     sep_pos=None,
@@ -555,6 +556,12 @@ def animate_line(
     vmax : float, optional
         Maximum value to use for colorbar. Default is to use maximum value of
         data across whole timeseries.
+    logscale : bool or float, optional
+        If True, default to a logarithmic color scale instead of a linear one.
+        If a non-bool type is passed it is treated as a float used to set the linear
+        threshold of a symmetric logarithmic scale as
+        linthresh=min(abs(vmin),abs(vmax))*logscale, defaults to 1e-5 if True is
+        passed.
     fps : int, optional
         Frames per second of resulting gif
     save_as : True or str, optional
@@ -639,6 +646,17 @@ def animate_line(
     if "units" in data.attrs:
         y_label = y_label + f" [{data.units}]"
     ax.set_ylabel(y_label)
+
+    if logscale:
+        if vmin * vmax > 0.0:
+            ax.set_yscale("log")
+        else:
+            if not isinstance(logscale, bool):
+                linear_scale = logscale
+            else:
+                linear_scale = 1.0e-5
+            linear_threshold = min(abs(vmin), abs(vmax)) * linear_scale
+            ax.set_yscale("symlog", linthresh=linear_threshold)
 
     # Plot separatrix
     if sep_pos:


### PR DESCRIPTION
Implement the `logscale` option in `animate_line()`. Means `logscale` works for line plots in `BoutDataset.animate_list()`.