### PR TITLE
Import ADIOS2 only when actually used to remove warning

### DIFF
--- a/xbout/xarraybackend.py
+++ b/xbout/xarraybackend.py
@@ -13,7 +13,6 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ItemsView
 
 import numpy as np
-from adios2 import FileReader
 
 from xarray import Dataset, Variable
 from xarray.backends.common import (
@@ -25,8 +24,22 @@ from xarray.backends.common import (
 from xarray.core import indexing
 
 if TYPE_CHECKING:
+    from adios2 import FileReader
     from io import BufferedIOBase
     from xarray.backends.common import AbstractDataStore
+
+
+def _get_file_reader_class():
+    try:
+        from adios2 import FileReader
+    except ImportError as exc:
+        raise ImportError(
+            "The 'bout_adios2' backend requires the optional 'adios2' package. "
+            "Install adios2 to open '.bp' files with xBOUT."
+        ) from exc
+
+    return FileReader
+
 
 # need some special secret attributes to tell us the dimensions
 DIMENSION_KEY = "time_dimension"
@@ -199,6 +212,7 @@ class BoutAdiosBackendEntrypoint(BackendEntrypoint):
         #        stacklevel=3,
         #        adios_version=None,
     ) -> Dataset:
+        file_reader_class = _get_file_reader_class()
         filename_or_obj = _normalize_path(filename_or_obj)
         # print(f"BoutAdiosBackendEntrypoint: path = {filename_or_obj} type = {type(filename_or_obj)}")
 
@@ -214,7 +228,7 @@ class BoutAdiosBackendEntrypoint(BackendEntrypoint):
         #        if isinstance(filename_or_obj, AbstractDataStore):
         #            raise ValueError("ADIOS2 does not support AbstractDataStore input")
 
-        self._fh = FileReader(filename_or_obj)
+        self._fh = file_reader_class(filename_or_obj)
         vars = self._fh.available_variables()
         attrs = self._fh.available_attributes()
         attr_items = attrs.items()

--- a/xbout/xarraybackend.py
+++ b/xbout/xarraybackend.py
@@ -29,18 +29,6 @@ if TYPE_CHECKING:
     from xarray.backends.common import AbstractDataStore
 
 
-def _get_file_reader_class():
-    try:
-        from adios2 import FileReader
-    except ImportError as exc:
-        raise ImportError(
-            "The 'bout_adios2' backend requires the optional 'adios2' package. "
-            "Install adios2 to open '.bp' files with xBOUT."
-        ) from exc
-
-    return FileReader
-
-
 # need some special secret attributes to tell us the dimensions
 DIMENSION_KEY = "time_dimension"
 
@@ -212,7 +200,8 @@ class BoutAdiosBackendEntrypoint(BackendEntrypoint):
         #        stacklevel=3,
         #        adios_version=None,
     ) -> Dataset:
-        file_reader_class = _get_file_reader_class()
+        from adios2 import FileReader
+
         filename_or_obj = _normalize_path(filename_or_obj)
         # print(f"BoutAdiosBackendEntrypoint: path = {filename_or_obj} type = {type(filename_or_obj)}")
 
@@ -228,7 +217,7 @@ class BoutAdiosBackendEntrypoint(BackendEntrypoint):
         #        if isinstance(filename_or_obj, AbstractDataStore):
         #            raise ValueError("ADIOS2 does not support AbstractDataStore input")
 
-        self._fh = file_reader_class(filename_or_obj)
+        self._fh = FileReader(filename_or_obj)
         vars = self._fh.available_variables()
         attrs = self._fh.available_attributes()
         attr_items = attrs.items()


### PR DESCRIPTION
Every single time I use xBOUT I get this warning:
```
/home/mike/spack/var/spack/environments/hermes3/.spack-env/view/lib/python3.12/site-packages/xarray/backends/plugins.py:109: RuntimeWarning: Engine 'bout_adios2' loading failed:
No module named 'adios2'
  external_backend_entrypoints = backends_dict_from_pkg(entrypoints_unique)
```

This PR fixes this by making sure that `from adios2 import FileReader` is done only when xarray actually needs it, i.e. in the ADIOS2 backend. 

Unfortunately as I have never used ADIOS2 and it is completely untested as far as I can tell, I cannot verify that this doesn't break loading with it... although it is a simple change.

Perhaps @pnorbert or someone else with ADIOS2 experience could review.