### PR TITLE
Allow reading walltime variables

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -972,7 +972,11 @@ def _trim(ds, *, guards, keep_boundaries, nxpe, nype, is_restart):
         ):
             trimmed_ds = trimmed_ds.drop_vars(name)
 
-    to_drop = _BOUT_PER_PROC_VARIABLES
+    if ds["MYPE"] == 0:
+        # Keep per-process variables from the root process
+        to_drop = None
+    else:
+        to_drop = _BOUT_PER_PROC_VARIABLES
 
     return trimmed_ds.drop_vars(to_drop, errors="ignore")
 


### PR DESCRIPTION
The walltime variables are defined here:

https://github.com/boutproject/BOUT-dev/blob/3d6cb4b7da6605e2d39828f07ece36c8d3886bcd/include/bout/monitor.hxx#L80-L110

They are slightly different in each processor which causes issues with xarray concatenation. For this reason, wall time stats have been dropped from xBOUT at load time so far.

This PR changes this. We read the proc 0 variables and drop the rest. This should be representative of the whole domain as the wtime load should be near identical for each processor anyway.

To keep the change simple, this also keeps three more variables from `_BOUT_PER_PROC_VARIABLES` which are not particularly useful (`PE_XIND`, `PE_YIND` and `MYPE`). Let me know if you think those should be removed.
