### PR TITLE
Many files no warn

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -739,14 +739,6 @@ def _expand_filepaths(datapath):
         raise IOError("No datafiles found matching datapath={}".format(datapath))
 
     if len(filepaths) > xr.get_options().get("file_cache_maxsize", 128):
-        warn(
-            "Trying to open a large number of files - setting xarray's"
-            " `file_cache_maxsize` global option to {} to accommodate this. "
-            "Recommend using `xr.set_options(file_cache_maxsize=NUM)`"
-            " to explicitly set this to a large enough value.".format(
-                str(len(filepaths))
-            )
-        )
         xr.set_options(file_cache_maxsize=len(filepaths))
 
     return filepaths, filetype


### PR DESCRIPTION
I think it is best to completely remove the warning.
As a user I do not want to first figure out how many files I will be opening, and then set that with xarray to avoid a warning.

It was broken anyway, as it did always raise the warning, so I think it is best to remove the warning completely.

The first commit a4c0996 is still needed, as otherwise we may lower the limit, which is needed for other things.