### PR TITLE
Require netcdf4-1.6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     natsort>=5.5.0
     matplotlib>=3.1.1,!=3.3.0,!=3.3.1,!=3.3.2
     animatplot>=0.4.2
-    netcdf4>=1.4.0
+    netcdf4>=1.6.0
     Pillow>=6.1.0
     importlib-metadata; python_version < "3.8"
 include_package_data = True


### PR DESCRIPTION
With netcdf4-1.5.3 (sometimes?) get errors when BOUT++ reads files produced by `from_restart()`, so require newer version.

Fixes #256.