### PR TITLE
Remove unrecognised variable warning on grid load

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -1155,10 +1155,6 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2, **kw
     if len(unrecognised_dims) > 0:
         # Weird string formatting is a workaround to deal with possible bug in
         # pytest warnings capture - doesn't match strings containing brackets
-        warn(
-            "Will drop all variables containing the dimensions {} because "
-            "they are not recognised".format(str(unrecognised_dims)[1:-1])
-        )
         grid = grid.drop_dims(unrecognised_dims)
 
     if keep_xboundaries:

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -1153,8 +1153,6 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2, **kw
 
     unrecognised_dims = list(set(grid.dims) - set(acceptable_dims))
     if len(unrecognised_dims) > 0:
-        # Weird string formatting is a workaround to deal with possible bug in
-        # pytest warnings capture - doesn't match strings containing brackets
         grid = grid.drop_dims(unrecognised_dims)
 
     if keep_xboundaries:

--- a/xbout/tests/test_grid.py
+++ b/xbout/tests/test_grid.py
@@ -41,27 +41,6 @@ class TestOpenGrid:
         assert_equal(result, open_dataset(example_grid))
         result.close()
 
-    def test_open_grid_extra_dims(self, create_example_grid_file, tmp_path_factory):
-        example_grid = open_dataset(create_example_grid_file)
-
-        new_var = DataArray(
-            name="new",
-            data=[[1, 2], [8, 9], [16, 17], [27, 28], [37, 38]],
-            dims=["x", "w"],
-        )
-
-        dodgy_grid_directory = tmp_path_factory.mktemp("dodgy_grid")
-        dodgy_grid_path = dodgy_grid_directory.joinpath("dodgy_grid.nc")
-        merge([example_grid, new_var]).to_netcdf(dodgy_grid_path, engine="h5netcdf")
-
-        with pytest.warns(
-            UserWarning, match="drop all variables containing " "the dimensions 'w'"
-        ):
-            result = open_boutdataset(datapath=dodgy_grid_path)
-        result = result.drop_vars(["x", "y"])
-        assert_equal(result, example_grid)
-        result.close()
-
     def test_open_grid_apply_geometry(self, create_example_grid_file):
         @register_geometry(name="Schwarzschild")
         def add_schwarzschild_coords(ds, coordinates=None):


### PR DESCRIPTION
This thing prints a warning every time I load a Hermes-3 dataset:

https://github.com/boutproject/xBOUT/blob/9b67b373a75fafa858c74b936d61ad8a876d4c5c/xbout/load.py#L1155-L1162

It's picking up `closed_wall_R` and `closed_wall_Z`, which are 1D arrays defined over the time dimension (I guess for a lack of a dummy dimension), and so cause an error due to not being over [x,y,z]. 

This PR removes the warning. If anyone wants these variables, they can look to modify the code further to make sure they are read properly. 