### PR TITLE
to_restart: fix _FillValue incompatibility

### DIFF
--- a/xbout/boutdataset.py
+++ b/xbout/boutdataset.py
@@ -999,12 +999,24 @@ class BoutDatasetAccessor:
             self.data, variables, savepath, nxpe, nype, tind, prefix, overwrite
         )
 
+        # Xarray sets _FillValue=NaN by default for floating-point variables,
+        # but BOUT++ rewrites restart-file attributes after writing data, which
+        # NetCDF does not allow for _FillValue. Disable that default here.
+        restart_encoding = {}
+        if restart_datasets:
+            restart_encoding = {
+                name: {"_FillValue": None}
+                for name, variable in restart_datasets[0].variables.items()
+                if np.issubdtype(variable.dtype, np.floating)
+            }
+
         with ProgressBar():
             xr.save_mfdataset(
                 restart_datasets,
                 paths,
                 compute=True,
                 engine=_check_filetype(paths[0]),
+                encoding=restart_encoding,
             )
 
     def animate_list(


### PR DESCRIPTION
This fixes BOUT++ crashing when running with restart files produced by `to_restart()`.
Unlike the boutdata tool, the xBOUT restart tool let Xarray set the `_FillValue` attribute on all variables to NaN, which is default behaviour. When BOUT++ reads restart files, it rewrites all the attributes, which includes `_FillValue`. However, this is a special attribute and NetCDF doesn't allow it to be redefined, leading to a crash at launch.