### PR TITLE
Switch to h5netcdf as default engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "natsort>=5.5.0",
     "matplotlib>=3.1.1,!=3.3.0,!=3.3.1,!=3.3.2",
     "animatplot-ng>=0.4.2",
-    "netcdf4>=1.4.0",
+    "h5netcdf",
     "Pillow>=6.1.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dask[array]>=2.10.0
 natsort>=5.5.0
 matplotlib>=3.1.1,!=3.3.0,!=3.3.1,!=3.3.2
 animatplot>=0.4.2
-netcdf4>=1.4.0
+h5netcdf
 Pillow>=6.1.0
 
 # Not required for Python>=3.8, but included because conda does not support

--- a/xbout/tests/conftest.py
+++ b/xbout/tests/conftest.py
@@ -165,7 +165,7 @@ def create_example_grid_file_fci(tmp_path_factory):
 
     # Save
     filepath = save_dir.joinpath("fci.nc")
-    grid.to_netcdf(filepath, engine="netcdf4")
+    grid.to_netcdf(filepath, engine="h5netcdf")
 
     return filepath
 

--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -27,7 +27,7 @@ def create_example_grid_file(tmp_path_factory):
 
     # Save
     filepath = save_dir.joinpath("grid.nc")
-    grid.to_netcdf(filepath, engine="netcdf4")
+    grid.to_netcdf(filepath, engine="h5netcdf")
 
     return filepath
 
@@ -52,7 +52,7 @@ class TestOpenGrid:
 
         dodgy_grid_directory = tmp_path_factory.mktemp("dodgy_grid")
         dodgy_grid_path = dodgy_grid_directory.joinpath("dodgy_grid.nc")
-        merge([example_grid, new_var]).to_netcdf(dodgy_grid_path, engine="netcdf4")
+        merge([example_grid, new_var]).to_netcdf(dodgy_grid_path, engine="h5netcdf")
 
         with pytest.warns(
             UserWarning, match="drop all variables containing " "the dimensions 'w'"

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -31,7 +31,7 @@ def _add_attrs_to_var(ds, varname, copy=False):
 
 def _check_filetype(path):
     if path.suffix == ".nc":
-        filetype = "netcdf4"
+        filetype = "h5netcdf"
     elif path.suffix == ".h5netcdf":
         filetype = "h5netcdf"
     elif path.suffix == ".bp":


### PR DESCRIPTION
This works around https://github.com/pydata/xarray/issues/9779

I tested that it works with python3.14:
https://copr.fedorainfracloud.org/coprs/build/9572692

Without the patch, it fails:
https://copr.fedorainfracloud.org/coprs/build/9572805
