### PR TITLE
Fix for closed_wall_R/Z warning on load

### DIFF
--- a/xbout/load.py
+++ b/xbout/load.py
@@ -37,6 +37,32 @@ _BOUT_GEOMETRY_VARS = [
 ]
 
 
+def _update_legacy_closed_wall_dimension(grid):
+    """Older Hypnotoad grids wrote closed_wall_Z/R with a "t" dim.
+       This function changes the dim to "closed_wall" which is 
+       the current Hypnotoad behaviour."""
+
+    if "closed_wall" in grid.dims:
+        return grid
+
+    if "closed_wall_R" not in grid or "closed_wall_Z" not in grid:
+        return grid
+
+    if grid["closed_wall_R"].dims != ("t",):
+        return grid
+
+    if grid["closed_wall_Z"].dims != ("t",):
+        return grid
+
+    for name in ("closed_wall_R", "closed_wall_Z"):
+        attrs = grid[name].attrs.copy()
+        data = grid[name].data
+        grid[name] = (("closed_wall",), data)
+        grid[name].attrs = attrs
+
+    return grid
+
+
 # This code should run whenever any function from this module is imported
 # Set all attrs to survive all mathematical operations
 # (see https://github.com/pydata/xarray/pull/2482)
@@ -752,7 +778,10 @@ def _check_dataset_type(datapath):
     if "metadata:keep_yboundaries" in ds.attrs:
         # (i)
         return "reload"
-    elif "t" in ds.dims:
+
+    _update_legacy_closed_wall_dimension(ds)
+
+    if "t" in ds.dims:
         # (iii)
         return "dump"
     elif all(["restart" in Path(p).name for p in filepaths]):
@@ -1266,7 +1295,7 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2, **kw
     boundaries to deal with different conventions in a BOUT grid file.
     """
 
-    acceptable_dims = ["x", "y", "z"]
+    acceptable_dims = ["x", "y", "z", "closed_wall"]
 
     # Passing 'chunks' with dimensions that are not present in the
     # dataset causes an error. A gridfile will be missing 't' and may
@@ -1286,6 +1315,8 @@ def _open_grid(datapath, chunks, keep_xboundaries, keep_yboundaries, mxg=2, **kw
         )
     else:
         grid = datapath
+
+    grid = _update_legacy_closed_wall_dimension(grid)
 
     unrecognised_dims = list(set(grid.dims) - set(acceptable_dims))
     if len(unrecognised_dims) > 0:

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -39,8 +39,8 @@ _BOUT_GEOMETRY_VARS = [
 
 def _update_legacy_closed_wall_dimension(grid):
     """Older Hypnotoad grids wrote closed_wall_Z/R with a "t" dim.
-       This function changes the dim to "closed_wall" which is 
-       the current Hypnotoad behaviour."""
+    This function changes the dim to "closed_wall" which is
+    the current Hypnotoad behaviour."""
 
     if "closed_wall" in grid.dims:
         return grid

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -50,7 +50,7 @@ def _update_legacy_closed_wall_dimension(grid):
             return grid
 
     for name in ("closed_wall_R", "closed_wall_Z"):
-        attrs = grid[name].attrs.copy()
+        attrs = grid[name].attrs
         data = grid[name].data
         grid[name] = (("closed_wall",), data)
         grid[name].attrs = attrs

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -774,7 +774,7 @@ def _check_dataset_type(datapath):
         # (i)
         return "reload"
 
-    _update_legacy_closed_wall_dimension(ds)
+    ds = _update_legacy_closed_wall_dimension(ds)
 
     if "t" in ds.dims:
         # (iii)

--- a/xbout/load.py
+++ b/xbout/load.py
@@ -45,14 +45,9 @@ def _update_legacy_closed_wall_dimension(grid):
     if "closed_wall" in grid.dims:
         return grid
 
-    if "closed_wall_R" not in grid or "closed_wall_Z" not in grid:
-        return grid
-
-    if grid["closed_wall_R"].dims != ("t",):
-        return grid
-
-    if grid["closed_wall_Z"].dims != ("t",):
-        return grid
+    for name in ("closed_wall_R", "closed_wall_Z"):
+        if name not in grid or len(grid[name].dims) != 1:
+            return grid
 
     for name in ("closed_wall_R", "closed_wall_Z"):
         attrs = grid[name].attrs.copy()

--- a/xbout/utils.py
+++ b/xbout/utils.py
@@ -68,12 +68,7 @@ def _separate_metadata(ds):
     # whether it is scalar or 2d/3d array.
     exclude = ["dz"]
 
-    scalar_vars = [
-        var
-        for var in variables
-        if not any(dim in ["t", "x", "y", "z"] for dim in ds[var].dims)
-        and var not in exclude
-    ]
+    scalar_vars = [var for var in variables if ds[var].ndim == 0 and var not in exclude]
 
     # Save metadata as a dictionary
     metadata_vals = [ds[var].values.item() for var in scalar_vars]


### PR DESCRIPTION
`closed_wall_R` and `closed_wall_Z` used to be defined over a `t` dimension, which caused a warning on unrecognised variable on grid load. This was resolved in Hypnotoad by changing the coordinate to `closed_wall`: https://github.com/boutproject/hypnotoad/pull/191

This PR reproduces this fix on the xBOUT side for legacy grids which still have the `t` coordinate, and adds `closed_wall` to the list of acceptable dimensions.

This PR supersedes https://github.com/boutproject/xBOUT/pull/338.