### PR TITLE
Require netcdf4-1.5.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ setup_requires =
     setuptools_scm[toml]>=3.4
     setuptools_scm_git_archive
 install_requires =
-    xarray>=0.18.0,!=2022.9.0,!=2022.10.0
+    xarray>=0.18.0,!=2022.9.0,!=2022.10.0,!=2022.11.0
     boutdata>=0.1.4
     dask[array]>=2.10.0
     gelidum>=0.5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     natsort>=5.5.0
     matplotlib>=3.1.1,!=3.3.0,!=3.3.1,!=3.3.2
     animatplot>=0.4.2
-    netcdf4>=1.4.0
+    netcdf4>=1.5.6
     Pillow>=6.1.0
     importlib-metadata; python_version < "3.8"
 include_package_data = True


### PR DESCRIPTION
With netcdf4 versions 1.5.3 to 1.5.5, (sometimes?) get errors when BOUT++ reads files produced by `to_restart()`, so require newer version.

Fixes #256.