### PR TITLE
Fix in case 'dz' was actually 0-dimensional

### DIFF
--- a/xbout/geometries.py
+++ b/xbout/geometries.py
@@ -214,7 +214,7 @@ def apply_geometry(ds, geometry_name, *, coordinates=None, grid=None):
                 dz = updated_ds["dz"]
 
             z0 = 2 * np.pi * updated_ds.metadata["ZMIN"]
-            z1 = z0 + nz * dz.data[0, 0]
+            z1 = z0 + nz * dz.data.flatten()[0]
             if not np.all(
                 np.isclose(
                     z1,


### PR DESCRIPTION
Fixes f49585e1e1661e9acf25bd50815b8d3ffad251c1 "Changes required to load output from a grid-free BOUT.0.nc file, necessary for MMS tests of the differential operators." in case dz was actually zero dimensional, rather than 2-dimensional.

Sorry, I missed that the tests failed on #309, because the final commit by the linter didn't run all the tests, so they weren't listed in the box, and I forgot for a minute that we have lots of pytest tests that should have been there. This PR should fix the test failures.