### PR TITLE
Polygonal 2D poloidal plots

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -1073,6 +1073,12 @@ class BoutDataArrayAccessor:
         Colour-plot a radial-poloidal slice on the R-Z plane
         """
         return plotfuncs.plot2d_wrapper(self.data, xr.plot.pcolormesh, ax=ax, **kwargs)
+    
+    def polygon(self, ax=None, **kwargs):
+        """
+        Colour-plot of a radial-poloidal slice on the R-Z plane using polygons
+        """
+        return plotfuncs.plot2d_polygon(self.data, ax=ax, **kwargs)
 
     def plot_regions(self, ax=None, **kwargs):
         """

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -383,6 +383,14 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
             "total_poloidal_distance",
             "zShift",
             "zShift_ylow",
+            "Rxy_corners",   # Lower left corners
+            "Rxy_lower_right_corners",
+            "Rxy_upper_left_corners",
+            "Rxy_upper_right_corners",
+            "Zxy_corners",   # Lower left corners
+            "Zxy_lower_right_corners",
+            "Zxy_upper_left_corners",
+            "Zxy_upper_right_corners"
         ],
     )
 
@@ -421,6 +429,23 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
         ds = ds.set_coords(("R", "Z"))
     else:
         ds = ds.set_coords(("Rxy", "Zxy"))
+    
+    # Add cell corners as coordinates for polygon plotting
+    if "Rxy_lower_right_corners" in ds:
+        ds = ds.rename(
+            Rxy_corners = "Rxy_lower_left_corners",
+            Zxy_corners = "Zxy_lower_left_corners"
+            )
+        ds = ds.set_coords((
+            "Rxy_lower_left_corners",
+            "Rxy_lower_right_corners",
+            "Rxy_upper_left_corners",
+            "Rxy_upper_right_corners",
+            "Zxy_lower_left_corners",
+            "Zxy_lower_right_corners",
+            "Zxy_upper_left_corners",
+            "Zxy_upper_right_corners"
+             ))
 
     # Rename zShift_ylow if it was added from grid file, to be consistent with name if
     # it was added from dump file


### PR DESCRIPTION
xBOUT's default pcolormesh() method creates plotting artifacts around the X-point due to having to plot the grid on a per-region basis and not having corner information.

This new method uses a different approach, and is more like what UEDGE, SOLEDGE2D and SOLPS users do. Using coordinates of cell centres and cell corners, a Matplotlib [Polygon](https://matplotlib.org/stable/api/_as_gen/matplotlib.patches.Polygon.html) is created for each cell independently and put into a [PatchCollection ](https://matplotlib.org/stable/api/collections_api.html#matplotlib.collections.PatchCollection). With each cell being independently plotted, there are no issues arising from the poloidal ordering of the cells or from the X-point.

The polygon plotting routine was adapted from this [PR](https://github.com/boutproject/hypnotoad/pull/136) which was itself based on a UEDGE routine. The cell corners were obtained using this Hypnotoad [PR](https://github.com/boutproject/hypnotoad/pull/168).

- [ ] Add facility to read the cell corners into dataset coords in `geometry.py`
- [ ] Create `plot2d_polygon` in `plotfuncs.py`
- [ ] Properly integrate with `plot2d_wrapper` 

Status: pretty much functional with most of the kwargs you'd expect. I don't fully understand how `plot2d_wrapper` works (especially the region bits), so I left it as a separate function for now.
