### PR TITLE
Add topology to metadata

### DIFF
--- a/xbout/region.py
+++ b/xbout/region.py
@@ -1220,7 +1220,8 @@ def _create_regions_toroidal(ds):
     _check_connections(regions)
 
     ds = _set_attrs_on_all_vars(ds, "regions", regions)
-
+    ds["topology"] = topology
+    
     return ds
 
 


### PR DESCRIPTION
It would be useful for xHermes to know the type of topology (e.g. connected double null). I was going to write something for this but @johnomotani pointed out that this functionality already exists in xBOUT [here](https://github.com/boutproject/xBOUT/blob/212b407adb50008ef91d848dfbd22e979996e184/xbout/region.py#L312). If it's already in xBOUT then this should be the only place where the topology is worked out. This simple PR adds it to the dataset metadata.

Will leave it as a draft for now in case I think of any other useful related metadata to expose.