### PR TITLE
Fix loading of grid files

### DIFF
--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -400,7 +400,7 @@ def add_toroidal_geometry_coords(ds, *, coordinates=None, grid=None):
     ds = ds.rename(y=coordinates["y"])
 
     # TODO automatically make this coordinate 1D in simplified cases?
-    ds = ds.rename(psixy=coordinates["x"])
+    ds[coordinates["x"]] = ds["psixy"]
     ds = ds.set_coords(coordinates["x"])
     ds[coordinates["x"]].attrs["units"] = "Wb"
 

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -367,7 +367,12 @@ but we did load {grididfile}."""
                 ds.metadata[v] = grid[v].values
 
     # Update coordinates to match particular geometry of grid
-    ds = geometries.apply_geometry(ds, geometry, grid=grid)
+    if input_type == "grid":
+        # Specify coordinate names to avoid name clash
+        coordinates = {"x": "psi_poloidal", "y": "y", "z": "zeta"}
+    else:
+        coordinates = None
+    ds = geometries.apply_geometry(ds, geometry, grid=grid, coordinates=coordinates)
 
     if remove_yboundaries:
         ds = ds.bout.remove_yboundaries()

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -724,12 +724,6 @@ def _auto_open_mfboutdataset(
             combine_attrs="override",
         )
 
-    if not is_restart:
-        if "t_array" in ds.keys():
-            # Remove any duplicate time values from concatenation
-            _, unique_indices = unique(ds["t_array"], return_index=True)
-            ds = ds.isel(t=unique_indices)
-
     return ds, remove_yboundaries
 
 

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -84,6 +84,7 @@ def open_boutdataset(
     run_name=None,
     info=True,
     is_restart=None,
+    is_mms_dump=False,
     **kwargs,
 ):
     """
@@ -180,12 +181,12 @@ def open_boutdataset(
         chunks = {}
 
     input_type = _check_dataset_type(datapath)
-
     if is_restart is None:
         is_restart = input_type == "restart"
     elif is_restart is True:
         input_type = "restart"
-
+    if is_mms_dump:
+        input_type = "dump"
     if "reload" in input_type:
         if input_type == "reload":
             if isinstance(datapath, Path):
@@ -633,7 +634,6 @@ def _auto_open_mfboutdataset(
         nxpe, nype, mxg, myg, mxsub, mysub, is_squashed_doublenull = _read_splitting(
             filepaths[0], info, keep_yboundaries
         )
-
         if is_squashed_doublenull:
             # Need to remove y-boundaries after loading: (i) in case we are loading a
             # squashed data-set, in which case we cannot easily remove the upper
@@ -737,9 +737,10 @@ def _auto_open_mfboutdataset(
         )
 
     if not is_restart:
-        # Remove any duplicate time values from concatenation
-        _, unique_indices = unique(ds["t_array"], return_index=True)
-        ds = ds.isel(t=unique_indices)
+        if "t_array" in ds.keys():
+            # Remove any duplicate time values from concatenation
+            _, unique_indices = unique(ds["t_array"], return_index=True)
+            ds = ds.isel(t=unique_indices)
 
     return ds, remove_yboundaries
 

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -945,14 +945,14 @@ def plot2d_polygon(
 
     if "Rxy_lower_right_corners" in da.coords:
         r_nodes = [
-            "R",
+            "Rxy",
             "Rxy_lower_left_corners",
             "Rxy_lower_right_corners",
             "Rxy_upper_left_corners",
             "Rxy_upper_right_corners",
         ]
         z_nodes = [
-            "Z",
+            "Zxy",
             "Zxy_lower_left_corners",
             "Zxy_lower_right_corners",
             "Zxy_upper_left_corners",

--- a/xbout/plotting/plotfuncs.py
+++ b/xbout/plotting/plotfuncs.py
@@ -945,14 +945,14 @@ def plot2d_polygon(
 
     if "Rxy_lower_right_corners" in da.coords:
         r_nodes = [
-            "Rxy",
+            "R",
             "Rxy_lower_left_corners",
             "Rxy_lower_right_corners",
             "Rxy_upper_left_corners",
             "Rxy_upper_right_corners",
         ]
         z_nodes = [
-            "Zxy",
+            "Z",
             "Zxy_lower_left_corners",
             "Zxy_lower_right_corners",
             "Zxy_upper_left_corners",

--- a/xbout/tests/test_boutdataset.py
+++ b/xbout/tests/test_boutdataset.py
@@ -1136,6 +1136,7 @@ class TestBoutDatasetMethods:
                 "G3",
                 "J",
                 "Bxy",
+                "psixy",
             )
         )
 


### PR DESCRIPTION
There is (now) a 'theta' variable in grid files, which prevents naming a dimension 'theta', so need to choose a different dimension name when opening a grid file.

Also keep the 'psixy' variable in the Dataset - create a new variable referecing it rather than renaming it to make the 'psi_poloidal' coordinate.

Along with https://github.com/boutproject/hypnotoad/pull/187, fixes #306.

The `examples/plot_grid.py` script should work again.