### PR TITLE
Fix lazy loading when using pathlib.Path 

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,7 +20,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14", "3.x"]
+        python-version: ["3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14", "3.x"]
+        python-version: ["3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/xbout/lazyload.py
+++ b/xbout/lazyload.py
@@ -338,6 +338,7 @@ def lazy_open_boutdataset(
     )
 
     # Process all data variables
+    coords = {}
     data_vars = {}
     for name, var in ds.data_vars.items():
         if "x" in var.dims and "y" in var.dims:
@@ -350,6 +351,8 @@ def lazy_open_boutdataset(
                 attrs=var.attrs,
             )
         elif len(var.dims) == 0:
+            if name == "dz":
+                data_vars[name] = var
             continue  # scalars already in metadata
         elif ("x" not in var.dims) and ("y" not in var.dims):
             # Take DataArray from first processor
@@ -360,7 +363,6 @@ def lazy_open_boutdataset(
                 f"Variable '{name}' has only one of x/y dimensions and will be skipped"
             )
 
-    coords = {}
     if "t_array" in ds:
         coords["t"] = ds["t_array"].values
 

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -291,7 +291,7 @@ def open_boutdataset(
     if "dump" in input_type or "restart" in input_type:
 
         def is_netcdf_collection(datapath):
-            if not isinstance(datapath, str):
+            if not _is_path(datapath):
                 return None
             # Expand globs into a list of files
             p = Path(datapath)


### PR DESCRIPTION
The new lazy loader assumed that all paths are strings. When passed a `pathlib.Path`, it would fall back to the non-lazy loader. This caused me quite a bit of confusion as some of my simulations started taking forever to load.

There is already a tool called `_is_path`. This PR makes the lazy loader use this to check, which makes it consistent with the same operation elsewhere in the code.

@bendudson was the intention to still lazy load even for a single file? The code design suggests not (you are checking for a `collection` of files), but in practice single files will still get lazy loaded in the current implementation.
