### PR TITLE
Compatibility with xarray>=2022.9.0

### DIFF
--- a/xbout/region.py
+++ b/xbout/region.py
@@ -124,8 +124,8 @@ class Region:
                 ref_yind = ylower_ind
             dx = ds["dx"].isel({self.ycoord: ref_yind})
             dx_cumsum = dx.cumsum()
-            self.xinner = dx_cumsum[xinner_ind] - dx[xinner_ind]
-            self.xouter = dx_cumsum[xouter_ind - 1] + dx[xouter_ind - 1]
+            self.xinner = (dx_cumsum[xinner_ind] - dx[xinner_ind]).values
+            self.xouter = (dx_cumsum[xouter_ind - 1] + dx[xouter_ind - 1]).values
 
             # dy is constant in the x-direction, so convert to a 1d array
             # Define ref_xind so that we avoid using values from the corner cells, which
@@ -136,8 +136,8 @@ class Region:
                 ref_xind = xinner_ind
             dy = ds["dy"].isel(**{self.xcoord: ref_xind})
             dy_cumsum = dy.cumsum()
-            self.ylower = dy_cumsum[ylower_ind] - dy[ylower_ind]
-            self.yupper = dy_cumsum[yupper_ind - 1]
+            self.ylower = (dy_cumsum[ylower_ind] - dy[ylower_ind]).values
+            self.yupper = (dy_cumsum[yupper_ind - 1]).values
 
     def __repr__(self):
         result = "<xbout.region.Region>\n"


### PR DESCRIPTION
Following this comment https://github.com/boutproject/xBOUT/issues/213#issuecomment-1397686005, converting a few members of `Region` from scalar `DataArray` to `float` reduces the number of errors.

WIP because there are still a few errors in the unit tests, and performance is worse - for some unit tests between 1.5x and 2x slower.