### PR TITLE
Fix writing of `run_id` by `to_restart()`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ setup_requires =
     setuptools_scm[toml]>=3.4
     setuptools_scm_git_archive
 install_requires =
-    xarray>=0.18.0,!=2022.9.0,!=2022.10.0
+    xarray>=0.18.0,!=2022.9.0,!=2022.10.0,!=2022.11.0
     boutdata>=0.1.4
     dask[array]>=2.10.0
     gelidum>=0.5.3

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -488,7 +488,13 @@ def _split_into_restarts(ds, variables, savepath, nxpe, nype, tind, prefix, over
                 restart_ds[v] = data_variable
             for v in ds.metadata:
                 if v not in restart_exclude_metadata_vars:
-                    restart_ds[v] = ds.metadata[v]
+                    value = ds.metadata[v]
+
+                    if isinstance(value, str):
+                        # Write strings as byte-strings so BOUT++ can read them
+                        value = value.encode()
+
+                    restart_ds[v] = value
 
             # These variables need to be altered, because they depend on the number of
             # files and/or the rank of this file.


### PR DESCRIPTION
Convert `str` to byte-strings before writing to file in `to_restart()`. Need to write char-arrays rather than 'strings' so that BOUT++ can read them.

Fixes #256.