### PR TITLE
Changes required to load output from a grid-free BOUT.0.nc file, nece…

### DIFF
--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -214,7 +214,7 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
                 dz = updated_ds["dz"]
 
             z0 = 2 * np.pi * updated_ds.metadata["ZMIN"]
-            z1 = z0 + nz * dz.data[0,0]
+            z1 = z0 + nz * dz.data[0, 0]
             if not np.all(
                 np.isclose(
                     z1,

--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -214,7 +214,7 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
                 dz = updated_ds["dz"]
 
             z0 = 2 * np.pi * updated_ds.metadata["ZMIN"]
-            z1 = z0 + nz * dz.data[()]
+            z1 = z0 + nz * dz.data[0,0]
             if not np.all(
                 np.isclose(
                     z1,

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -372,9 +372,7 @@ but we did load {grididfile}."""
     # by xBOUT, not by BOUT++
     ds.bout.fine_interpolation_factor = 8
 
-    if ("dump" in input_type or "restart" in input_type) and ds.metadata[
-        "BOUT_VERSION"
-    ] < 4.0:
+    if ("dump" in input_type or "restart" in input_type) and ("BOUT_VERSION" in ds.metadata and ds.metadata["BOUT_VERSION"] < 4.0):
         # Add workarounds for missing information or different
         # conventions in data saved by BOUT++ v3.x.
         for v in ds:

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -372,7 +372,9 @@ but we did load {grididfile}."""
     # by xBOUT, not by BOUT++
     ds.bout.fine_interpolation_factor = 8
 
-    if ("dump" in input_type or "restart" in input_type) and ("BOUT_VERSION" in ds.metadata and ds.metadata["BOUT_VERSION"] < 4.0):
+    if ("dump" in input_type or "restart" in input_type) and (
+        "BOUT_VERSION" in ds.metadata and ds.metadata["BOUT_VERSION"] < 4.0
+    ):
         # Add workarounds for missing information or different
         # conventions in data saved by BOUT++ v3.x.
         for v in ds:


### PR DESCRIPTION
…ssary for MMS tests of the differential operators.

The variable `dz` and the key "BOUT_VERSION" were not as anticipated in the simple test output from https://github.com/bendudson/hermes-3/blob/divops-mms-test-minimal/tests/mms/run-jobs.py, these changes were required to successfully load the data into memory.