### PR TITLE
Plotting bugfix

### DIFF
--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -280,6 +280,7 @@ def plot2d_wrapper(
                 add_colorbar=False,
                 add_labels=add_label,
                 cmap=cmap,
+                norm=norm,
                 **kwargs,
             )
             for region, add_label in zip(da_regions.values(), add_labels)

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -239,11 +239,18 @@ def plot2d_wrapper(
         kwargs["vmax"] = vmax
 
         # create colorbar
-        norm = _create_norm(logscale, norm, vmin, vmax)
+        norm = _create_norm(logscale, norm, vmin, vmax)    
         sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap)
         sm.set_array([])
         cmap = sm.get_cmap()
-        fig.colorbar(sm, ax=ax, extend=extend)
+        cbar = fig.colorbar(sm, ax=ax, extend=extend)
+        if "long_name" in da.attrs:
+            cbar_label = da.long_name
+        else:
+            cbar_label = da.name
+        if "units" in da.attrs:
+            cbar_label += f" [{da.units}]"
+        cbar.ax.set_ylabel(cbar_label)
 
     if method is xr.plot.pcolormesh:
         if "infer_intervals" not in kwargs:


### PR DESCRIPTION
I have a 2D Hermes-3 simulation of a double null tokamak. I noticed that plotting the same data with the same settings produced different results when using `bout.pcolormesh` compared to `xbout.plotting.animate_poloidal`. See below for the poloidal animation on LHS and pcolormesh on the RHS.

Poloidal animation command:
`anim = xbout.plotting.animate.animate_poloidal(caseng.ds["Ne"], cmap = "Spectral_r", vmin = 1e14, vmax = 1e20, logscale = True)`

Pcolormesh command:
`caseng.ds.isel(t=-1)["Ne"].bout.pcolormesh(cmap = "Spectral_r", vmin = 1e14, vmax = 1e20, logscale = True)`

I found the source of the problem. It turned out to be because pcolormesh was not assigning the `norm` to the artists, even though a correct `norm` did exist and was used to make the colorbar. This resulted in the colorbar being correct but the plot showing a linear scale, even with `log_scale = True`. 

The fix is to add the norm to the artists. I also copied over some code from `animate_poloidal` to grab the plotting variable metadata and make a cbar label.

Before fix, with animate_poloidal on LHS and pcolormesh on the RHS:
![image](https://user-images.githubusercontent.com/62797494/219370381-320ca793-b608-4a50-995b-70ad9ec7ecc4.png)

After fix, pcolormesh with same settings:
![image](https://user-images.githubusercontent.com/62797494/219371443-5d9bb73c-c0d0-4d7e-a103-d943808aaa50.png)

