### PR TITLE
Restrict xarray to versions <2022.9.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ setup_requires =
     setuptools_scm[toml]>=3.4
     setuptools_scm_git_archive
 install_requires =
-    xarray>=0.18.0,!=2022.9.0,!=2022.10.0,!=2022.11.0,!=2022.12.0
+    xarray>=0.18.0,<2022.9.0
     boutdata>=0.1.4
     dask[array]>=2.10.0
     gelidum>=0.5.3


### PR DESCRIPTION
All the newer versions seem to have significant performance issues and occasional errors. Forbid using them until xBOUT is updated to be compatible.