### PR TITLE
Add helper accessor to return final time slice

### DIFF
--- a/xbout/boutdataarray.py
+++ b/xbout/boutdataarray.py
@@ -1169,3 +1169,13 @@ class BoutDataArrayAccessor:
             cylinder_rmax=cyliner_rmax,
             step=step,
         )
+        
+    def final_time(self):
+        """
+        Returns the final time in the Dataset whether
+        it contains a time dimension or not.
+        """
+        if "t" in self.data.sizes:
+            return self.data.isel(t=-1)
+        else:
+            return self.data

--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -33,7 +33,6 @@ from .utils import (
     _split_into_restarts,
 )
 
-
 @xr.register_dataset_accessor("bout")
 class BoutDatasetAccessor:
     """
@@ -1355,7 +1354,16 @@ class BoutDatasetAccessor:
         from .cherab import grid
 
         return grid.ds_with_cherab_grid(self.data)
-
+    
+    def final_time(self):
+        """
+        Returns the final time in the Dataset whether
+        it contains a time dimension or not.
+        """
+        if "t" in self.data.sizes:
+            return self.data.isel(t=-1)
+        else:
+            return self.data
 
 def _find_major_vars(data):
     """


### PR DESCRIPTION
This returns the final time slice of a Dataset or DataArray whether the data contains multiple time slices or not. This is helpful when working with multiple simulations, some of which may have only been run for one timestep for developer reasons. 

Here is how this can be done with built-in Xarray functionality right now - let's say we are reading in a 1D model, want to get the final timeslice whether the dataset contains time or not, and then snip off guard cells:

```
ds = ds.isel(t=-1, missing_dims = "ignore")
ds = ds.isel(y = slice(2,-2))

```
With this PR we can now do:

```
ds = ds.bout.final_time().isel(y = slice(2,-2))
```