### PR TITLE
No CI failure when coverage upload fails

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,7 +20,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', 3.x]
         pip-packages:
           - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray numpy>=1.16.0"
       fail-fast: false

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,8 +43,6 @@ jobs:
         pytest -v --long --cov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true
 
 
   pytest-min-versions:
@@ -76,8 +74,6 @@ jobs:
         pytest -v --long --cov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true
 
 
   # Need to tidy up the things that flake8 finds before we activate this

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', 3.x]
         pip-packages:
           - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray numpy>=1.16.0"
       fail-fast: false

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -43,8 +43,6 @@ jobs:
         pytest -v --long --cov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true
 
 
   pytest-min-versions:
@@ -76,8 +74,6 @@ jobs:
         pytest -v --long --cov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true
 
 
   # Need to tidy up the things that flake8 finds before we activate this

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, '3.10']
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata xarray numpy>=1.16.0"
+          - "setuptools pip pytest boutdata xarray numpy>=1.16.0"
       fail-fast: true
 
     steps:
@@ -34,11 +34,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest -v --long --cov
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true
+        pytest -v --long
 
 
   pytest-min-versions:
@@ -49,7 +45,7 @@ jobs:
       matrix:
         python-version: [3.8]
         pip-packages:
-          - "setuptools pip pytest pytest-cov coverage codecov boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==7.2.0" # test with oldest supported version of packages. Note, using numpy==1.18.0 as a workaround because numpy==1.17.0 is not supported on Python-3.7, even though we should currently support numpy==1.17.0.
+          - "setuptools pip pytest boutdata==0.1.4 xarray==0.18.0 dask==2.10.0 numpy==1.18.0 natsort==5.5.0 matplotlib==3.1.1 animatplot==0.4.2 netcdf4==1.4.2 Pillow==7.2.0" # test with oldest supported version of packages. Note, using numpy==1.18.0 as a workaround because numpy==1.17.0 is not supported on Python-3.7, even though we should currently support numpy==1.17.0.
       fail-fast: true
 
     steps:
@@ -67,11 +63,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest -v --long --cov
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true
+        pytest -v --long
 
 
   # Need to tidy up the things that flake8 finds before we activate this

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -14,7 +14,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', 3.x]
         pip-packages:
           - "setuptools pip pytest boutdata xarray numpy>=1.16.0"
       fail-fast: true


### PR DESCRIPTION
[Updated] The upload to Codecov fails intermittently, which is annoying:
* Remove code coverage checks from 'publish' CI job - there is no need to check coverage for the 'publish' job as it has already been checked when merging a PR to `master`.
* Remove `fail_ci_if_error: true` setting from the other CI jobs, so the CI runs still 'pass' even if the upload fails. The jobs can be re-run manually if the coverage upload is needed.

Do people find the test coverage statistics from Codecov useful? I find I never really look at them, and so just get annoyed when the upload fails and I have to re-run CI jobs. If they're not useful, maybe we should just remove them everywhere?