### PR TITLE
Do not call mlab.figure() if mayavi_figure_args=None

### DIFF
--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -692,9 +692,8 @@ def plot3d(
             )
 
         if mayavi_figure is None:
-            if mayavi_figure_args is None:
-                mayavi_figure_args = {}
-            mlab.figure(**mayavi_figure_args)
+            if mayavi_figure_args is not None:
+                mlab.figure(**mayavi_figure_args)
         else:
             mlab.figure(mayavi_figure)
 


### PR DESCRIPTION
On a headless machine (e.g. a CI server), calling mlab.figure() causes mayavi to error. This change allows plot3d() to run with mayavi without calling mlab.figure().